### PR TITLE
Add thin logger as demanded by #47

### DIFF
--- a/splinepy/_base.py
+++ b/splinepy/_base.py
@@ -1,0 +1,58 @@
+"""splinepy/splinepy/_base.py
+Useful base class for splinepy.
+Plus some useful decorators.
+"""
+
+import abc
+
+from splinepy.log import debug, info, warning
+
+class SplinepyBase(abc.ABC):
+    """
+    Base class for splinepy, where logging is nicely wrapped, and some useful
+    methods are defined as classmethods..
+    Since attributes are predefined with __slots__, we can pre define
+    all the properties that could have been saved.
+    Adding `get_` in front of such properties are names for functions that
+    freshly compute and save the properties and their byproducts.
+    Other more complex operations will be a separate function.
+    TODO: maybe add explicit `use_saved` switch to avoid recomputing
+    """
+
+    __slots__ = []
+
+    def _logd(self, *log):
+        """
+        Debug logger wrapper for Mesh.
+        Parameters
+        -----------
+        *log: *str
+        Returns
+        --------
+        None
+        """
+        debug(type(self).__qualname__, "-", *log)
+
+    def _logi(self, *log):
+        """
+        Info logger wrapper for Mesh.
+        Parameters
+        -----------
+        *log: *str
+        Returns
+        --------
+        None
+        """
+        info(type(self).__qualname__, "-", *log)
+
+    def _logw(self, *log):
+        """
+        Warning logger wrapper for Mesh.
+        Parameters
+        -----------
+        *log: *str
+        Returns
+        --------
+        None
+        """
+        warning(type(self).__qualname__, "-", *log)

--- a/splinepy/_spline.py
+++ b/splinepy/_spline.py
@@ -1,14 +1,11 @@
-import abc
-import logging
 import copy
 import os
-import itertools
 
 import numpy as np
 
 from splinepy import utils
 from splinepy import io
-from splinepy import _splinepy as core
+from splinepy._base import SplinepyBase
 
 
 class InputDimensionError(Exception):
@@ -106,7 +103,7 @@ class _RequiredProperties:
 required_properties = _RequiredProperties()
 
 
-class Spline(abc.ABC):
+class Spline(SplinepyBase):
     """
     Abstract Spline Class.
     """
@@ -182,7 +179,7 @@ class Spline(abc.ABC):
             if hasattr(self, s):
                 delattr(self, s)
 
-        logging.debug("Spline - All attributes are cleared!")
+        self._logd("All attributes are cleared!")
 
     @property
     def whatami(self):
@@ -217,7 +214,7 @@ class Spline(abc.ABC):
         --------
         None
         """
-        logging.warning("Spline - Excuse me, you cannot tell me what I am.")
+        self.logw("Excuse me, you cannot tell me what I am.")
 
     @property
     def skip_update(self):
@@ -348,7 +345,7 @@ class Spline(abc.ABC):
 
         self._degrees = degrees
 
-        logging.debug(f"Spline - Degrees set: {self.degrees}")
+        self.logd(f"Degrees set: {self.degrees}")
 
         self._check_and_update_c()
 
@@ -405,10 +402,10 @@ class Spline(abc.ABC):
 
         self._knot_vectors = copy.deepcopy(knot_vectors)
 
-        logging.debug("Spline - Knot vectors set:")
+        self.logd("Knot vectors set:")
         for i, kv in enumerate(self.knot_vectors):
-            logging.debug(
-                f"Spline -   {i}"
+            self.logd(
+                f"  {i}"
                 ". knot vector length: "
                 f"{len(kv)}"
             )
@@ -430,7 +427,7 @@ class Spline(abc.ABC):
         --------
         unique_knots: list
         """
-        logging.debug("Spline - Computing unique knots using `np.unique`.")
+        self.logd("Computing unique knots using `np.unique`.")
         unique_knots = []
         if "Bezier" in self.whatami:
             unique_knots = [[0, 1]] * self.para_dim
@@ -453,7 +450,7 @@ class Spline(abc.ABC):
         --------
         parametric_bounds: (2, para_dim) np.ndarray
         """
-        logging.debug("Spline - Computing parametric_bounds")
+        self.logd("Computing parametric_bounds")
         # beziers
         if "knot_vectors" not in self.required_properties:
             return [[0, 1] * self.para_dim]
@@ -469,8 +466,8 @@ class Spline(abc.ABC):
         use_minmax = False
         if not hasattr(self, "_c_spline"):
             # in this case, `_check_and_update_c()` wasn't called.
-            logging.debug(
-                "Spline - entries of `knot_vectors` has not been checked. "
+            self.logd(
+                "Entries of `knot_vectors` has not been checked. "
                 "Values of `parametric_bounds` will be min and max."
             )
             use_minmax = True
@@ -537,8 +534,8 @@ class Spline(abc.ABC):
                 )
 
         self._control_points = control_points
-        logging.debug(
-            f"Spline - {self.control_points.shape[0]} Control points set."
+        self.logd(
+            f"{self.control_points.shape[0]} Control points set."
         )
 
         self._check_and_update_c()
@@ -558,7 +555,7 @@ class Spline(abc.ABC):
         None
         """
         ind = np.lexsort([self.control_points[:, i] for i in order])
-        logging.debug(f"Spline - `lexsort` control points ({order})")
+        self.logd(f"`lexsort` control points ({order})")
         self.control_points = self.control_points[ind]
 
     @property
@@ -574,7 +571,7 @@ class Spline(abc.ABC):
         --------
         control_point_bounds: (2, dim) np.ndarray
         """
-        logging.debug("Spline - Computing control_point_bounds")
+        self.logd("Computing control_point_bounds")
         cps = self.control_points
 
         return np.vstack(
@@ -635,7 +632,7 @@ class Spline(abc.ABC):
 
         self._weights = weights
 
-        logging.debug(f"Spline - {self.weights.shape[0]} Weights set.")
+        self.logd(f"{self.weights.shape[0]} Weights set.")
 
         self._check_and_update_c()
 
@@ -705,8 +702,8 @@ class Spline(abc.ABC):
         for rp in required_props:
             tmp_rp = getattr(self, rp)
             if tmp_rp is None:
-                logging.debug(
-                    "Spline - Not enough information to update cpp spline. "
+                self.logd(
+                    "Not enough information to update cpp spline. "
                     "Skipping update / removing existing backend spline."
                 )
                 if hasattr(self, "_c_spline"):
@@ -783,8 +780,8 @@ class Spline(abc.ABC):
         # but, we still need to do setter's job.
         self._para_dim = self._c_spline.para_dim
         self._dim = self._c_spline.dim
-        logging.debug(
-            "Spline - Updated python spline. CPP spline and python spline are"
+        self.logd(
+            "Updated python spline. CPP spline and python spline are"
             "now identical."
         )
 
@@ -813,7 +810,7 @@ class Spline(abc.ABC):
                 "`queries` does not match current pametric dimension."
             )
 
-        logging.debug("Spline - Evaluating spline...")
+        self.logd("Evaluating spline...")
 
         if int(n_threads) > 1:
             return self._c_spline.p_evaluate(
@@ -855,7 +852,7 @@ class Spline(abc.ABC):
                 "`orders` does not match current pametric dimension."
             )
 
-        logging.debug("Spline - Evaluating derivatives of the spline...")
+        self.logd("Evaluating derivatives of the spline...")
 
         if int(n_threads) > 1:
             return self._c_spline.p_derivative(
@@ -897,7 +894,7 @@ class Spline(abc.ABC):
                 "`queries` does not match current pametric dimension."
             )
 
-        logging.debug("Spline - evaluating basis functions")
+        self.logd("Evaluating basis functions")
 
         return self._c_spline.basis_functions(queries)
 
@@ -948,7 +945,7 @@ class Spline(abc.ABC):
             knots
         )
 
-        logging.debug(f"Spline - Inserted {len(knots)} knot(s).")
+        self.logd(f"Inserted {len(knots)} knot(s).")
 
         self._update_p()
 
@@ -1007,11 +1004,11 @@ class Spline(abc.ABC):
 
         self._update_p()
 
-        logging.debug(
-            f"Spline - Tried to remove {len(knots)} knot(s)."
+        self.logd(
+            f"Tried to remove {len(knots)} knot(s)."
         )
-        logging.debug(
-            "Spline - Actually removed {nk} knot(s).".format(
+        self.logd(
+            "Actually removed {nk} knot(s).".format(
                 nk=(
                     total_knots_before
                     - len(self.knot_vectors[int(parametric_dimension)])
@@ -1070,7 +1067,7 @@ class Spline(abc.ABC):
         if not set(range(self.para_dim)) == set(permutation_list):
             raise ValueError("Permutation list invalid")
 
-        logging.debug("Spline - Permuting parametric axes...")
+        self.logd("Permuting parametric axes...")
 
         # Update knot_vectors where applicable
         if "knot_vectors" in self.required_properties:
@@ -1108,7 +1105,7 @@ class Spline(abc.ABC):
         spline_data_dict["control_points"] = self.control_points[global_indices, :]
 
         if inplace:
-            logging.debug("Spline -   applying permutation inplace")
+            self.logd("  applying permutation inplace")
             self.clear()
             for rp in self.required_properties:
                 setattr(self, rp, spline_data_dict[rp])
@@ -1116,7 +1113,7 @@ class Spline(abc.ABC):
             return None
 
         else:
-            logging.debug("Spline -   returning permuted spline")
+            self.logd("  returning permuted spline")
             return type(self)(**spline_data_dict)
 
     def elevate_degree(self, parametric_dimension):
@@ -1140,8 +1137,8 @@ class Spline(abc.ABC):
             )
 
         self._c_spline.elevate_degree(parametric_dimension)
-        logging.debug(
-            f"Spline - Elevated {parametric_dimension}.-dim. "
+        self.logd(
+            f"Elevated {parametric_dimension}.-dim. "
             "degree of the spline."
         )
 
@@ -1173,20 +1170,20 @@ class Spline(abc.ABC):
             tolerance
         )
 
-        logging.debug(
-            f"Spline - Tried to reduce {parametric_dimension}.-dim. "
+        self.logd(
+            f"Tried to reduce {parametric_dimension}.-dim. "
             "degree of the spline."
         )
 
         if reduced:
-            logging.debug(
-                f"Spline - Successfully reduced {parametric_dimension}.-dim. "
+            self.logd(
+                f"Successfully reduced {parametric_dimension}.-dim. "
                 "degree"
             )
             self._update_p()
         else:
-            logging.debug(
-                f"Spline - Could not reduce {parametric_dimension}.-dim. "
+            self.logd(
+                f"Could not reduce {parametric_dimension}.-dim. "
                 "degree"
             )
 
@@ -1219,16 +1216,16 @@ class Spline(abc.ABC):
 
         is_one_or_less = [int(qr) <= 1 for qr in query_resolutions]
         if any(is_one_or_less):
-            logging.debug(
-                "Spline - You cannot sample less than 2 points per each "
+            self.logd(
+                "You cannot sample less than 2 points per each "
                 "parametric dimension."
             )
-            logging.debug("Spline - Applying minimum sampling resolution 2.")
+            self.logd("Applying minimum sampling resolution 2.")
 
             query_resolutions[is_one_or_less] = int(2)
 
-        logging.debug(
-            f"Spline - Sampling {np.product(query_resolutions)} "
+        self.logd(
+            f"Sampling {np.product(query_resolutions)} "
             "points from spline."
         )
 
@@ -1272,8 +1269,8 @@ class Spline(abc.ABC):
         queries = utils.make_c_contiguous(queries, dtype="float64")
 
         if kdt_resolutions is None:
-            logging.debug(
-                "Spline - `kdt_resolutions` is None, "
+            self.logd(
+                "`kdt_resolutions` is None, "
                 "setting default resolution ([10] * para_dim)."
             )
             kdt_resolutions = [10] * self.para_dim
@@ -1295,7 +1292,7 @@ class Spline(abc.ABC):
                 "`queries` does not match current dimension."
             )
 
-        logging.debug("Spline - Searching for nearest parametric coord...")
+        self.logd("Searching for nearest parametric coord...")
 
         return self._c_spline.nearest_pcoord_kdt(
             queries=queries,
@@ -1331,7 +1328,7 @@ class Spline(abc.ABC):
                 "`queries` does not match current dimension."
             )
 
-        logging.debug("Spline - Searching for nearest parametric coord...")
+        self.logd("Searching for nearest parametric coord...")
 
         return self._c_spline.nearest_pcoord_midpoint(
             queries=queries,
@@ -1388,7 +1385,7 @@ class Spline(abc.ABC):
                 "< .iges | .xml | .itd | .npz | .mesh | .json> extentions"
             )
 
-        logging.info(f"Spline - Exported current spline as {fname}.")
+        self.logi(f"Exported current spline as {fname}.")
 
     def todict(self, tolist=False):
         """
@@ -1404,7 +1401,7 @@ class Spline(abc.ABC):
         --------
         dict_spline: dict
         """
-        logging.debug("Spline - Preparing dict_spline...")
+        self.logd("Preparing dict_spline...")
         dict_spline = dict()
         # loop and copy entries.
         for p in self.required_properties:

--- a/splinepy/_spline.py
+++ b/splinepy/_spline.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from splinepy import utils
 from splinepy import io
+from splinepy import _splinepy as core
 from splinepy._base import SplinepyBase
 
 
@@ -214,7 +215,7 @@ class Spline(SplinepyBase):
         --------
         None
         """
-        self.logw("Excuse me, you cannot tell me what I am.")
+        self._logw("Excuse me, you cannot tell me what I am.")
 
     @property
     def skip_update(self):
@@ -345,7 +346,7 @@ class Spline(SplinepyBase):
 
         self._degrees = degrees
 
-        self.logd(f"Degrees set: {self.degrees}")
+        self._logd(f"Degrees set: {self.degrees}")
 
         self._check_and_update_c()
 
@@ -402,9 +403,9 @@ class Spline(SplinepyBase):
 
         self._knot_vectors = copy.deepcopy(knot_vectors)
 
-        self.logd("Knot vectors set:")
+        self._logd("Knot vectors set:")
         for i, kv in enumerate(self.knot_vectors):
-            self.logd(
+            self._logd(
                 f"  {i}"
                 ". knot vector length: "
                 f"{len(kv)}"
@@ -427,7 +428,7 @@ class Spline(SplinepyBase):
         --------
         unique_knots: list
         """
-        self.logd("Computing unique knots using `np.unique`.")
+        self._logd("Computing unique knots using `np.unique`.")
         unique_knots = []
         if "Bezier" in self.whatami:
             unique_knots = [[0, 1]] * self.para_dim
@@ -450,7 +451,7 @@ class Spline(SplinepyBase):
         --------
         parametric_bounds: (2, para_dim) np.ndarray
         """
-        self.logd("Computing parametric_bounds")
+        self._logd("Computing parametric_bounds")
         # beziers
         if "knot_vectors" not in self.required_properties:
             return [[0, 1] * self.para_dim]
@@ -466,7 +467,7 @@ class Spline(SplinepyBase):
         use_minmax = False
         if not hasattr(self, "_c_spline"):
             # in this case, `_check_and_update_c()` wasn't called.
-            self.logd(
+            self._logd(
                 "Entries of `knot_vectors` has not been checked. "
                 "Values of `parametric_bounds` will be min and max."
             )
@@ -534,7 +535,7 @@ class Spline(SplinepyBase):
                 )
 
         self._control_points = control_points
-        self.logd(
+        self._logd(
             f"{self.control_points.shape[0]} Control points set."
         )
 
@@ -555,7 +556,7 @@ class Spline(SplinepyBase):
         None
         """
         ind = np.lexsort([self.control_points[:, i] for i in order])
-        self.logd(f"`lexsort` control points ({order})")
+        self._logd(f"`lexsort` control points ({order})")
         self.control_points = self.control_points[ind]
 
     @property
@@ -571,7 +572,7 @@ class Spline(SplinepyBase):
         --------
         control_point_bounds: (2, dim) np.ndarray
         """
-        self.logd("Computing control_point_bounds")
+        self._logd("Computing control_point_bounds")
         cps = self.control_points
 
         return np.vstack(
@@ -632,7 +633,7 @@ class Spline(SplinepyBase):
 
         self._weights = weights
 
-        self.logd(f"{self.weights.shape[0]} Weights set.")
+        self._logd(f"{self.weights.shape[0]} Weights set.")
 
         self._check_and_update_c()
 
@@ -702,7 +703,7 @@ class Spline(SplinepyBase):
         for rp in required_props:
             tmp_rp = getattr(self, rp)
             if tmp_rp is None:
-                self.logd(
+                self._logd(
                     "Not enough information to update cpp spline. "
                     "Skipping update / removing existing backend spline."
                 )
@@ -780,7 +781,7 @@ class Spline(SplinepyBase):
         # but, we still need to do setter's job.
         self._para_dim = self._c_spline.para_dim
         self._dim = self._c_spline.dim
-        self.logd(
+        self._logd(
             "Updated python spline. CPP spline and python spline are"
             "now identical."
         )
@@ -810,7 +811,7 @@ class Spline(SplinepyBase):
                 "`queries` does not match current pametric dimension."
             )
 
-        self.logd("Evaluating spline...")
+        self._logd("Evaluating spline...")
 
         if int(n_threads) > 1:
             return self._c_spline.p_evaluate(
@@ -852,7 +853,7 @@ class Spline(SplinepyBase):
                 "`orders` does not match current pametric dimension."
             )
 
-        self.logd("Evaluating derivatives of the spline...")
+        self._logd("Evaluating derivatives of the spline...")
 
         if int(n_threads) > 1:
             return self._c_spline.p_derivative(
@@ -894,7 +895,7 @@ class Spline(SplinepyBase):
                 "`queries` does not match current pametric dimension."
             )
 
-        self.logd("Evaluating basis functions")
+        self._logd("Evaluating basis functions")
 
         return self._c_spline.basis_functions(queries)
 
@@ -945,7 +946,7 @@ class Spline(SplinepyBase):
             knots
         )
 
-        self.logd(f"Inserted {len(knots)} knot(s).")
+        self._logd(f"Inserted {len(knots)} knot(s).")
 
         self._update_p()
 
@@ -1004,10 +1005,10 @@ class Spline(SplinepyBase):
 
         self._update_p()
 
-        self.logd(
+        self._logd(
             f"Tried to remove {len(knots)} knot(s)."
         )
-        self.logd(
+        self._logd(
             "Actually removed {nk} knot(s).".format(
                 nk=(
                     total_knots_before
@@ -1067,7 +1068,7 @@ class Spline(SplinepyBase):
         if not set(range(self.para_dim)) == set(permutation_list):
             raise ValueError("Permutation list invalid")
 
-        self.logd("Permuting parametric axes...")
+        self._logd("Permuting parametric axes...")
 
         # Update knot_vectors where applicable
         if "knot_vectors" in self.required_properties:
@@ -1105,7 +1106,7 @@ class Spline(SplinepyBase):
         spline_data_dict["control_points"] = self.control_points[global_indices, :]
 
         if inplace:
-            self.logd("  applying permutation inplace")
+            self._logd("  applying permutation inplace")
             self.clear()
             for rp in self.required_properties:
                 setattr(self, rp, spline_data_dict[rp])
@@ -1113,7 +1114,7 @@ class Spline(SplinepyBase):
             return None
 
         else:
-            self.logd("  returning permuted spline")
+            self._logd("  returning permuted spline")
             return type(self)(**spline_data_dict)
 
     def elevate_degree(self, parametric_dimension):
@@ -1137,7 +1138,7 @@ class Spline(SplinepyBase):
             )
 
         self._c_spline.elevate_degree(parametric_dimension)
-        self.logd(
+        self._logd(
             f"Elevated {parametric_dimension}.-dim. "
             "degree of the spline."
         )
@@ -1170,19 +1171,19 @@ class Spline(SplinepyBase):
             tolerance
         )
 
-        self.logd(
+        self._logd(
             f"Tried to reduce {parametric_dimension}.-dim. "
             "degree of the spline."
         )
 
         if reduced:
-            self.logd(
+            self._logd(
                 f"Successfully reduced {parametric_dimension}.-dim. "
                 "degree"
             )
             self._update_p()
         else:
-            self.logd(
+            self._logd(
                 f"Could not reduce {parametric_dimension}.-dim. "
                 "degree"
             )
@@ -1216,15 +1217,15 @@ class Spline(SplinepyBase):
 
         is_one_or_less = [int(qr) <= 1 for qr in query_resolutions]
         if any(is_one_or_less):
-            self.logd(
+            self._logd(
                 "You cannot sample less than 2 points per each "
                 "parametric dimension."
             )
-            self.logd("Applying minimum sampling resolution 2.")
+            self._logd("Applying minimum sampling resolution 2.")
 
             query_resolutions[is_one_or_less] = int(2)
 
-        self.logd(
+        self._logd(
             f"Sampling {np.product(query_resolutions)} "
             "points from spline."
         )
@@ -1269,7 +1270,7 @@ class Spline(SplinepyBase):
         queries = utils.make_c_contiguous(queries, dtype="float64")
 
         if kdt_resolutions is None:
-            self.logd(
+            self._logd(
                 "`kdt_resolutions` is None, "
                 "setting default resolution ([10] * para_dim)."
             )
@@ -1292,7 +1293,7 @@ class Spline(SplinepyBase):
                 "`queries` does not match current dimension."
             )
 
-        self.logd("Searching for nearest parametric coord...")
+        self._logd("Searching for nearest parametric coord...")
 
         return self._c_spline.nearest_pcoord_kdt(
             queries=queries,
@@ -1328,7 +1329,7 @@ class Spline(SplinepyBase):
                 "`queries` does not match current dimension."
             )
 
-        self.logd("Searching for nearest parametric coord...")
+        self._logd("Searching for nearest parametric coord...")
 
         return self._c_spline.nearest_pcoord_midpoint(
             queries=queries,
@@ -1385,7 +1386,7 @@ class Spline(SplinepyBase):
                 "< .iges | .xml | .itd | .npz | .mesh | .json> extentions"
             )
 
-        self.logi(f"Exported current spline as {fname}.")
+        self._logi(f"Exported current spline as {fname}.")
 
     def todict(self, tolist=False):
         """
@@ -1401,7 +1402,7 @@ class Spline(SplinepyBase):
         --------
         dict_spline: dict
         """
-        self.logd("Preparing dict_spline...")
+        self._logd("Preparing dict_spline...")
         dict_spline = dict()
         # loop and copy entries.
         for p in self.required_properties:

--- a/splinepy/bezier.py
+++ b/splinepy/bezier.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from splinepy import utils
@@ -48,7 +46,7 @@ class Bezier(Spline):
                 "`queries` does not match current pametric dimension."
             )
 
-        logging.debug("Spline - Evaluating spline...")
+        self.logd("Evaluating spline...")
 
         return self._c_spline.recursive_evaluate(queries=queries)
 

--- a/splinepy/bezier.py
+++ b/splinepy/bezier.py
@@ -46,7 +46,7 @@ class Bezier(Spline):
                 "`queries` does not match current pametric dimension."
             )
 
-        self.logd("Evaluating spline...")
+        self._logd("Evaluating spline...")
 
         return self._c_spline.recursive_evaluate(queries=queries)
 

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -102,7 +102,7 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        self.logd(
+        self._logd(
             "BSpline curve interpolation complete. "
             f"Your spline is {self.whatami}."
         )
@@ -162,11 +162,11 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        self.logd(
+        self._logd(
             "BSpline curve approximation complete. "
             f"Your spline is {self.whatami}."
         )
-        self.logd(f"  Approximation residual: {res}")
+        self._logd(f"  Approximation residual: {res}")
 
         if save_query:
             self._fitting_queries = query_points
@@ -225,7 +225,7 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        self.logd(
+        self._logd(
             "BSpline surface interpolation complete. "
             f"Your spline is {self.whatami}."
         )

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from splinepy import utils
@@ -104,8 +102,8 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        logging.debug(
-            "Spline - BSpline curve interpolation complete. "
+        self.logd(
+            "BSpline curve interpolation complete. "
             f"Your spline is {self.whatami}."
         )
 
@@ -164,11 +162,11 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        logging.debug(
-            "Spline - BSpline curve approximation complete. "
+        self.logd(
+            "BSpline curve approximation complete. "
             f"Your spline is {self.whatami}."
         )
-        logging.debug(f"Spline -   Approximation residual: {res}")
+        self.logd(f"  Approximation residual: {res}")
 
         if save_query:
             self._fitting_queries = query_points
@@ -227,8 +225,8 @@ class BSpline(Spline):
         )
         self._c_spline = c_spline
 
-        logging.debug(
-            "Spline - BSpline surface interpolation complete. "
+        self.logd(
+            "BSpline surface interpolation complete. "
             f"Your spline is {self.whatami}."
         )
 

--- a/splinepy/io/json.py
+++ b/splinepy/io/json.py
@@ -4,8 +4,9 @@ Export splines in custom json format
 
 import base64
 import json
-import logging
 import numpy as np
+
+from splinepy.log import debug
 
 
 def load(fname):
@@ -61,7 +62,7 @@ def load(fname):
             data_dict[prop] = jbz[prop]
         return_dict[jbz["SplineType"]].append(data_dict)
 
-    logging.debug("Imported " + str(len(spline_list)) + " splines from file.")
+    debug("Imported " + str(len(spline_list)) + " splines from file.")
 
     return return_dict
 

--- a/splinepy/log.py
+++ b/splinepy/log.py
@@ -1,0 +1,66 @@
+"""splinepy/splinepy/log.py
+Thin logging wrapper.
+"""
+
+import logging
+
+
+def configure(debug=False, logfile=None):
+    """
+    Logging configurator.
+    Parameters
+    -----------
+    debug: bool
+    logfile: str
+    Returns
+    --------
+    None
+    """
+    logger = logging.getLogger()
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+    else:
+        logger.setLevel(logging.INFO)
+
+    if logfile is not None:
+        file_logger_handler = logging.FileHandler(logfile)
+
+
+def debug(*log):
+    """
+    Debug logger.
+    Parameters
+    -----------
+    *log: *str
+    Returns
+    --------
+    None
+    """
+    logging.debug(" ".join(map(str, log)))
+
+
+def info(*log):
+    """
+    Info logger.
+    Parameters
+    -----------
+    *log: *str
+    Returns
+    --------
+    None
+    """
+    logging.info(" ".join(map(str, log)))
+
+
+def warning(*log):
+    """
+    warning logger.
+    Parameters
+    -----------
+    *log: *str
+    Returns
+    --------
+    None
+    """
+    logging.warning(" ".join(map(str, log)))

--- a/splinepy/nurbs.py
+++ b/splinepy/nurbs.py
@@ -1,8 +1,3 @@
-import logging
-
-import numpy as np
-
-from splinepy import utils
 from splinepy._splinepy import *
 from splinepy._spline import Spline
 from splinepy.rational_bezier import RationalBezier

--- a/splinepy/rational_bezier.py
+++ b/splinepy/rational_bezier.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 
 from splinepy import utils

--- a/splinepy/utils.py
+++ b/splinepy/utils.py
@@ -4,33 +4,10 @@ Utility functions.
 """
 
 import os
-import logging
 
 import numpy as np
 
-
-def configure_logging(debug=False, logfile=None):
-    """
-    Logging configurator.
-
-    Parameters
-    -----------
-    debug: bool
-    logfile: str
-
-    Returns
-    --------
-    None
-    """
-    logger = logging.getLogger()
-    if debug:
-        logger.setLevel(logging.DEBUG)
-
-    else:
-        logger.setLevel(logging.INFO)
-
-    if logfile is not None:
-        file_logger_handler = logging.FileHandler(logfile)
+from splinepy.log import debug 
 
 
 def is_property(property_dict, key, class_name):
@@ -51,7 +28,7 @@ def is_property(property_dict, key, class_name):
         return True
 
     else:
-        logging.debug(
+        debug(
             class_name
             + " - `"
             + key


### PR DESCRIPTION
# Implement thin logging functionality for `splinepy`

This is my first PR, hopefully I'm doing it right...

## Related Issues

* [Create own logger class for `splinepy`](https://github.com/tataratat/splinepy/issues/47)

## Description

* Moved `configure()` from `splinepy.utils` to `splinepy.log`
* Added `debug()`, `info()` and `warning()` methods in `splinepy.log`
* Added a base class `SplinepyBase` implemented in `_base.py`, which is now the base class for all `splinepy` classes and so far only implements logging functions `logd()`, `logi()` and `logw()` utilizing the functionality provided by `splinepy.log` 
* Changed logging in all other classes to use the functions provided by `SplinepyBase` instead of the native `logging` module