### PR TITLE
dynamic sdist build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft third_party
+graft cpp
+global-include CMakeLists.txt
+global-exclude .git .git*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "cmake>=3.16",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+test-command = "pytest {project}/tests"
+test-extras = ["test"]
+#test-skip = ["*universal2:arm64"]
+# Setuptools bug causes collision between pypy and cpython artifacts
+before-build = "rm -rf {project}/build"

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
     ],
     ext_modules=[CMakeExtension('splinepy._splinepy', cmake_args=cma)],
     cmdclass=dict(build_ext=CMakeBuild),
+    extras_require={"test": ["pytest>=6.0"]},
     zip_safe=False,
     license="MIT",
 )


### PR DESCRIPTION
# Overview
Enables dynamic build with sdist, in case there's not an appropriate wheels available in pypi.

## Related Issues

#48 

## Outlook
More distribution options like `conda` and add CI to build and upload, each time we bump the version