### PR TITLE
Get rid of warning

### DIFF
--- a/cpp/splinepy/fitting/fitting.cpp
+++ b/cpp/splinepy/fitting/fitting.cpp
@@ -14,7 +14,8 @@ double FitCurve(double* points,
   u_k = ParametrizeCurve(points, num_points, dim, centripetal);
 
   // Check knot_vector dimensions and updated if required
-  if (knot_vector.size() != static_cast<std::size_t>(num_control_points + degree + 1)) {
+  if (knot_vector.size()
+      != static_cast<std::size_t>(num_control_points + degree + 1)) {
     knot_vector =
         ComputeKnotVector(degree, num_points, num_control_points, u_k);
   }

--- a/cpp/splinepy/fitting/fitting.cpp
+++ b/cpp/splinepy/fitting/fitting.cpp
@@ -14,7 +14,7 @@ double FitCurve(double* points,
   u_k = ParametrizeCurve(points, num_points, dim, centripetal);
 
   // Check knot_vector dimensions and updated if required
-  if (knot_vector.size() != num_control_points + degree + 1) {
+  if (knot_vector.size() != static_cast<std::size_t>(num_control_points + degree + 1)) {
     knot_vector =
         ComputeKnotVector(degree, num_points, num_control_points, u_k);
   }

--- a/cpp/splinepy/py/py_bezier.hpp
+++ b/cpp/splinepy/py/py_bezier.hpp
@@ -11,8 +11,9 @@ namespace py = pybind11;
 
 template<std::size_t para_dim, std::size_t dim>
 using Bezier = bezman::BezierSpline<
-    static_cast<std::size_t>(para_dim),                          
-    std::conditional_t<(dim > 1), bezman::Point<dim>, double>, double>;
+    static_cast<std::size_t>(para_dim),
+    std::conditional_t<(dim > 1), bezman::Point<dim>, double>,
+    double>;
 
 template<std::size_t para_dim, std::size_t dim>
 class PyRationalBezier;
@@ -71,7 +72,8 @@ public:
     // update cps
     py::buffer_info cps_buf = p_control_points.request();
     double* cps_buf_ptr = static_cast<double*>(cps_buf.ptr);
-    for (std::size_t i = 0; i < static_cast<std::size_t>(cps_buf.shape[0]); i++) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(cps_buf.shape[0]);
+         i++) {
       if constexpr (dim > 1) {
         for (std::size_t j = 0; j < dim; j++) {
           c_bezier.control_points[i][j] = cps_buf_ptr[i * dim + j];
@@ -96,7 +98,8 @@ public:
     // update control_points
     const std::size_t number_of_ctps = c_bezier.control_points.size();
     // Check if shape changed
-    if (static_cast<long int>(c_bezier.control_points.size()) != p_control_points.request().shape[0]) {
+    if (static_cast<long int>(c_bezier.control_points.size())
+        != p_control_points.request().shape[0]) {
       // Update Control Point Vector
       p_control_points = py::array_t<double>(number_of_ctps * dim);
       p_control_points.resize({(int) number_of_ctps, (int) dim});
@@ -179,7 +182,7 @@ public:
       }
     }
 
-    results.resize({(int) q_buf.shape[0], (int)dim});
+    results.resize({(int) q_buf.shape[0], (int) dim});
 
     return results;
   }

--- a/cpp/splinepy/py/py_bspline.hpp
+++ b/cpp/splinepy/py/py_bspline.hpp
@@ -57,10 +57,6 @@ public:
   int para_dim_ = para_dim;
   int dim_ = dim;
 
-  // Counters
-  int i = 0;
-  int j = 0;
-
   // Hr. BSpline himself
   BSpline c_bspline;
   std::shared_ptr<ParameterSpace> c_parameter_space;
@@ -72,25 +68,27 @@ public:
       + ", physical dimension: " + std::to_string(dim);
 
   // Hr. BSpline's python Family
-  py::list p_knot_vectors;
   py::array_t<int> p_degrees;
   py::array_t<double> p_control_points;
+  py::list p_knot_vectors;
 
   // Hr. BSpline's switch to skip_update_c
   bool skip_update = false;
 
-  // Constructor.
+  // Empty constructor
   PyBSpline() {
     py::list empty_list;
     p_knot_vectors.attr("clear")();
     p_knot_vectors.append(empty_list);
   }
+
+  // Constructor
   PyBSpline(py::array_t<int> degrees,
             py::list knot_vectors,
             py::array_t<double> control_points)
       : p_degrees(degrees),
-        p_knot_vectors(knot_vectors),
-        p_control_points(control_points) {
+        p_control_points(control_points),
+        p_knot_vectors(knot_vectors) {
     update_c();
   }
 
@@ -104,12 +102,12 @@ public:
     // Formulate Degrees
     py::buffer_info ds_buf = p_degrees.request();
     int* ds_buf_ptr = static_cast<int*>(ds_buf.ptr);
-    for (i = 0; i < para_dim; i++) {
-      c_degrees[i] = Degree{ds_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      c_degrees[i_para_dim] = Degree{ds_buf_ptr[i_para_dim]};
     }
 
     // Formulate Knotvectors
-    i = 0;
+    int i_kv = 0;
     KnotVectors c_knot_vectors{};
     for (py::handle kv : p_knot_vectors) {
       c_knots.clear(); // Clear each time.
@@ -117,8 +115,8 @@ public:
         c_knots.push_back(Knot(k.cast<double>()));
       }
       std::shared_ptr knot_vector{std::make_shared<KnotVector>(c_knots)};
-      c_knot_vectors[i] = knot_vector;
-      i++;
+      c_knot_vectors[i_kv] = knot_vector;
+      i_kv++;
     }
 
     // Formulate Parameter_space
@@ -130,10 +128,10 @@ public:
     py::buffer_info cps_buf = p_control_points.request();
     double* cps_buf_ptr = static_cast<double*>(cps_buf.ptr);
 
-    for (i = 0; i < cps_buf.shape[0]; i++) { // cps_buf.shape[0] : number of cps
+    for (int i_cps = 0; i_cps < cps_buf.shape[0]; i_cps++) { // cps_buf.shape[0] : number of cps
       Coordinate control_point{};
-      for (j = 0; j < dim; j++) { // dim : cps_buf.shape[1]
-        control_point[j] = ScalarCoordinate{cps_buf_ptr[i * dim + j]};
+      for (int j_dim = 0; j_dim < dim; j_dim++) { // dim : cps_buf.shape[1]
+        control_point[j_dim] = ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
       }
       c_control_points.push_back(control_point);
     }
@@ -183,17 +181,17 @@ public:
 
     // Loop.
     int num_queries = q_buf.shape[0];
-    for (i = 0; i < num_queries; i++) {
+    for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{(q_buf_ptr[i * para_dim + j])};
+      for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
+        pc[j_para_dim] = ScalarParametricCoordinate{(q_buf_ptr[i_query * para_dim + j_para_dim])};
       }
       Coordinate const& c_result = c_bspline(pc);
 
-      j = 0;
+      int j_dim = 0;
       for (auto& sc : c_result) { // `sc` : ScarlarCoordinate
-        r_buf_ptr[i * dim + j] = sc.Get();
-        j++;
+        r_buf_ptr[i_query * dim + j_dim] = sc.Get();
+        j_dim++;
       }
     }
 
@@ -233,13 +231,13 @@ public:
     // thread exe
     const int chunk_size = std::ceil(n_queries / n_workers);
     std::vector<std::thread> pool;
-    for (i = 0; i < (n_workers - 1); i++) {
-      std::thread th(eval, i * chunk_size, (i + 1) * chunk_size);
+    for (int i_thread = 0; i_thread < (n_workers - 1); i_thread++) {
+      std::thread th(eval, i_thread * chunk_size, (i_thread + 1) * chunk_size);
       pool.push_back(std::move(th));
     }
     {
       // last one
-      std::thread th(eval, i * chunk_size, n_queries);
+      std::thread th(eval, (n_workers - 1) * chunk_size, n_queries);
       pool.push_back(std::move(th));
     }
 
@@ -271,24 +269,24 @@ public:
 
     // Formulate Derivative Orders.
     Derivative derivative{};
-    for (i = 0; i < o_buf.shape[0]; i++) {
-      derivative[i] = splinelib::Derivative{o_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < o_buf.shape[0]; i_para_dim++) {
+      derivative[i_para_dim] = splinelib::Derivative{o_buf_ptr[i_para_dim]};
     }
 
     // Loop - Queries.
     int num_queries = q_buf.shape[0];
-    for (i = 0; i < num_queries; i++) {
+    for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{q_buf_ptr[i * para_dim + j]};
+      for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
+        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
       Coordinate const& c_result = c_bspline(pc, derivative);
 
       // Write `c_result` to `results`.
-      j = 0;
+      int j_dim = 0;
       for (const auto& sc : c_result) { // `sc` : ScalarCoordinate
-        r_buf_ptr[i * dim + j] = sc.Get();
-        j++;
+        r_buf_ptr[i_query * dim + j_dim] = sc.Get();
+        j_dim++;
       }
     }
 
@@ -314,8 +312,8 @@ public:
 
     // Formulate Derivative Orders.
     Derivative derivative{};
-    for (i = 0; i < o_buf.shape[0]; i++) {
-      derivative[i] = splinelib::Derivative{o_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < o_buf.shape[0]; i_para_dim++) {
+      derivative[i_para_dim] = splinelib::Derivative{o_buf_ptr[i_para_dim]};
     }
 
     // deval and fill up result array
@@ -337,13 +335,13 @@ public:
     // thread exe
     const int chunk_size = std::ceil(n_queries / n_workers);
     std::vector<std::thread> pool;
-    for (i = 0; i < (n_workers - 1); i++) {
-      std::thread th(deval, i * chunk_size, (i + 1) * chunk_size);
+    for (int i_thread = 0; i_thread < (n_workers - 1); i_thread++) {
+      std::thread th(deval, i_thread * chunk_size, (i_thread + 1) * chunk_size);
       pool.push_back(std::move(th));
     }
     {
       // last one
-      std::thread th(deval, i * chunk_size, n_queries);
+      std::thread th(deval, (n_workers - 1) * chunk_size, n_queries);
       pool.push_back(std::move(th));
     }
 
@@ -360,8 +358,8 @@ public:
   py::list ExtractBezierPatches() {
     const auto c_patches = splinepy::splines::ExtractBezierPatches(c_bspline);
     py::list bezier_list{};
-    for (std::size_t i{}; i < c_patches.size(); i++) {
-      bezier_list.append(PyBezier<para_dim, dim>{c_patches[i]});
+    for (std::size_t i_patch{}; i_patch < c_patches.size(); i_patch++) {
+      bezier_list.append(PyBezier<para_dim, dim>{c_patches[i_patch]});
     }
     return bezier_list;
   }
@@ -381,8 +379,8 @@ public:
     py::buffer_info ds_buf = p_degrees.request();
     int* ds_buf_ptr = static_cast<int*>(ds_buf.ptr);
     int n_supports = 1;
-    for (i = 0; i < para_dim; i++) {
-      n_supports *= (ds_buf_ptr[i] + 1);
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      n_supports *= (ds_buf_ptr[i_para_dim] + 1);
     }
 
     // prepare results array
@@ -395,13 +393,13 @@ public:
     int* sci_buf_ptr = static_cast<int*>(sci_buf.ptr);
 
     // iterate queries and fill up result arrays
-    for (i = 0; i < n_queries; i++) {
+    for (int i_query = 0; i_query < n_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{q_buf_ptr[i * para_dim + j]};
+      for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
+        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
-      double* bf_current_ptr = &bf_buf_ptr[i * n_supports];
-      int* sci_current_ptr = &sci_buf_ptr[i * n_supports];
+      double* bf_current_ptr = &bf_buf_ptr[i_query * n_supports];
+      int* sci_current_ptr = &sci_buf_ptr[i_query * n_supports];
       c_bspline.BasisFunctionsAndIDs(pc, bf_current_ptr, sci_current_ptr);
     }
 
@@ -487,8 +485,8 @@ public:
 
     // Prepare results array.
     int num_results = 1;
-    for (i = 0; i < para_dim; i++) {
-      num_results *= q_buf_ptr[i];
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      num_results *= q_buf_ptr[i_para_dim];
     }
     py::array_t<double> results(num_results * dim);
     py::buffer_info r_buf = results.request();
@@ -498,19 +496,19 @@ public:
     //   Could be done with "Prepare results array", but easier to read this
     //   way.
     NumberOfParametricCoordinates npc{};
-    for (i = 0; i < para_dim; i++) {
-      npc[i] = splinelib::Length{q_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      npc[i_para_dim] = splinelib::Length{q_buf_ptr[i_para_dim]};
     }
 
     // Sample and write to `results`
     Coordinates sampled_coordinates = c_bspline.Sample(npc);
-    for (int i = 0; i < sampled_coordinates.size(); i++) {
-      Coordinate c = sampled_coordinates[i];
+    for (std::size_t i_sample = 0; i_sample < sampled_coordinates.size(); i_sample++) {
+      Coordinate c = sampled_coordinates[i_sample];
 
-      j = 0;
+      int j_dim = 0;
       for (const auto& sc : c) {
-        r_buf_ptr[i * dim + j] = sc.Get();
-        j++;
+        r_buf_ptr[i_sample * dim + j_dim] = sc.Get();
+        j_dim++;
       }
     }
 
@@ -578,9 +576,9 @@ public:
     py::buffer_info pc_buf = p_control_points.request();
     double* pc_buf_ptr = static_cast<double*>(pc_buf.ptr);
 
-    for (i = 0; i < num_control_points; i++) {
-      for (j = 0; j < curve_dim; j++) {
-        pc_buf_ptr[i * dim + j] = control_points[i * dim + j];
+    for (int i_cps = 0; i_cps < num_control_points; i_cps++) {
+      for (int j_dim = 0; j_dim < curve_dim; j_dim++) {
+        pc_buf_ptr[i_cps * dim + j_dim] = control_points[i_cps * dim + j_dim];
       }
     }
 
@@ -671,9 +669,9 @@ public:
     py::buffer_info pc_buf = p_control_points.request();
     double* pc_buf_ptr = static_cast<double*>(pc_buf.ptr);
 
-    for (i = 0; i < num_points; i++) {
-      for (j = 0; j < surface_dim; j++) {
-        pc_buf_ptr[i * dim + j] = control_points[i * dim + j];
+    for (int i_cps = 0; i_cps < num_points; i_cps++) {
+      for (int j_dim = 0; j_dim < surface_dim; j_dim++) {
+        pc_buf_ptr[i_cps * dim + j_dim] = control_points[i_cps * dim + j_dim];
       }
     }
 

--- a/cpp/splinepy/py/py_bspline.hpp
+++ b/cpp/splinepy/py/py_bspline.hpp
@@ -128,10 +128,12 @@ public:
     py::buffer_info cps_buf = p_control_points.request();
     double* cps_buf_ptr = static_cast<double*>(cps_buf.ptr);
 
-    for (int i_cps = 0; i_cps < cps_buf.shape[0]; i_cps++) { // cps_buf.shape[0] : number of cps
+    for (int i_cps = 0; i_cps < cps_buf.shape[0];
+         i_cps++) { // cps_buf.shape[0] : number of cps
       Coordinate control_point{};
       for (int j_dim = 0; j_dim < dim; j_dim++) { // dim : cps_buf.shape[1]
-        control_point[j_dim] = ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
+        control_point[j_dim] =
+            ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
       }
       c_control_points.push_back(control_point);
     }
@@ -184,7 +186,8 @@ public:
     for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
-        pc[j_para_dim] = ScalarParametricCoordinate{(q_buf_ptr[i_query * para_dim + j_para_dim])};
+        pc[j_para_dim] = ScalarParametricCoordinate{
+            (q_buf_ptr[i_query * para_dim + j_para_dim])};
       }
       Coordinate const& c_result = c_bspline(pc);
 
@@ -278,7 +281,8 @@ public:
     for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
-        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
+        pc[j_para_dim] = ScalarParametricCoordinate{
+            q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
       Coordinate const& c_result = c_bspline(pc, derivative);
 
@@ -396,7 +400,8 @@ public:
     for (int i_query = 0; i_query < n_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
-        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
+        pc[j_para_dim] = ScalarParametricCoordinate{
+            q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
       double* bf_current_ptr = &bf_buf_ptr[i_query * n_supports];
       int* sci_current_ptr = &sci_buf_ptr[i_query * n_supports];
@@ -502,7 +507,8 @@ public:
 
     // Sample and write to `results`
     Coordinates sampled_coordinates = c_bspline.Sample(npc);
-    for (std::size_t i_sample = 0; i_sample < sampled_coordinates.size(); i_sample++) {
+    for (std::size_t i_sample = 0; i_sample < sampled_coordinates.size();
+         i_sample++) {
       Coordinate c = sampled_coordinates[i_sample];
 
       int j_dim = 0;

--- a/cpp/splinepy/py/py_nurbs.hpp
+++ b/cpp/splinepy/py/py_nurbs.hpp
@@ -58,10 +58,6 @@ public:
   int para_dim_ = para_dim;
   int dim_ = dim;
 
-  // Counters
-  int i = 0;
-  int j = 0;
-
   // Fr. Nurbs herself
   Nurbs c_nurbs;
   std::shared_ptr<ParameterSpace> c_parameter_space;
@@ -73,9 +69,9 @@ public:
       + ", physical dimension: " + std::to_string(dim);
 
   // Fr. Nurbs' python Family
-  py::list p_knot_vectors;
   py::array_t<int> p_degrees;
   py::array_t<double> p_control_points;
+  py::list p_knot_vectors;
   py::array_t<double> p_weights;
 
   // Fr. Nurbs' switch to skip update_c
@@ -88,8 +84,8 @@ public:
           py::array_t<double> control_points, //
           py::array_t<double> weights)
       : p_degrees(degrees),
-        p_knot_vectors(knot_vectors),
         p_control_points(control_points),
+        p_knot_vectors(knot_vectors),
         p_weights(weights) {
     update_c();
   }
@@ -105,12 +101,12 @@ public:
     // Formulate Degrees
     py::buffer_info ds_buf = p_degrees.request();
     int* ds_buf_ptr = static_cast<int*>(ds_buf.ptr);
-    for (i = 0; i < para_dim; i++) {
-      c_degrees[i] = Degree{ds_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      c_degrees[i_para_dim] = Degree{ds_buf_ptr[i_para_dim]};
     }
 
     // Formulate Knotvectors
-    i = 0;
+    int i_kv = 0;
     KnotVectors c_knot_vectors{};
     for (py::handle kv : p_knot_vectors) {
       c_knots.clear(); // Clear each time.
@@ -118,8 +114,8 @@ public:
         c_knots.push_back(Knot(k.cast<double>()));
       }
       std::shared_ptr knot_vector{std::make_shared<KnotVector>(c_knots)};
-      c_knot_vectors[i] = knot_vector;
-      i++;
+      c_knot_vectors[i_kv] = knot_vector;
+      i_kv++;
     }
 
     // Formulate Parameter_space
@@ -133,12 +129,12 @@ public:
     c_control_points.clear();
     c_control_points.assign(cps_buf.shape[0], Coordinate{});
 
-    for (i = 0; i < cps_buf.shape[0]; i++) { // cps_buf.shape[0] : number of cps
+    for (int i_cps = 0; i_cps < cps_buf.shape[0]; i_cps++) { // cps_buf.shape[0] : number of cps
       Coordinate control_point{};
-      for (j = 0; j < dim; j++) { // dim : cps_bus.shape[1]
-        control_point[j] = ScalarCoordinate{cps_buf_ptr[i * dim + j]};
+      for (int j_dim = 0; j_dim < dim; j_dim++) { // dim : cps_bus.shape[1]
+        control_point[j_dim] = ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
       }
-      c_control_points[i] = control_point;
+      c_control_points[i_cps] = control_point;
     }
 
     // Formulate Weights
@@ -154,8 +150,8 @@ public:
           "Number of control points and number of weights does not match.");
     }
 
-    for (i = 0; i < ws_buf.shape[0]; i++) {
-      c_weights[i] = Weight{ws_buf_ptr[i]};
+    for (int i_weight = 0; i_weight < ws_buf.shape[0]; i_weight++) {
+      c_weights[i_weight] = Weight{ws_buf_ptr[i_weight]};
     }
 
     // Formulate Weighted Vector Space
@@ -211,15 +207,15 @@ public:
 
     // Loop.
     int num_queries = q_buf.shape[0];
-    for (i = 0; i < num_queries; i++) {
+    for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{(q_buf_ptr[i * para_dim + j])};
+      for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
+        pc[j_para_dim] = ScalarParametricCoordinate{(q_buf_ptr[i_query * para_dim + j_para_dim])};
       }
       Coordinate const& c_result = c_nurbs(pc);
-      j = 0;
+      int j = 0;
       for (auto& sc : c_result) { // `sc` : ScarlarCoordinate
-        r_buf_ptr[i * dim + j] = sc.Get();
+        r_buf_ptr[i_query * dim + j] = sc.Get();
         j++;
       }
     }
@@ -264,13 +260,13 @@ public:
     // thread exe
     const int chunk_size = std::ceil(n_queries / n_workers);
     std::vector<std::thread> pool;
-    for (i = 0; i < (n_workers - 1); i++) {
-      std::thread th(eval, i * chunk_size, (i + 1) * chunk_size);
+    for (int i_thread = 0; i_thread < (n_workers - 1); i_thread++) {
+      std::thread th(eval, i_thread * chunk_size, (i_thread + 1) * chunk_size);
       pool.push_back(std::move(th));
     }
     {
       // last one
-      std::thread th(eval, i * chunk_size, n_queries);
+      std::thread th(eval, (n_workers - 1) * chunk_size, n_queries);
       pool.push_back(std::move(th));
     }
 
@@ -302,24 +298,24 @@ public:
 
     // Formulate Derivative Orders.
     Derivative derivative{};
-    for (i = 0; i < o_buf.shape[0]; i++) {
-      derivative[i] = splinelib::Derivative{o_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < o_buf.shape[0]; i_para_dim++) {
+      derivative[i_para_dim] = splinelib::Derivative{o_buf_ptr[i_para_dim]};
     }
 
     // Loop - Queries.
     int num_queries = q_buf.shape[0];
-    for (i = 0; i < num_queries; i++) {
+    for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{q_buf_ptr[i * para_dim + j]};
+      for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+        pc[i_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + i_para_dim]};
       }
       Coordinate const& c_result = c_nurbs(pc, derivative);
 
       // Write `c_result` to `results`.
-      j = 0;
+      int j_dim = 0;
       for (const auto& sc : c_result) { // `sc` : ScalarCoordinate
-        r_buf_ptr[i * dim + j] = sc.Get();
-        j++;
+        r_buf_ptr[i_query * dim + j_dim] = sc.Get();
+        j_dim++;
       }
     }
 
@@ -349,8 +345,8 @@ public:
 
     // Formulate Derivative Orders.
     Derivative derivative{};
-    for (i = 0; i < o_buf.shape[0]; i++) {
-      derivative[i] = splinelib::Derivative{o_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < o_buf.shape[0]; i_para_dim++) {
+      derivative[i_para_dim] = splinelib::Derivative{o_buf_ptr[i_para_dim]};
     }
 
     // deval and fill up result array
@@ -372,14 +368,14 @@ public:
     // thread exe
     const int chunk_size = std::ceil(n_queries / n_workers);
     std::vector<std::thread> pool;
-    for (i = 0; i < (n_workers - 1); i++) {
-      std::thread th(deval, i * chunk_size, (i + 1) * chunk_size);
+    for (int i_thread = 0; i_thread < (n_workers - 1); i_thread++) {
+      std::thread th(deval, i_thread * chunk_size, (i_thread + 1) * chunk_size);
       pool.push_back(std::move(th));
     }
 
     {
       // last one
-      std::thread th(deval, i * chunk_size, n_queries);
+      std::thread th(deval, (n_workers - 1) * chunk_size, n_queries);
       pool.push_back(std::move(th));
     }
 
@@ -417,8 +413,8 @@ public:
     py::buffer_info ds_buf = p_degrees.request();
     int* ds_buf_ptr = static_cast<int*>(ds_buf.ptr);
     int n_supports = 1;
-    for (i = 0; i < para_dim; i++) {
-      n_supports *= (ds_buf_ptr[i] + 1);
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      n_supports *= (ds_buf_ptr[i_para_dim] + 1);
     }
 
     // prepare results array
@@ -431,13 +427,13 @@ public:
     int* sci_buf_ptr = static_cast<int*>(sci_buf.ptr);
 
     // iterate queries and fill up result arrays
-    for (i = 0; i < n_queries; i++) {
+    for (int i_query = 0; i_query < n_queries; i_query++) {
       ParametricCoordinate pc{};
-      for (j = 0; j < para_dim; j++) {
-        pc[j] = ScalarParametricCoordinate{q_buf_ptr[i * para_dim + j]};
+      for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
+        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
-      double* bf_current_ptr = &bf_buf_ptr[i * n_supports];
-      int* sci_current_ptr = &sci_buf_ptr[i * n_supports];
+      double* bf_current_ptr = &bf_buf_ptr[i_query * n_supports];
+      int* sci_current_ptr = &sci_buf_ptr[i_query * n_supports];
       c_nurbs.BasisFunctionsAndIDs(pc, bf_current_ptr, sci_current_ptr);
     }
 
@@ -523,8 +519,8 @@ public:
 
     // Prepare results array.
     int num_results = 1;
-    for (i = 0; i < para_dim; i++) {
-      num_results *= q_buf_ptr[i];
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      num_results *= q_buf_ptr[i_para_dim];
     }
 
     py::array_t<double> results(num_results * dim);
@@ -535,19 +531,19 @@ public:
     //   Could be done with "Prepare results array", but easier to read this
     //   way.
     NumberOfParametricCoordinates npc{};
-    for (i = 0; i < para_dim; i++) {
-      npc[i] = splinelib::Length{q_buf_ptr[i]};
+    for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
+      npc[i_para_dim] = splinelib::Length{q_buf_ptr[i_para_dim]};
     }
 
     // Sample and write to `results`
     Coordinates sampled_coordinates = c_nurbs.Sample(npc);
-    for (int i = 0; i < sampled_coordinates.size(); i++) {
-      Coordinate c = sampled_coordinates[i];
+    for (std::size_t i_coord = 0; i_coord < sampled_coordinates.size(); i_coord++) {
+      Coordinate c = sampled_coordinates[i_coord];
 
-      j = 0;
+      int j_dim = 0;
       for (const auto& sc : c) {
-        r_buf_ptr[i * dim + j] = sc.Get();
-        j++;
+        r_buf_ptr[i_coord * dim + j_dim] = sc.Get();
+        j_dim++;
       }
     }
 
@@ -763,4 +759,4 @@ void add_nurbs_pyclass(py::module& m, const char* class_name) {
             );
             return pyn;
           }));
-};
+}

--- a/cpp/splinepy/py/py_nurbs.hpp
+++ b/cpp/splinepy/py/py_nurbs.hpp
@@ -129,10 +129,12 @@ public:
     c_control_points.clear();
     c_control_points.assign(cps_buf.shape[0], Coordinate{});
 
-    for (int i_cps = 0; i_cps < cps_buf.shape[0]; i_cps++) { // cps_buf.shape[0] : number of cps
+    for (int i_cps = 0; i_cps < cps_buf.shape[0];
+         i_cps++) { // cps_buf.shape[0] : number of cps
       Coordinate control_point{};
       for (int j_dim = 0; j_dim < dim; j_dim++) { // dim : cps_bus.shape[1]
-        control_point[j_dim] = ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
+        control_point[j_dim] =
+            ScalarCoordinate{cps_buf_ptr[i_cps * dim + j_dim]};
       }
       c_control_points[i_cps] = control_point;
     }
@@ -210,7 +212,8 @@ public:
     for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
-        pc[j_para_dim] = ScalarParametricCoordinate{(q_buf_ptr[i_query * para_dim + j_para_dim])};
+        pc[j_para_dim] = ScalarParametricCoordinate{
+            (q_buf_ptr[i_query * para_dim + j_para_dim])};
       }
       Coordinate const& c_result = c_nurbs(pc);
       int j = 0;
@@ -307,7 +310,8 @@ public:
     for (int i_query = 0; i_query < num_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int i_para_dim = 0; i_para_dim < para_dim; i_para_dim++) {
-        pc[i_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + i_para_dim]};
+        pc[i_para_dim] = ScalarParametricCoordinate{
+            q_buf_ptr[i_query * para_dim + i_para_dim]};
       }
       Coordinate const& c_result = c_nurbs(pc, derivative);
 
@@ -430,7 +434,8 @@ public:
     for (int i_query = 0; i_query < n_queries; i_query++) {
       ParametricCoordinate pc{};
       for (int j_para_dim = 0; j_para_dim < para_dim; j_para_dim++) {
-        pc[j_para_dim] = ScalarParametricCoordinate{q_buf_ptr[i_query * para_dim + j_para_dim]};
+        pc[j_para_dim] = ScalarParametricCoordinate{
+            q_buf_ptr[i_query * para_dim + j_para_dim]};
       }
       double* bf_current_ptr = &bf_buf_ptr[i_query * n_supports];
       int* sci_current_ptr = &sci_buf_ptr[i_query * n_supports];
@@ -537,7 +542,8 @@ public:
 
     // Sample and write to `results`
     Coordinates sampled_coordinates = c_nurbs.Sample(npc);
-    for (std::size_t i_coord = 0; i_coord < sampled_coordinates.size(); i_coord++) {
+    for (std::size_t i_coord = 0; i_coord < sampled_coordinates.size();
+         i_coord++) {
       Coordinate c = sampled_coordinates[i_coord];
 
       int j_dim = 0;

--- a/cpp/splinepy/py/py_rational_bezier.hpp
+++ b/cpp/splinepy/py/py_rational_bezier.hpp
@@ -99,7 +99,9 @@ public:
     // Check if size matches
     assert(p_control_points.request().shape[0]
            == c_rational_bezier.NumberOfControlPoints);
-    for (std::size_t i = 0; i < static_cast<std::size_t>(p_control_points.request().shape[0]); i++) {
+    for (std::size_t i = 0;
+         i < static_cast<std::size_t>(p_control_points.request().shape[0]);
+         i++) {
       // Update weight
       c_rational_bezier.GetWeights()[i] = weights_ptr[i];
       // Update CTPS
@@ -131,13 +133,14 @@ public:
 
     // update control_points
     // Check if shape changed
-    if (static_cast<long int>(c_rational_bezier.GetWeightedControlPoints().size())
+    if (static_cast<long int>(
+            c_rational_bezier.GetWeightedControlPoints().size())
         != p_control_points.request().shape[0]) {
       const std::size_t number_of_ctps =
           c_rational_bezier.GetWeightedControlPoints().size();
       // Update Control Point Vector
       p_control_points = py::array_t<double>(number_of_ctps * dim);
-      p_control_points.resize({(int) number_of_ctps, (int)dim});
+      p_control_points.resize({(int) number_of_ctps, (int) dim});
       // Update Control Point Vector
       p_weights = py::array_t<double>(number_of_ctps);
       p_weights.resize({(int) number_of_ctps, 1});
@@ -147,7 +150,9 @@ public:
     }
 
     // update control_points
-    for (std::size_t i = 0; i < static_cast<std::size_t>(p_control_points.request().shape[0]); i++) {
+    for (std::size_t i = 0;
+         i < static_cast<std::size_t>(p_control_points.request().shape[0]);
+         i++) {
       weights_ptr[i] = c_rational_bezier.GetWeights()[i];
       double inv_weight_i = static_cast<double>(1.) / weights_ptr[i];
       if constexpr (dim > 1) {
@@ -181,7 +186,9 @@ public:
     double* r_ptr = static_cast<double*>(results.request().ptr);
 
     // Loop over query points for evaluation
-    for (std::size_t i = 0; i < static_cast<std::size_t>(queries.request().shape[0]); i++) {
+    for (std::size_t i = 0;
+         i < static_cast<std::size_t>(queries.request().shape[0]);
+         i++) {
       bezman::Point<static_cast<unsigned>(para_dim)> query_ptr;
       for (std::size_t j = 0; j < para_dim; j++) {
         query_ptr[j] = q_ptr[i * para_dim + j];

--- a/cpp/splinepy/py/py_rational_bezier.hpp
+++ b/cpp/splinepy/py/py_rational_bezier.hpp
@@ -11,7 +11,7 @@
 
 namespace py = pybind11;
 
-template<int para_dim, int dim>
+template<std::size_t para_dim, std::size_t dim>
 using RationalBezier = bezman::RationalBezierSpline<
     static_cast<std::size_t>(para_dim),
     std::conditional_t<(dim > 1),
@@ -19,7 +19,7 @@ using RationalBezier = bezman::RationalBezierSpline<
                        double>,
     double>;
 
-template<int para_dim, int dim>
+template<std::size_t para_dim, std::size_t dim>
 class PyRationalBezier {
 private:
   // Alias to the internal RationalBezier type
@@ -67,7 +67,7 @@ public:
     // Init c_rational_bezier using move constructor
     c_rational_bezier = std::move(rhs);
     p_control_points.resize(
-        {(int) c_rational_bezier.GetWeightedControlPoints().size(), dim});
+        {(int) c_rational_bezier.GetWeightedControlPoints().size(), (int) dim});
     p_weights.resize({(int) c_rational_bezier.GetWeights().size(), 1});
     p_degrees.resize({(int) para_dim});
     update_p();
@@ -77,7 +77,7 @@ public:
   PyRationalBezier(const PyBezier<para_dim, dim>& rhs)
       : c_rational_bezier{rhs.c_bezier} {
     p_control_points.resize(
-        {(int) c_rational_bezier.GetWeightedControlPoints().size(), dim});
+        {(int) c_rational_bezier.GetWeightedControlPoints().size(), (int) dim});
     p_weights.resize({(int) c_rational_bezier.GetWeights().size(), 1});
     p_degrees.resize({(int) para_dim});
     update_p();
@@ -99,12 +99,12 @@ public:
     // Check if size matches
     assert(p_control_points.request().shape[0]
            == c_rational_bezier.NumberOfControlPoints);
-    for (std::size_t i = 0; i < p_control_points.request().shape[0]; i++) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(p_control_points.request().shape[0]); i++) {
       // Update weight
       c_rational_bezier.GetWeights()[i] = weights_ptr[i];
       // Update CTPS
       if constexpr (dim > 1) {
-        for (int j = 0; j < dim; j++) {
+        for (std::size_t j = 0; j < dim; j++) {
           c_rational_bezier.GetWeightedControlPoints()[i][j] =
               cps_ptr[i * dim + j] * weights_ptr[i];
         }
@@ -125,19 +125,19 @@ public:
     double* weights_ptr = static_cast<double*>(p_weights.request().ptr);
 
     // update degrees
-    for (int i = 0; i < para_dim; i++) {
+    for (std::size_t i = 0; i < para_dim; i++) {
       ds_ptr[i] = c_rational_bezier.GetDegrees()[i];
     }
 
     // update control_points
     // Check if shape changed
-    if (c_rational_bezier.GetWeightedControlPoints().size()
+    if (static_cast<long int>(c_rational_bezier.GetWeightedControlPoints().size())
         != p_control_points.request().shape[0]) {
       const std::size_t number_of_ctps =
           c_rational_bezier.GetWeightedControlPoints().size();
       // Update Control Point Vector
       p_control_points = py::array_t<double>(number_of_ctps * dim);
-      p_control_points.resize({(int) number_of_ctps, dim});
+      p_control_points.resize({(int) number_of_ctps, (int)dim});
       // Update Control Point Vector
       p_weights = py::array_t<double>(number_of_ctps);
       p_weights.resize({(int) number_of_ctps, 1});
@@ -147,11 +147,11 @@ public:
     }
 
     // update control_points
-    for (int i = 0; i < p_control_points.request().shape[0]; i++) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(p_control_points.request().shape[0]); i++) {
       weights_ptr[i] = c_rational_bezier.GetWeights()[i];
       double inv_weight_i = static_cast<double>(1.) / weights_ptr[i];
       if constexpr (dim > 1) {
-        for (int j = 0; j < dim; j++) {
+        for (std::size_t j = 0; j < dim; j++) {
           cps_ptr[i * dim + j] =
               c_rational_bezier.GetWeightedControlPoints()[i][j] * inv_weight_i;
         }
@@ -181,14 +181,14 @@ public:
     double* r_ptr = static_cast<double*>(results.request().ptr);
 
     // Loop over query points for evaluation
-    for (int i = 0; i < queries.request().shape[0]; i++) {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(queries.request().shape[0]); i++) {
       bezman::Point<static_cast<unsigned>(para_dim)> query_ptr;
-      for (int j = 0; j < para_dim; j++) {
+      for (std::size_t j = 0; j < para_dim; j++) {
         query_ptr[j] = q_ptr[i * para_dim + j];
       }
       const auto& eqpt = c_rational_bezier.ForwardEvaluate(query_ptr);
       if constexpr (dim > 1) {
-        for (int j = 0; j < dim; j++) {
+        for (std::size_t j = 0; j < dim; j++) {
           r_ptr[i * dim + j] = eqpt[j];
         }
       } else {
@@ -196,7 +196,7 @@ public:
       }
     }
 
-    results.resize({(int) queries.request().shape[0], dim});
+    results.resize({(int) queries.request().shape[0], (int) dim});
 
     return results;
   }

--- a/cpp/splinepy/py/spline_reader.hpp
+++ b/cpp/splinepy/py/spline_reader.hpp
@@ -11,9 +11,8 @@
 #include <Sources/InputOutput/iges.hpp>
 #include <Sources/InputOutput/irit.hpp>
 #include <Sources/InputOutput/xml.hpp>
-#include <Sources/Splines/b_spline.hpp>
 #include <Sources/Utilities/named_type.hpp>
-//#include <Sources/Splines/nurbs.hpp>
+#include <Sources/Splines/b_spline.hpp>
 
 namespace py = pybind11;
 

--- a/cpp/splinepy/py/spline_reader.hpp
+++ b/cpp/splinepy/py/spline_reader.hpp
@@ -11,8 +11,8 @@
 #include <Sources/InputOutput/iges.hpp>
 #include <Sources/InputOutput/irit.hpp>
 #include <Sources/InputOutput/xml.hpp>
-#include <Sources/Utilities/named_type.hpp>
 #include <Sources/Splines/b_spline.hpp>
+#include <Sources/Utilities/named_type.hpp>
 
 namespace py = pybind11;
 

--- a/cpp/splinepy/splines/helpers.hpp
+++ b/cpp/splinepy/splines/helpers.hpp
@@ -83,7 +83,7 @@ auto ExtractBezierPatches(SplineType& input) {
   }
   std::array<std::size_t, para_dim> bezier_index_offsets{};
   bezier_index_offsets[0] = 1;
-  int n_ctps_per_patch = degrees[0] + 1;
+  std::size_t n_ctps_per_patch = degrees[0] + 1;
   for (std::size_t i{1}; i < para_dim; i++) {
     bezier_index_offsets[i] =
         bezier_index_offsets[i - 1] * (degrees[i - 1] + 1);

--- a/cpp/splinepy/utils/arrays.hpp
+++ b/cpp/splinepy/utils/arrays.hpp
@@ -210,8 +210,8 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
 
   // back substitution
   double sum;
-  for (std::size_t i_para_dim{}; i_para_dim <para_dim; i_para_dim++) {
-    std::size_t i = para_dim -1 -i_para_dim;
+  for (std::size_t i_para_dim{}; i_para_dim < para_dim; i_para_dim++) {
+    std::size_t i{para_dim - 1 - i_para_dim};
     // ignore clipped entries
     if (skipmask[i] != 0)
       continue;

--- a/cpp/splinepy/utils/arrays.hpp
+++ b/cpp/splinepy/utils/arrays.hpp
@@ -59,7 +59,6 @@ inline T1 Dot(const std::array<T1, dim>& arr1,
 template<typename T, std::size_t dim1, std::size_t dim2>
 inline std::array<std::array<T, dim1>, dim1>
 AAt(const std::array<std::array<T, dim2>, dim1>& arr1) {
-
   std::array<std::array<T, dim1>, dim1> out;
 
   for (std::size_t i{}; i < dim1; ++i) {
@@ -95,7 +94,6 @@ template<typename T1, typename T2, std::size_t para_dim>
 inline void Clip(const std::array<std::array<T1, para_dim>, 2>& bounds,
                  std::array<T2, para_dim>& para_coord,
                  std::array<int, para_dim>& clipped) {
-
   for (std::size_t i{0}; i < para_dim; i++) {
     // check max
     if (static_cast<T1>(para_coord[i]) > bounds[1][i]) {
@@ -155,7 +153,6 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
                std::array<double, para_dim>& b,
                std::array<int, para_dim>& skipmask,
                std::array<double, para_dim>& x) {
-
   std::size_t maxrow;
   double maxval, maybemax;
   std::array<int, para_dim> indexmap;
@@ -210,8 +207,9 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
 
   // back substitution
   double sum;
-  for (std::size_t i_para_dim{}; i_para_dim < para_dim; i_para_dim++) {
-    std::size_t i{para_dim - 1 - i_para_dim};
+  // Looping backwards, stopping once overflow is reached, which corresponds to
+  // (-1), i.e., such that the last value is 0
+  for (std::size_t i{para_dim - 1}; i != static_cast<std::size_t>(-1); --i) {
     // ignore clipped entries
     if (skipmask[i] != 0)
       continue;

--- a/cpp/splinepy/utils/arrays.hpp
+++ b/cpp/splinepy/utils/arrays.hpp
@@ -38,7 +38,7 @@ template<typename ReturnT, typename T, std::size_t dim>
 inline std::array<ReturnT, dim> Mean(const std::array<T, dim>& arr1,
                                      const std::array<T, dim>& arr2) {
   std::array<ReturnT, dim> out;
-  for (int i{0}; i < dim; ++i) {
+  for (std::size_t i{0}; i < dim; ++i) {
     out[i] = ReturnT{(arr1[i] + arr2[i]) * .5};
   }
   return out;
@@ -49,7 +49,7 @@ template<typename T1, typename T2, std::size_t dim>
 inline T1 Dot(const std::array<T1, dim>& arr1,
               const std::array<T2, dim>& arr2) {
   T1 dotted{}; /* default value should be 0. */
-  for (int i{0}; i < dim; ++i) {
+  for (std::size_t i{0}; i < dim; ++i) {
     dotted += arr1[i] * static_cast<T1>(arr2[i]);
   }
   return dotted;
@@ -62,8 +62,8 @@ AAt(const std::array<std::array<T, dim2>, dim1>& arr1) {
 
   std::array<std::array<T, dim1>, dim1> out;
 
-  for (int i{}; i < dim1; ++i) {
-    for (int j{i}; j < dim1; ++j) {
+  for (std::size_t i{}; i < dim1; ++i) {
+    for (std::size_t j{i}; j < dim1; ++j) {
       out[i][j] = Dot(arr1[i], arr1[j]);
       if (i != j)
         out[j][i] = out[i][j]; // fill symmetric part
@@ -77,7 +77,7 @@ AAt(const std::array<std::array<T, dim2>, dim1>& arr1) {
 template<typename T1, typename T2, std::size_t dim>
 inline void AddSecondToFirst(std::array<T1, dim>& arr1,
                              const std::array<T2, dim>& arr2) {
-  for (int i{0}; i < dim; i++) {
+  for (std::size_t i{0}; i < dim; i++) {
     arr1[i] += T1{arr2[i]};
   }
 }
@@ -96,7 +96,7 @@ inline void Clip(const std::array<std::array<T1, para_dim>, 2>& bounds,
                  std::array<T2, para_dim>& para_coord,
                  std::array<int, para_dim>& clipped) {
 
-  for (int i{0}; i < para_dim; i++) {
+  for (std::size_t i{0}; i < para_dim; i++) {
     // check max
     if (static_cast<T1>(para_coord[i]) > bounds[1][i]) {
       clipped[i] = 1;
@@ -115,7 +115,7 @@ inline void Clip(const std::array<std::array<T1, para_dim>, 2>& bounds,
 template<typename T, std::size_t dim>
 inline double NormL2(std::array<T, dim>& arr) {
   double returnval{};
-  for (int i{}; i < dim; ++i) {
+  for (std::size_t i{}; i < dim; ++i) {
     returnval += arr[i] * arr[i];
   }
   return std::sqrt(returnval);
@@ -133,7 +133,7 @@ inline double NormL2(std::array<T, dim>& arr) {
 template<typename T, typename IndexT, std::size_t dim>
 void CopyReorder(std::array<T, dim>& arr, std::array<IndexT, dim>& order) {
   const auto copyarr = arr; // should copy.
-  for (IndexT i{0}; i < dim; i++) {
+  for (std::size_t i{0}; i < dim; i++) {
     arr[order[i]] = copyarr[i];
   }
 }
@@ -156,13 +156,13 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
                std::array<int, para_dim>& skipmask,
                std::array<double, para_dim>& x) {
 
-  int maxrow;
+  std::size_t maxrow;
   double maxval, maybemax;
   std::array<int, para_dim> indexmap;
   std::iota(indexmap.begin(), indexmap.end(), 0);
 
   // partial pivoting and forward reduction
-  for (int i{0}; i < para_dim; i++) {
+  for (std::size_t i{0}; i < para_dim; i++) {
     // sneak in x initialization here.
     // done first, so that skipping it will have no effect on update later
     x[i] = 0.;
@@ -175,7 +175,7 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
     // go through the rows and compare magnitude and mark it if needed
     maxrow = i;
     maxval = std::abs(A[i][i]);
-    for (int j{i + 1}; j < para_dim; j++) {
+    for (std::size_t j{i + 1}; j < para_dim; j++) {
       maybemax = std::abs(A[j][i]);
       if (maybemax > maxval) {
         maxval = maybemax;
@@ -194,10 +194,10 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
 
     /* forward reduction */
     const double Aii = A[i][i];
-    for (int j{i + 1}; j < para_dim; j++) {
+    for (std::size_t j{i + 1}; j < para_dim; j++) {
       const double redfac = A[j][i] / Aii;
       // matrix reduction
-      for (int k{i + 1}; k < para_dim; k++) {
+      for (std::size_t k{i + 1}; k < para_dim; k++) {
         A[j][k] -= A[i][k] * redfac;
       }
       A[j][i] = 0.;
@@ -210,13 +210,14 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
 
   // back substitution
   double sum;
-  for (int i{para_dim - 1}; i >= 0; i--) {
+  for (std::size_t i_para_dim{}; i_para_dim <para_dim; i_para_dim++) {
+    std::size_t i = para_dim -1 -i_para_dim;
     // ignore clipped entries
     if (skipmask[i] != 0)
       continue;
 
     sum = 0.;
-    for (int j{i + 1}; j < para_dim; j++) {
+    for (std::size_t j{i + 1}; j < para_dim; j++) {
       sum += A[i][j] * x[j];
     }
     x[i] = (b[i] - sum) / A[i][i];


### PR DESCRIPTION
# Minor Code Clean-up

This is to deal with issue #43 .

1. There were many warnings when building splinepy, that made the project look very unprofessional. Most of the warnings were related to comparisons between signed and unsigned types. 
2. There were a class member variables used as counters that were very unspecific, called `i` and `j`, which is problematic as it is unclear what the counters are actually referring to.

- [x] clang-format applied
- [x] unit tests for new feature (not applicable)
