### PR TITLE
Fix initial guess metric

### DIFF
--- a/cpp/splinepy/proximity/proximity.hpp
+++ b/cpp/splinepy/proximity/proximity.hpp
@@ -269,14 +269,14 @@ public:
     if (initial_guess == InitialGuess::KdTree && aggressive_bounds) {
       // you need to be sure that you have sampled your spline fine enough
       for (std::size_t i{}; i < SplineType::kParaDim; ++i) {
-          // adjust lower (0) and upper (1) bounds aggressively
-          // but of course, not so aggresive that it is out of bound.
-          search_bounds[0][i] = std::max(
-              search_bounds[0][i], current_guess[i] - grid_points_.step_size_[i]
-          );
-          search_bounds[1][i] = std::min(
-              search_bounds[1][i], current_guess[i] + grid_points_.step_size_[i]
-          );
+        // adjust lower (0) and upper (1) bounds aggressively
+        // but of course, not so aggresive that it is out of bound.
+        search_bounds[0][i] =
+            std::max(search_bounds[0][i],
+                     current_guess[i] - grid_points_.step_size_[i]);
+        search_bounds[1][i] =
+            std::min(search_bounds[1][i],
+                     current_guess[i] + grid_points_.step_size_[i]);
       }
     }
 
@@ -338,4 +338,3 @@ protected:
 };
 
 } // namespace splinepy::proximity
-

--- a/cpp/splinepy/proximity/proximity.hpp
+++ b/cpp/splinepy/proximity/proximity.hpp
@@ -308,6 +308,99 @@ public:
     return current_guess;
   }
 
+  void FirstOrderFallBack() {}
+
+  /*!
+   * Given physical coordinate, finds closest parametric coordinate.
+   * Experimental and hardcoded for 2P2D splines.
+   * Subroutine style, returns also normals, difference, normal gap.
+   *
+   * @params query_dim 
+   * @params boundary
+   * @params query
+   * @params initial_guess
+   * @params tolerance
+   */
+  void BoundaryQuery(const int& query_dim,
+                     const int& boundary,
+                     const double* query,
+                     InitialGuess initial_guess,
+                     const double& tolerance = 1e-12,
+                     double& distance,
+                     double& difference,
+                     double* normal,
+                     double& normal_gap) const {
+
+    PxPMatrixD_ lhs;
+    PArrayD_ rhs;
+    PArrayD_ delta_guess;
+    DArrayD_ difference;
+    PxDMatrixD_ spline_gradient;
+    PArrayI_ clipped{}; /* clip status after most recent update */
+    PArrayI_ previous_clipped{};
+    PArrayI_ solver_skip_mask{}; /* tell solver to skip certain entry */
+    bool solver_skip_mask_activated = false;
+
+    // search_bounds is parametric bounds.
+    const auto search_bounds = splinepy::splines::GetParametricBounds(spline_);
+
+    typename SplineType::ParametricCoordinate_ current_guess =
+        MakeInitialGuess(initial_guess, query);
+
+    // Be optimistic and check if initial guess was awesome
+    // If it is awesome, return and have feierabend
+    GuessMinusQuery(current_guess, query, difference);
+    if (splinepy::utils::NormL2(difference) < tolerance) {
+      return current_guess;
+    }
+
+    const int max_iteration = SplineType::kParaDim * 20;
+    double previous_norm{}, current_norm;
+
+    // newton iteration
+    for (int i{}; i < max_iteration; ++i) {
+      // build systems to solve
+      FillSplineGradientAndRhs(current_guess, difference, spline_gradient, rhs);
+      FillLhs(current_guess, difference, spline_gradient, lhs);
+
+      // solve and update
+      // 1. set solver skip mask if clipping happend twice at the same place.
+      if (previous_clipped == clipped && !solver_skip_mask_activated) {
+        solver_skip_mask = clipped;
+        solver_skip_mask_activated = true;
+        // if skip mask is on for all entries, return now.
+        if (splinepy::utils::NonZeros(solver_skip_mask)
+            == SplineType::kParaDim) {
+          // current_guess should be clipped at this point.
+          return current_guess;
+        }
+      }
+
+      // GaussWithPivot may swap and modify enties of all the input
+      // -> can't use lhs and rhs afterwards, and we don't need them.
+      // -> solver_skip_mask and delta_guess is reordered to rewind swaps
+      splinepy::utils::GaussWithPivot(lhs, rhs, solver_skip_mask, delta_guess);
+
+      // Update
+      splinepy::utils::AddSecondToFirst(current_guess, delta_guess);
+      // Clip
+      previous_clipped = clipped; // swap?
+      splinepy::utils::Clip(search_bounds, current_guess, clipped);
+      // Converged?
+      current_norm = splinepy::utils::NormL2(rhs);
+      GuessMinusQuery(current_guess, query, difference);
+      if (std::abs(previous_norm - current_norm) < tolerance
+          || splinepy::utils::NormL2(difference) < tolerance)
+        break;
+
+      // prepare next round
+      previous_norm = current_norm;
+    }
+
+
+    return current_guess;
+  }
+
 protected:
   SplineType const& spline_;
   // kdtree related variables


### PR DESCRIPTION
# Overview
- Minor fix regarding kdtree's distance metric. Uses L2 instead of L1.
- Adds aggresive_bounds option, that is currently not used from py-side.


## Summary
| before | after |
| -- | -- |
| <img width="708" alt="Screenshot 2022-09-01 at 14 56 42" src="https://user-images.githubusercontent.com/47114801/188388501-5f2990da-9ba2-4652-bd95-c2af83390e94.png"> | <img width="700" alt="Screenshot 2022-09-05 at 09 12 24" src="https://user-images.githubusercontent.com/47114801/188389080-9ec9384d-b8db-4671-b41a-1d9d87dd6192.png"> |



## Outlook / Notes
- this is a small progress PR of "verbose query"
- no guarantee what so ever for aggressive bounds
- for somewhat complex spline, we need a kdt of very fine samples -> local / weighted resampling that's thread-safe