### PR TITLE
Bindings for Derivatives

### DIFF
--- a/cpp/splinepy/py/py_bezier.hpp
+++ b/cpp/splinepy/py/py_bezier.hpp
@@ -100,11 +100,11 @@ public:
     // update control_points
     const std::size_t number_of_ctps = c_bezier.control_points.size();
     // Check if shape changed
-    if (static_cast<long int>(c_bezier.control_points.size())
+    if (static_cast<long int>(number_of_ctps)
         != p_control_points.request().shape[0]) {
       // Update Control Point Vector
       p_control_points = py::array_t<double>(number_of_ctps * dim);
-      p_control_points.reshape({(int) number_of_ctps, (int) dim});
+      p_control_points.resize({(int) number_of_ctps, (int) dim});
       // Update pointers
       cps_ptr = static_cast<double*>(p_control_points.request().ptr);
     }

--- a/cpp/splinepy/py/py_nurbs.hpp
+++ b/cpp/splinepy/py/py_nurbs.hpp
@@ -313,7 +313,7 @@ public:
         pc[i_para_dim] = ScalarParametricCoordinate{
             q_buf_ptr[i_query * para_dim + i_para_dim]};
       }
-      Coordinate const& c_result = c_nurbs(pc, derivative);
+      Coordinate const c_result = c_nurbs(pc, derivative);
 
       // Write `c_result` to `results`.
       int j_dim = 0;

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -25,47 +25,47 @@ class TestSplinepyEvaluation(unittest.TestCase):
 
         # reference solutions
         bspline_ref_basis_functions = np.array(
-            [[9.4128804e-01, 3.8615940e-02, 1.9602000e-04, 1.9015920e-02, 
-              7.8012000e-04, 3.9600000e-06, 9.6040000e-05, 3.9400000e-06, 
+            [[9.4128804e-01, 3.8615940e-02, 1.9602000e-04, 1.9015920e-02,
+              7.8012000e-04, 3.9600000e-06, 9.6040000e-05, 3.9400000e-06,
               2.0000000e-08],
-             [2.4010000e-01, 9.8500000e-03, 5.0000000e-05, 4.8020000e-01, 
-              1.9700000e-02, 1.0000000e-04, 2.4010000e-01, 9.8500000e-03, 
+             [2.4010000e-01, 9.8500000e-03, 5.0000000e-05, 4.8020000e-01,
+              1.9700000e-02, 1.0000000e-04, 2.4010000e-01, 9.8500000e-03,
               5.0000000e-05],
-             [1.6200000e-02, 2.7540000e-01, 5.1840000e-01, 3.6000000e-03, 
-              6.1200000e-02, 1.1520000e-01, 2.0000000e-04, 3.4000000e-03, 
+             [1.6200000e-02, 2.7540000e-01, 5.1840000e-01, 3.6000000e-03,
+              6.1200000e-02, 1.1520000e-01, 2.0000000e-04, 3.4000000e-03,
               6.4000000e-03],
-             [7.2000000e-03, 5.0400000e-02, 3.2400000e-02, 3.3600000e-02, 
-              2.3520000e-01, 1.5120000e-01, 3.9200000e-02, 2.7440000e-01, 
+             [7.2000000e-03, 5.0400000e-02, 3.2400000e-02, 3.3600000e-02,
+              2.3520000e-01, 1.5120000e-01, 3.9200000e-02, 2.7440000e-01,
               1.7640000e-01],
-             [4.0000000e-06, 6.4000000e-05, 3.2000000e-05, 7.9200000e-04, 
-              1.2672000e-02, 6.3360000e-03, 3.9204000e-02, 6.2726400e-01, 
-              3.1363200e-01]] 
+             [4.0000000e-06, 6.4000000e-05, 3.2000000e-05, 7.9200000e-04,
+              1.2672000e-02, 6.3360000e-03, 3.9204000e-02, 6.2726400e-01,
+              3.1363200e-01]]
         )
         nurbs_ref_basis_functions = np.array(
             [[9.75958864e-01, 1.39415582e-02, 9.95774782e-05, 9.85817035e-03,
                 1.40823820e-04, 1.00583311e-06],
-              [4.92908517e-01, 7.04119101e-03, 5.02916557e-05, 4.92908517e-01,
+             [4.92908517e-01, 7.04119101e-03, 5.02916557e-05, 4.92908517e-01,
                 7.04119101e-03, 5.02916557e-05],
-              [9.50089457e-03, 1.20926646e-01, 7.69572460e-01, 1.05565495e-03,
+             [9.50089457e-03, 1.20926646e-01, 7.69572460e-01, 1.05565495e-03,
                 1.34362940e-02, 8.55080511e-02],
-              [1.32410262e-02, 7.49025551e-02, 2.11856419e-01, 3.08957277e-02,
+             [1.32410262e-02, 7.49025551e-02, 2.11856419e-01, 3.08957277e-02,
                 1.74772629e-01, 4.94331644e-01],
-              [4.18891419e-03, 3.94934617e-03, 1.86173964e-03, 4.14702505e-01,
+             [4.18891419e-03, 3.94934617e-03, 1.86173964e-03, 4.14702505e-01,
                 3.90985271e-01, 1.84312224e-01]]
         )
 
         # test basis functions
         self.assertTrue(np.allclose(
-            self.bspline.basis_functions(c.q2D)[0], 
+            self.bspline.basis_functions(c.q2D)[0],
             bspline_ref_basis_functions
-            )
+        )
         )
         self.assertTrue(np.allclose(
-            self.nurbs.basis_functions(c.q2D)[0], 
+            self.nurbs.basis_functions(c.q2D)[0],
             nurbs_ref_basis_functions
-            )
         )
-    
+        )
+
     def test_partition_of_unity(self):
         """ Test the partition of unity of the calculated basis functions. """
 
@@ -73,21 +73,21 @@ class TestSplinepyEvaluation(unittest.TestCase):
             return basis_functions.sum(axis=1)
 
         # use random query points
-        q2D = np.random.rand(10,2)
+        q2D = np.random.rand(10, 2)
 
         u_bspline = basis_functions_sum(self.bspline.basis_functions(q2D)[0])
         self.assertTrue(np.allclose(
-            u_bspline, 
+            u_bspline,
             np.ones(np.shape(u_bspline))
-            )
+        )
         )
         u_nurbs = basis_functions_sum(self.nurbs.basis_functions(q2D)[0])
         self.assertTrue(np.allclose(
-            u_nurbs, 
+            u_nurbs,
             np.ones(np.shape(u_nurbs))
-            )
         )
-    
+        )
+
     def test_evaluate(self):
         """ Test the correct spline evaluation in the physical space.
         (.evaluate()) """
@@ -95,53 +95,53 @@ class TestSplinepyEvaluation(unittest.TestCase):
         # reference solutions
         bspline_ref_evaluate = np.array(
             [[-0.019796,    0.04049403],
-             [-0.9996,      0.069675  ],
-             [ 2.256,       1.9691    ],
-             [ 1.528,       4.0766    ],
-             [-1.0264,      2.873488  ]]
+             [-0.9996,      0.069675],
+             [2.256,       1.9691],
+             [1.528,       4.0766],
+             [-1.0264,      2.873488]]
         )
         nurbs_ref_evaluate = np.array(
             [[-1.00989841,  0.01432479],
              [-1.49984913,  0.02127445],
-             [-0.15941144,  1.0883878 ],
+             [-0.15941144,  1.0883878],
              [-0.49948029,  1.62496752],
-             [-1.61951381,  1.15640608]] 
+             [-1.61951381,  1.15640608]]
         )
         bezier_ref_evaluate = np.array(
             [[-1.009899,  0.020099],
-             [-1.49985,   0.02985 ],
-             [-0.209,     1.089   ],
-             [-0.612,     1.632   ],
-             [-1.6716,    1.2736  ]] 
+             [-1.49985,   0.02985],
+             [-0.209,     1.089],
+             [-0.612,     1.632],
+             [-1.6716,    1.2736]]
         )
         rational_ref_evaluate = np.array(
             [[-1.00989841,  0.01432479],
              [-1.49984913,  0.02127445],
-             [-0.15941144,  1.0883878 ],
+             [-0.15941144,  1.0883878],
              [-0.49948029,  1.62496752],
              [-1.61951381,  1.15640608]]
         )
 
         # test evaluation
         self.assertTrue(np.allclose(
-            self.bspline.evaluate(c.q2D), 
+            self.bspline.evaluate(c.q2D),
             bspline_ref_evaluate
-            )
+        )
         )
         self.assertTrue(np.allclose(
-            self.nurbs.evaluate(c.q2D), 
+            self.nurbs.evaluate(c.q2D),
             nurbs_ref_evaluate
-            )
+        )
         )
         self.assertTrue(np.allclose(
-            self.bezier.evaluate(c.q2D), 
+            self.bezier.evaluate(c.q2D),
             bezier_ref_evaluate
-            )
+        )
         )
         self.assertTrue(np.allclose(
-            self.rational.evaluate(c.q2D), 
+            self.rational.evaluate(c.q2D),
             rational_ref_evaluate
-            )
+        )
         )
 
     def test_derivative(self):
@@ -151,33 +151,75 @@ class TestSplinepyEvaluation(unittest.TestCase):
         # reference solutions
         bspline_ref_derivative = np.array(
             [[0.0408,   4.019206],
-             [0.08,     6.935   ],
-             [6.88,     0.318   ],
-             [6.72,     1.884   ],
-             [4.768,    6.36784 ]] 
+             [0.08,     6.935],
+             [6.88,     0.318],
+             [6.72,     1.884],
+             [4.768,    6.36784]]
         )
         nurbs_ref_derivative = np.array(
             [[0.02037649, 1.43654295],
              [0.03026211, 2.13347963],
              [1.62487759, 0.23798877],
              [2.5357129,  0.77942396],
-             [1.90293663, 2.66500861]] 
+             [1.90293663, 2.66500861]]
         )
 
         # order
-        o1 = [[1,1]]
+        o1 = [[1, 1]]
 
         # test derivative evaluation
         self.assertTrue(np.allclose(
-            self.bspline.derivative(c.q2D,o1), 
+            self.bspline.derivative(c.q2D, o1),
             bspline_ref_derivative
-            )
+        )
         )
         self.assertTrue(np.allclose(
-            self.nurbs.derivative(c.q2D,o1), 
+            self.nurbs.derivative(c.q2D, o1),
             nurbs_ref_derivative
-            )
         )
+        )
+
+        # Test higher order derivatives against each other
+        max_deg = 5
+        dim = 3
+        n_test_points = 10
+        derivatives = np.random.randint(0, max_deg, size=(dim))
+        queries = np.random.random((n_test_points, dim))
+        randomized = {
+            "degrees": [5] * dim,
+            "control_points": np.random.random(((max_deg+1)**dim, dim)),
+            "weights": np.random.random(((max_deg+1)**dim)),
+            "knot_vectors": [[0]*(max_deg+1) + [1]*(max_deg+1)] * dim
+        }
+        random_bezier = splinepy.Bezier(
+            degrees=randomized["degrees"],
+            control_points=randomized["control_points"]
+        )
+        random_rational = splinepy.RationalBezier(
+            degrees=randomized["degrees"],
+            control_points=randomized["control_points"],
+            weights=randomized["weights"]
+        )
+        random_bspline = splinepy.BSpline(
+            degrees=randomized["degrees"],
+            control_points=randomized["control_points"],
+            knot_vectors=randomized["knot_vectors"]
+        )
+        random_nurbs = splinepy.NURBS(
+            degrees=randomized["degrees"],
+            control_points=randomized["control_points"],
+            knot_vectors=randomized["knot_vectors"],
+            weights=randomized["weights"]
+        )
+        self.assertTrue(np.allclose(
+            random_bezier.derivative(queries, derivatives),
+            random_bspline.derivative(queries, derivatives)
+        ))
+        self.assertTrue(np.allclose(
+            random_rational.derivative(queries, derivatives),
+            random_nurbs.derivative(queries, derivatives)
+        ))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Addressed issues
*  Related to #32 and #33

# Description
Up to this point, derivatives of Bézier splines resulted in new splines, which were a parametric representation of the derivative. In the SplineLib, however, the derivatives are evaluated at specific points with indexed derivates. This functionality has now also been transfered to `bezman` and ultimately added to `splinepy`.

## Example
```
deg, dim = 3, 3
derivative = np.random.randint(deg,size=(3))
a = gus.Bezier(degrees=[deg] * 3, control_points=np.random.rand(5**dim,dim))
derivatives = a.derivative(np.random.rand(400,dim), derivative)
```
which calculates the derivative of a random spline.


# Check list
### Test documentation
* [x]  Build `--minimal`
* [x]  Build 
* [x]  Executed Tests
* [x] Added tests
* [x]  Executed Examples

### Documentation of changes and theory
* [x]  I have updated the relevant documentations, as far as necessary.

### Style guide compliance
* [x]  Edited `C++` files formatted with clang-format (`14.x.x`+)
* [x]  Edited Python files formatted to style guide from PEP8

