### PR TITLE
add splinepybase for python

### DIFF
--- a/splinepy/_base.py
+++ b/splinepy/_base.py
@@ -1,0 +1,17 @@
+"""splinepy/splinepy/_base.py
+
+Base type of splinepy
+"""
+from splinepy.utils import log
+
+class SplinepyBase:
+    __slots__ = ()
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Add logger shortcut.
+        """
+        cls._logi = log.prepend_log(cls.__qualname__, log.info)
+        cls._logd = log.prepend_log(cls.__qualname__, log.debug)
+        cls._logw = log.prepend_log(cls.__qualname__, log.warning)
+        return super().__new__(cls, *args, **kwargs)

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -12,6 +12,7 @@ from splinepy import utils
 from splinepy import io
 from splinepy import settings
 from splinepy import splinepy_core as core
+from splinepy._base import SplinepyBase
 
 
 class RequiredProperties:
@@ -411,21 +412,12 @@ def _new_core_if_modified(func):
     return inner
 
 
-class Spline(core.CoreSpline):
+class Spline(SplinepyBase, core.CoreSpline):
     """
     Spline base class. Extends CoreSpline with documentation.
     """
 
     __slots__ = ()
-
-    def __new__(cls, *args, **kwargs):
-        """
-        Add logger shortcut during creation
-        """
-        cls._logi = utils.log.prepend_log(cls.__qualname__, utils.log.info)
-        cls._logd = utils.log.prepend_log(cls.__qualname__, utils.log.debug)
-        cls._logw = utils.log.prepend_log(cls.__qualname__, utils.log.warning)
-        return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, spline=None, **kwargs):
         """


### PR DESCRIPTION
# Overview
Add base type for splinepy. Enables easy and uniform logging for all inherited classes.

## Showcase 
A short / one-liner example to highlight the (new) feature
```python
# multipatch.py

class Multipatch(SplinepyBase):
    ...
    def some_func(self):
        self._logi("this func is for demo")
        self._logd("some_func is called and log is tested")
        self._logw("this func doesn't do much")
```
