### PR TITLE
Avoid wrong overwrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(SPLINEPY_WARNING_FLAGS
         -Wall -Wextra -Wmost -Wextra -Wpedantic -Wunreachable-code
         -Wshadow -Wfloat-equal -Weffc++ -Wno-unused-parameter
-        -Wno-unused-variable)
+        -Wno-unused-variable -Wzero-as-null-pointer-constant)
 else()
   message(WARNING
             "Unsupported compiler."

--- a/cpp/splinepy/splines/splinepy_base.cpp
+++ b/cpp/splinepy/splines/splinepy_base.cpp
@@ -579,7 +579,7 @@ SplinepyBase::SplinepyExtractBoundary(const int& para_dim, const int& extrema) {
 }
 
 std::shared_ptr<SplinepyBase>
-SplinepyBase::SplinepyExtractDim(const int& phys_dim) {
+SplinepyBase::SplinepyExtractDim(const int& phys_dim) const {
   splinepy::utils::PrintAndThrowError(
       "SplinepyExtractDim is not implemented for",
       SplinepyWhatAmI());

--- a/cpp/splinepy/splines/splinepy_base.hpp
+++ b/cpp/splinepy/splines/splinepy_base.hpp
@@ -186,7 +186,7 @@ public:
   SplinepyExtractBoundary(const int& para_dim, const int& extrema);
 
   /// Scalar Spline extraction from dim - TODO: const
-  virtual std::shared_ptr<SplinepyBase> SplinepyExtractDim(const int& phys_dim);
+  virtual std::shared_ptr<SplinepyBase> SplinepyExtractDim(const int& phys_dim) const;
 
   /// Derivative of composition
   virtual std::shared_ptr<SplinepyBase> SplinepyCompositionDerivative(


### PR DESCRIPTION
# Overview
- Adds a warning flag to clang
- Add missing const, so that it matches derived class' implementation

## Addressed issues
* `SplinepyBase::ExtractDim` couldn't find matching implementation
