### PR TITLE
Ft orientation gismo

### DIFF
--- a/cpp/splinepy/py/init/exporter.cpp
+++ b/cpp/splinepy/py/init/exporter.cpp
@@ -22,7 +22,7 @@ void init_exporter(py::module_& m) {
         py::arg("neighbor_ids"),
         py::arg("neighbor_face_ids"),
         py::arg("tolerance"),
-        py::arg("nthreads")=1);
+        py::arg("nthreads") = 1);
   m.def("export_iges",
         &splinepy::py::ExportIges,
         py::arg("fname"),

--- a/cpp/splinepy/py/init/exporter.cpp
+++ b/cpp/splinepy/py/init/exporter.cpp
@@ -14,13 +14,15 @@ void init_exporter(py::module_& m) {
         py::arg("face_center_vertices"),
         py::arg("tolerance"),
         py::arg("para_dim"));
-  m.def("get_orientation",
-        &splinepy::py::GetBoundaryOrientation,
-        py::arg("start_spline"),
-        py::arg("start_boundary_id"),
-        py::arg("end_spline"),
-        py::arg("end_boundary_id"),
-        py::arg("tolerance"));
+  m.def("orientations",
+        &splinepy::py::GetBoundaryOrientations,
+        py::arg("spline_list"),
+        py::arg("base_ids"),
+        py::arg("base_face_ids"),
+        py::arg("neighbor_ids"),
+        py::arg("neighbor_face_ids"),
+        py::arg("tolerance"),
+        py::arg("n_threads"));
   m.def("export_iges",
         &splinepy::py::ExportIges,
         py::arg("fname"),

--- a/cpp/splinepy/py/init/exporter.cpp
+++ b/cpp/splinepy/py/init/exporter.cpp
@@ -16,13 +16,13 @@ void init_exporter(py::module_& m) {
         py::arg("para_dim"));
   m.def("orientations",
         &splinepy::py::GetBoundaryOrientations,
-        py::arg("spline_list"),
+        py::arg("splines"),
         py::arg("base_ids"),
         py::arg("base_face_ids"),
         py::arg("neighbor_ids"),
         py::arg("neighbor_face_ids"),
         py::arg("tolerance"),
-        py::arg("n_threads"));
+        py::arg("nthreads"));
   m.def("export_iges",
         &splinepy::py::ExportIges,
         py::arg("fname"),

--- a/cpp/splinepy/py/init/exporter.cpp
+++ b/cpp/splinepy/py/init/exporter.cpp
@@ -14,6 +14,13 @@ void init_exporter(py::module_& m) {
         py::arg("face_center_vertices"),
         py::arg("tolerance"),
         py::arg("para_dim"));
+  m.def("get_orientation",
+        &splinepy::py::GetBoundaryOrientation,
+        py::arg("start_spline"),
+        py::arg("start_boundary_id"),
+        py::arg("end_spline"),
+        py::arg("end_boundary_id"),
+        py::arg("tolerance"));
   m.def("export_iges",
         &splinepy::py::ExportIges,
         py::arg("fname"),

--- a/cpp/splinepy/py/init/exporter.cpp
+++ b/cpp/splinepy/py/init/exporter.cpp
@@ -22,7 +22,7 @@ void init_exporter(py::module_& m) {
         py::arg("neighbor_ids"),
         py::arg("neighbor_face_ids"),
         py::arg("tolerance"),
-        py::arg("nthreads"));
+        py::arg("nthreads")=1);
   m.def("export_iges",
         &splinepy::py::ExportIges,
         py::arg("fname"),

--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -373,42 +373,6 @@ public:
     return cmr;
   }
 
-  /// @brief Evaluate Splines at boundary face centers
-  /// @return numpy array with results
-  py::array_t<double> EvaluateBoundaryCenters() const {
-    // prepare output
-    const int n_faces = 2 * para_dim_;
-    std::vector<double> queries(n_faces * para_dim_);
-    py::array_t<double> face_centers(n_faces * dim_);
-    double* face_centers_ptr = static_cast<double*>(face_centers.request().ptr);
-
-    // Get parametric bounds
-    // They are given back in the order [min_0, min_1,...,max_0, max_1...]
-    std::vector<double> bounds(para_dim_ * 2);
-    Core()->SplinepyParametricBounds(bounds.data());
-
-    // Set parametric coordinates
-    for (int i{}; i < para_dim_; i++) {
-      for (int j{}; j < para_dim_; j++) {
-        if (i == j) {
-          queries[2 * i * para_dim_ + j] = bounds[j];
-          queries[(2 * i + 1) * para_dim_ + j] = bounds[j + para_dim_];
-        } else {
-          queries[2 * i * para_dim_ + j] =
-              .5 * (bounds[j] + bounds[j + para_dim_]);
-          queries[(2 * i + 1) * para_dim_ + j] = queries[2 * i * para_dim_ + j];
-        }
-      }
-    }
-    for (int i{}; i < n_faces; ++i) {
-      Core()->SplinepyEvaluate(&queries.data()[i * para_dim_],
-                               &face_centers_ptr[i * dim_]);
-    }
-
-    face_centers.resize({n_faces, dim_});
-    return face_centers;
-  }
-
   py::array_t<double> Evaluate(py::array_t<double> queries,
                                int nthreads) const {
     CheckPyArrayShape(queries, {-1, para_dim_}, true);
@@ -963,6 +927,44 @@ inline PySpline SameSplineWithKnotVectors(PySpline& spline) {
   return PySpline(props);
 }
 
+/// @brief Evaluate Splines at boundary face centers
+/// @return numpy array with results
+inline py::array_t<double> EvaluateBoundaryCenters(PySpline& spline) {
+  // prepare output
+  const int& para_dim_ = spline.para_dim_;
+  const int& dim_ = spline.dim_;
+  const int n_faces = 2 * para_dim_;
+  std::vector<double> queries(n_faces * para_dim_);
+  py::array_t<double> face_centers(n_faces * dim_);
+  double* face_centers_ptr = static_cast<double*>(face_centers.request().ptr);
+
+  // Get parametric bounds
+  // They are given back in the order [min_0, min_1,...,max_0, max_1...]
+  std::vector<double> bounds(para_dim_ * 2);
+  spline.Core()->SplinepyParametricBounds(bounds.data());
+
+  // Set parametric coordinates
+  for (int i{}; i < para_dim_; i++) {
+    for (int j{}; j < para_dim_; j++) {
+      if (i == j) {
+        queries[2 * i * para_dim_ + j] = bounds[j];
+        queries[(2 * i + 1) * para_dim_ + j] = bounds[j + para_dim_];
+      } else {
+        queries[2 * i * para_dim_ + j] =
+            .5 * (bounds[j] + bounds[j + para_dim_]);
+        queries[(2 * i + 1) * para_dim_ + j] = queries[2 * i * para_dim_ + j];
+      }
+    }
+  }
+  for (int i{}; i < n_faces; ++i) {
+    spline.Core()->SplinepyEvaluate(&queries.data()[i * para_dim_],
+                                    &face_centers_ptr[i * dim_]);
+  }
+
+  face_centers.resize({n_faces, dim_});
+  return face_centers;
+}
+
 /// returns core spline's ptr address
 inline intptr_t CoreId(const PySpline& spline) {
   return reinterpret_cast<intptr_t>(spline.Core().get());
@@ -1020,8 +1022,6 @@ inline void add_spline_pyclass(py::module& m, const char* class_name) {
                              &splinepy::py::PySpline::ParametricBounds)
       .def_property_readonly("control_mesh_resolutions",
                              &splinepy::py::PySpline::ControlMeshResolutions)
-      .def_property_readonly("boundary_centers",
-                             &splinepy::py::PySpline::EvaluateBoundaryCenters)
       .def("current_core_properties",
            &splinepy::py::PySpline::CurrentCoreProperties)
       .def("evaluate",
@@ -1122,6 +1122,9 @@ inline void add_spline_pyclass(py::module& m, const char* class_name) {
         py::arg("inner_derivative"));
   m.def("same_spline_with_knot_vectors",
         &splinepy::py::SameSplineWithKnotVectors,
+        py::arg("spline"));
+  m.def("boundary_centers",
+        &splinepy::py::EvaluateBoundaryCenters,
         py::arg("spline"));
   m.def("core_id", &splinepy::py::CoreId, py::arg("spline"));
   m.def("core_ref_count", &splinepy::py::CoreRefCount, py::arg("spline"));

--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -489,16 +489,12 @@ public:
 
     // prepare lambda for nthread exe
     double* queries_ptr = static_cast<double*>(queries.request().ptr);
+    const int stride = para_dim_ * dim_;
     auto derive = [&](int begin, int end) {
       for (int i{begin}; i < end; ++i) {
-        for (int j{0}; j < para_dim_; j++) {
-          std::vector<int> orders(para_dim_); // zero init
-          orders[j] = 1;
-          Core()->SplinepyDerivative(
-              &queries_ptr[i * para_dim_],
-              orders.data(),
-              &jacobians_ptr[i * para_dim_ * dim_ + j * dim_]);
-        }
+        Core()->SplinepyJacobian(&queries_ptr[i * para_dim_],
+                                 orders.data(),
+                                 &jacobians_ptr[i * stride]);
       }
     };
 

--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -493,7 +493,6 @@ public:
     auto derive = [&](int begin, int end) {
       for (int i{begin}; i < end; ++i) {
         Core()->SplinepyJacobian(&queries_ptr[i * para_dim_],
-                                 orders.data(),
                                  &jacobians_ptr[i * stride]);
       }
     };

--- a/cpp/splinepy/py/py_spline_exporter.hpp
+++ b/cpp/splinepy/py/py_spline_exporter.hpp
@@ -733,19 +733,21 @@ InterfacesFromBoundaryCenters(const py::array_t<double>& py_center_vertices,
  * @param bool_orientations_ptr (output) axis alignement
  * @return void
  */
-void GetBoundaryOrientation(const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
-                            const int& boundary_start,
-                            const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
-                            const int& boundary_end,
-                            const double& tolerance,
-                            int* int_mappings_ptr,
-                            bool* bool_orientations_ptr) {
+void GetBoundaryOrientation(
+    const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
+    const int& boundary_start,
+    const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
+    const int& boundary_end,
+    const double& tolerance,
+    int* int_mappings_ptr,
+    bool* bool_orientations_ptr) {
   // Init return values and get auxiliary data
-  const int& para_dim_ = pyspline_start.para_dim_;
-  const int& dim_ = pyspline_end.dim_;
+  const int& para_dim_ = pyspline_start->SplinepyParaDim();
+  const int& dim_ = pyspline_start->SplinepyDim();
 
   // Checks
-  if ((para_dim_ != pyspline_end.para_dim_) || (dim_ != pyspline_end.dim_)) {
+  if ((para_dim_ != pyspline_end->SplinepyParaDim())
+      || (dim_ != pyspline_end->SplinepyDim())) {
     splinepy::utils::PrintAndThrowError(
         "Spline Orientation can not be checked, as they have mismatching"
         "dimensionality start spline has dimensions ",
@@ -753,9 +755,9 @@ void GetBoundaryOrientation(const std::shared_ptr<splinepy::splines::SplinepyBas
         "D -> ",
         dim_,
         "D, the adjacent one has dimensions ",
-        pyspline_end.para_dim_,
+        pyspline_end->SplinepyParaDim(),
         "D -> ",
-        pyspline_end.dim_,
+        pyspline_end->SplinepyDim(),
         "D.");
   }
 

--- a/cpp/splinepy/py/py_spline_exporter.hpp
+++ b/cpp/splinepy/py/py_spline_exporter.hpp
@@ -733,9 +733,9 @@ InterfacesFromBoundaryCenters(const py::array_t<double>& py_center_vertices,
  * @param bool_orientations_ptr (output) axis alignement
  * @return void
  */
-void GetBoundaryOrientation(const PySpline& pyspline_start,
+void GetBoundaryOrientation(const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
                             const int& boundary_start,
-                            const PySpline& pyspline_end,
+                            const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
                             const int& boundary_end,
                             const double& tolerance,
                             int* int_mappings_ptr,
@@ -771,9 +771,9 @@ void GetBoundaryOrientation(const PySpline& pyspline_start,
   /// Compare jacobians for remaining entries
   // Determine face center position in parametric space
   std::vector<double> bounds_start(para_dim_ * 2);
-  pyspline_start.Core()->SplinepyParametricBounds(bounds_start.data());
+  pyspline_start->SplinepyParametricBounds(bounds_start.data());
   std::vector<double> bounds_end(para_dim_ * 2);
-  pyspline_end.Core()->SplinepyParametricBounds(bounds_end.data());
+  pyspline_end->SplinepyParametricBounds(bounds_end.data());
   py::array_t<double> boundary_center_start(para_dim_),
       boundary_center_end(para_dim_);
   double* bcs_start_ptr =

--- a/cpp/splinepy/py/py_spline_exporter.hpp
+++ b/cpp/splinepy/py/py_spline_exporter.hpp
@@ -880,7 +880,7 @@ py::tuple GetBoundaryOrientations(const py::list& spline_list,
       static_cast<bool*>(bool_orientations.request().ptr);
 
   // Provide lambda for multithread execution
-  auto get_orientation = [&](const int& start, const int& end) {
+  auto get_orientation = [&](const int start, const int end) {
     for (int i{start}; i < end; ++i) {
       GetBoundaryOrientation(cpp_spline_list[base_id_ptr[i]],
                              base_face_id_ptr[i],

--- a/cpp/splinepy/splines/bezier.hpp
+++ b/cpp/splinepy/splines/bezier.hpp
@@ -178,6 +178,13 @@ public:
                                                      derived);
   }
 
+  virtual void SplinepyJacobian(const double* para_coord,
+                                double* jacobians) const {
+    splinepy::splines::helpers::ScalarTypeJacobian(*this,
+                                                   para_coord,
+                                                   jacobians);
+  }
+
   virtual void SplinepyPlantNewKdTreeForProximity(const int* resolutions,
                                                   const int& nthreads) {
     splinepy::splines::helpers::ScalarTypePlantNewKdTreeForProximity(

--- a/cpp/splinepy/splines/bspline.hpp
+++ b/cpp/splinepy/splines/bspline.hpp
@@ -251,6 +251,13 @@ public:
                                                      derived);
   }
 
+  virtual void SplinepyJacobian(const double* para_coord,
+                                double* jacobians) const {
+    splinepy::splines::helpers::ScalarTypeJacobian(*this,
+                                                   para_coord,
+                                                   jacobians);
+  }
+
   virtual void SplinepyBasis(const double* para_coord, double* basis) const {
     splinepy::splines::helpers::BSplineBasis(*this, para_coord, basis);
   }

--- a/cpp/splinepy/splines/helpers/scalar_type_wrapper.hpp
+++ b/cpp/splinepy/splines/helpers/scalar_type_wrapper.hpp
@@ -74,14 +74,14 @@ void ScalarTypeJacobian(const SplineType& spline,
                         OutputType* output) {
 
   std::array<int, SplineType::kParaDim> orders{};
-  for (int i{} : i < SplineType::kParaDim; ++i) {
+  for (int i{}; i < SplineType::kParaDim; ++i) {
     orders[i] = 1;
     // call scalar derivative helper
     ScalarTypeDerivative(spline,
                          query,
                          orders.data(),
                          &output[i * SplineType::kDim]);
-    orders.fill(0);
+    orders[i] = 0;
   }
 }
 

--- a/cpp/splinepy/splines/helpers/scalar_type_wrapper.hpp
+++ b/cpp/splinepy/splines/helpers/scalar_type_wrapper.hpp
@@ -66,6 +66,25 @@ void ScalarTypeDerivative(const SplineType& spline,
   }
 }
 
+/// Spline Jacobian
+/// output should have the size of dim * para_dim
+template<typename SplineType, typename QueryType, typename OutputType>
+void ScalarTypeJacobian(const SplineType& spline,
+                        const QueryType* query,
+                        OutputType* output) {
+
+  std::array<int, SplineType::kParaDim> orders{};
+  for (int i{} : i < SplineType::kParaDim; ++i) {
+    orders[i] = 1;
+    // call scalar derivative helper
+    ScalarTypeDerivative(spline,
+                         query,
+                         orders.data(),
+                         &output[i * SplineType::kDim]);
+    orders.fill(0);
+  }
+}
+
 template<typename SplineType, typename ResolutionType, typename NThreadsType>
 void ScalarTypePlantNewKdTreeForProximity(SplineType& spline,
                                           const ResolutionType* resolutions,

--- a/cpp/splinepy/splines/nurbs.hpp
+++ b/cpp/splinepy/splines/nurbs.hpp
@@ -259,6 +259,13 @@ public:
                                                      derived);
   }
 
+  virtual void SplinepyJacobian(const double* para_coord,
+                                double* jacobians) const {
+    splinepy::splines::helpers::ScalarTypeJacobian(*this,
+                                                   para_coord,
+                                                   jacobians);
+  }
+
   virtual void SplinepyBasis(const double* para_coord, double* basis) const {
     splinepy::splines::helpers::BSplineBasis(*this, para_coord, basis);
   }

--- a/cpp/splinepy/splines/rational_bezier.hpp
+++ b/cpp/splinepy/splines/rational_bezier.hpp
@@ -192,6 +192,13 @@ public:
                                                      derived);
   }
 
+  virtual void SplinepyJacobian(const double* para_coord,
+                                double* jacobians) const {
+    splinepy::splines::helpers::ScalarTypeJacobian(*this,
+                                                   para_coord,
+                                                   jacobians);
+  }
+
   virtual void SplinepyElevateDegree(const int& p_dim) {
     splinepy::splines::helpers::ScalarTypeElevateDegree(*this, p_dim);
   }

--- a/cpp/splinepy/splines/splinepy_base.cpp
+++ b/cpp/splinepy/splines/splinepy_base.cpp
@@ -441,7 +441,7 @@ void SplinepyBase::SplinepyDerivative(const double* para_coord,
 
 void SplinepyBase::SplinepyJacobian(const double* para_coord,
                                     double* jacobians) const {
-  splinepy::utils::PrintAndThrowError("SplinepyEvaluate not implemented for",
+  splinepy::utils::PrintAndThrowError("SplinepyJacobian not implemented for",
                                       SplinepyWhatAmI());
 };
 

--- a/cpp/splinepy/splines/splinepy_base.cpp
+++ b/cpp/splinepy/splines/splinepy_base.cpp
@@ -439,6 +439,12 @@ void SplinepyBase::SplinepyDerivative(const double* para_coord,
                                       SplinepyWhatAmI());
 };
 
+void SplinepyBase::SplinepyJacobian(const double* para_coord,
+                                    double* jacobians) const {
+  splinepy::utils::PrintAndThrowError("SplinepyEvaluate not implemented for",
+                                      SplinepyWhatAmI());
+};
+
 void SplinepyBase::SplinepyBasis(const double* para_coord,
                                  double* basis) const {
   splinepy::utils::PrintAndThrowError("SplinepyBasis not implemented for",

--- a/cpp/splinepy/splines/splinepy_base.hpp
+++ b/cpp/splinepy/splines/splinepy_base.hpp
@@ -104,6 +104,10 @@ public:
                                   const int* orders,
                                   double* derived) const;
 
+  /// Spline evaluation
+  virtual void SplinepyJacobian(const double* para_coord,
+                                double* jacobian) const;
+
   /// Basis Function values
   virtual void SplinepyBasis(const double* para_coord, double* basis) const;
 

--- a/examples/basis_and_support.py
+++ b/examples/basis_and_support.py
@@ -51,3 +51,9 @@ if __name__ == "__main__":
 
     print("NURBS basis functions and support ids:")
     print(n.basis_and_support(q))
+
+    print("These can also be stored within a matrix using numpy functions")
+    basis_function_matrix = np.zeros((len(q), b.control_points.shape[0]))
+    bf, supports = b.basis_and_support(q)
+    np.put_along_axis(basis_function_matrix, supports, bf, axis=1)
+    print(basis_function_matrix)

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -25,9 +25,9 @@ def export(fname, multipatch=None, indent=True):
     None
     """
     from splinepy import NURBS, BSpline, Multipatch
+    from splinepy.settings import TOLERANCE
     from splinepy.spline import Spline
     from splinepy.splinepy_core import get_orientation
-    from splinepy.settings import TOLERANCE
 
     # First transform spline-data into a multipatch-data if required
     if issubclass(type(multipatch), Spline):
@@ -105,37 +105,41 @@ def export(fname, multipatch=None, indent=True):
 
         # Identify Orientation
         axis_mapping = np.empty(
-                (start_order.size, multipatch.para_dim), dtype=np.int32
+            (start_order.size, multipatch.para_dim), dtype=np.int32
         )
         axis_orientation = np.empty(
-                (start_order.size, multipatch.para_dim), dtype=bool
+            (start_order.size, multipatch.para_dim), dtype=bool
         )
         for i, (id_start, start_face, id_end, end_face) in enumerate(
-                zip(
-                        con_spline_id_start.flatten(),
-                        con_face_id_start.flatten(),
-                        con_spline_id_end.flatten(), con_face_id_end.flatten()
-                )
+            zip(
+                con_spline_id_start.flatten(),
+                con_face_id_start.flatten(),
+                con_spline_id_end.flatten(),
+                con_face_id_end.flatten(),
+            )
         ):
             axis_mapping[i, :], axis_orientation[i, :] = get_orientation(
-                    multipatch.splines[id_start], start_face,
-                    multipatch.splines[id_end], end_face, TOLERANCE
+                multipatch.splines[id_start],
+                start_face,
+                multipatch.splines[id_end],
+                end_face,
+                TOLERANCE,
             )
 
         # write to file
         # Reminder: Face enumeration starts at 1 in gismo (i.e. requires an
         # offset of 1)
         interface_array = np.hstack(
-                (
-                        con_spline_id_start + index_offset,
-                        con_face_id_start + 1,
-                        con_spline_id_end + index_offset,
-                        con_face_id_end + 1,
-                        # This is the orientation:
-                        axis_mapping,
-                        # Convert bool into -1 and 1 for gismo
-                        axis_orientation.astype(np.int32) * 2 - 1
-                )
+            (
+                con_spline_id_start + index_offset,
+                con_face_id_start + 1,
+                con_spline_id_end + index_offset,
+                con_face_id_end + 1,
+                # This is the orientation:
+                axis_mapping,
+                # Convert bool into -1 and 1 for gismo
+                axis_orientation.astype(np.int32) * 2 - 1,
+            )
         )
         interface_data.text = "\n".join(
             [" ".join([str(xx) for xx in x]) for x in interface_array]

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -112,10 +112,10 @@ def export(fname, multipatch=None, indent=True):
         )
         for i, (id_start, start_face, id_end, end_face) in enumerate(
             zip(
-                con_spline_id_start.flatten(),
-                con_face_id_start.flatten(),
-                con_spline_id_end.flatten(),
-                con_face_id_end.flatten(),
+                con_spline_id_start.ravel(),
+                con_face_id_start.ravel(),
+                con_spline_id_end.ravel(),
+                con_face_id_end.ravel(),
             )
         ):
             axis_mapping[i, :], axis_orientation[i, :] = get_orientation(

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -25,9 +25,9 @@ def export(fname, multipatch=None, indent=True):
     None
     """
     from splinepy import NURBS, BSpline, Multipatch
-    from splinepy.settings import TOLERANCE
+    from splinepy.settings import NTHREADS, TOLERANCE
     from splinepy.spline import Spline
-    from splinepy.splinepy_core import get_orientation
+    from splinepy.splinepy_core import orientations
 
     # First transform spline-data into a multipatch-data if required
     if issubclass(type(multipatch), Spline):
@@ -104,27 +104,15 @@ def export(fname, multipatch=None, indent=True):
         con_face_id_end = con_face_id_end[end_order]
 
         # Identify Orientation
-        axis_mapping = np.empty(
-            (start_order.size, multipatch.para_dim), dtype=np.int32
+        (axis_mapping, axis_orientation,) = orientations(
+            multipatch.splines,
+            con_spline_id_start,
+            con_face_id_start,
+            con_spline_id_end,
+            con_face_id_end,
+            TOLERANCE,
+            NTHREADS,
         )
-        axis_orientation = np.empty(
-            (start_order.size, multipatch.para_dim), dtype=bool
-        )
-        for i, (id_start, start_face, id_end, end_face) in enumerate(
-            zip(
-                con_spline_id_start.ravel(),
-                con_face_id_start.ravel(),
-                con_spline_id_end.ravel(),
-                con_face_id_end.ravel(),
-            )
-        ):
-            axis_mapping[i, :], axis_orientation[i, :] = get_orientation(
-                multipatch.splines[id_start],
-                start_face,
-                multipatch.splines[id_end],
-                end_face,
-                TOLERANCE,
-            )
 
         # write to file
         # Reminder: Face enumeration starts at 1 in gismo (i.e. requires an

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -239,6 +239,7 @@ class Multipatch(SplinepyBase):
         talk to at @j042
         """
         from splinepy.splinepy_core import boundary_centers
+
         # If spline list is empty will throw excetion
         return np.vstack([boundary_centers(s) for s in self.splines])
 

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -238,8 +238,9 @@ class Multipatch(SplinepyBase):
 
         talk to at @j042
         """
+        from splinepy.splinepy_core import boundary_centers
         # If spline list is empty will throw excetion
-        return np.vstack([s.boundary_centers for s in self.splines])
+        return np.vstack([boundary_centers(s) for s in self.splines])
 
     def determine_interfaces(self):
         """

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1026,6 +1026,29 @@ class Spline(SplinepyBase, core.CoreSpline):
         )
 
     @_new_core_if_modified
+    def jacobian(self, queries, nthreads=None):
+        """
+        Evaluates jacobians on spline.
+
+        Parameters
+        -----------
+        queries: (n, para_dim) array-like
+        n_threads: int
+
+        Returns
+        --------
+        results: (n, para_dim, dim) np.ndarray
+        """
+        self._logd("Determining spline jacobians")
+
+        queries = utils.data.enforce_contiguous(queries, dtype="float64")
+
+        return super().jacobian(
+            queries,
+            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+        )
+
+    @_new_core_if_modified
     def basis_and_support(self, queries, nthreads=None):
         """
         Returns basis function values and their support ids of given queries.

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -35,34 +35,53 @@ class orientationTest(c.unittest.TestCase):
             degrees=[1, 1], control_points=[[2, 1], [1, 1], [2, 0], [1, 0]]
         )
 
-        # Right Arm
+        # Provide connectivity data
+        spline_list = [a_s, b_s, c_s, d_s, e_s]
+        start_ids = [0, 0, 0, 0]
+        start_face_ids = [1, 3, 0, 2]
+        neighbor_ids = [1, 2, 3, 4]
+        neighbor_face_ids = [2, 2, 1, 2]
+
+        # Determine orientation single thread
         (
             axis_mapping,
             axis_orientation,
-        ) = c.splinepy.splinepy_core.get_orientation(a_s, 1, b_s, 2, 0.001)
-        self.assertTrue(c.np.all([1, 0] == axis_mapping))
-        self.assertTrue(c.np.all([True, True] == axis_orientation))
-        # Upper Arm
+        ) = c.splinepy.splinepy_core.orientations(
+            spline_list,
+            start_ids,
+            start_face_ids,
+            neighbor_ids,
+            neighbor_face_ids,
+            0.00001,
+            1,
+        )
+
+        # Check results
+        expected_mappings = [[1, 0], [0, 1], [0, 1], [0, 1]]
+        expected_orientations = [
+            [True, True],
+            [True, True],
+            [True, False],
+            [False, False],
+        ]
+        self.assertTrue(c.np.all(expected_mappings == axis_mapping))
+        self.assertTrue(c.np.all(expected_orientations == axis_orientation))
+
+        # Repeat with multithread execution
         (
             axis_mapping,
             axis_orientation,
-        ) = c.splinepy.splinepy_core.get_orientation(a_s, 3, c_s, 2, 0.001)
-        self.assertTrue(c.np.all([0, 1] == axis_mapping))
-        self.assertTrue(c.np.all([True, True] == axis_orientation))
-        # Left Arm
-        (
-            axis_mapping,
-            axis_orientation,
-        ) = c.splinepy.splinepy_core.get_orientation(a_s, 0, d_s, 1, 0.001)
-        self.assertTrue(c.np.all([0, 1] == axis_mapping))
-        self.assertTrue(c.np.all([True, False] == axis_orientation))
-        # Lower Arm
-        (
-            axis_mapping,
-            axis_orientation,
-        ) = c.splinepy.splinepy_core.get_orientation(a_s, 2, e_s, 2, 0.001)
-        self.assertTrue(c.np.all([0, 1] == axis_mapping))
-        self.assertTrue(c.np.all([False, False] == axis_orientation))
+        ) = c.splinepy.splinepy_core.orientations(
+            spline_list,
+            start_ids,
+            start_face_ids,
+            neighbor_ids,
+            neighbor_face_ids,
+            0.00001,
+            3,
+        )
+        self.assertTrue(c.np.all(expected_mappings == axis_mapping))
+        self.assertTrue(c.np.all(expected_orientations == axis_orientation))
 
 
 if __name__ == "__main__":

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -67,6 +67,7 @@ class orientationTest(c.unittest.TestCase):
         self.assertTrue(c.np.all(expected_mappings == axis_mapping))
         self.assertTrue(c.np.all(expected_orientations == axis_orientation))
 
+        return True
         # Repeat with multithread execution
         (
             axis_mapping,

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -67,7 +67,6 @@ class orientationTest(c.unittest.TestCase):
         self.assertTrue(c.np.all(expected_mappings == axis_mapping))
         self.assertTrue(c.np.all(expected_orientations == axis_orientation))
 
-        return True
         # Repeat with multithread execution
         (
             axis_mapping,

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -18,6 +18,7 @@ class orientationTest(c.unittest.TestCase):
     """
 
     def test_orientation(self):
+        return True
         # Init Splines to be tested
         a_s = c.splinepy.Bezier(
             degrees=[1, 1], control_points=[[1, 1], [2, 1], [1, 2], [2, 2]]

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,69 @@
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+
+class orientationTest(c.unittest.TestCase):
+    """Test Orientation between adjacent spline patches
+         2--3
+         |C |
+         0--1
+    0--1 2--3 1--3
+    |D | |A | | B|
+    2--3 0--1 0--2
+         1--0
+    |    |E |
+    O-   3--2
+    """
+
+    def test_orientation(self):
+        # Init Splines to be tested
+        a_s = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[1, 1], [2, 1], [1, 2], [2, 2]]
+        )
+        b_s = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[2, 1], [2, 2], [3, 1], [3, 2]]
+        )
+        c_s = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[1, 2], [2, 2], [1, 3], [2, 3]]
+        )
+        d_s = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[0, 2], [1, 2], [0, 1], [1, 1]]
+        )
+        e_s = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[2, 1], [1, 1], [2, 0], [1, 0]]
+        )
+
+        # Right Arm
+        (
+            axis_mapping,
+            axis_orientation,
+        ) = c.splinepy.splinepy_core.get_orientation(a_s, 1, b_s, 2, 0.001)
+        self.assertTrue(c.np.all([1, 0] == axis_mapping))
+        self.assertTrue(c.np.all([True, True] == axis_orientation))
+        # Upper Arm
+        (
+            axis_mapping,
+            axis_orientation,
+        ) = c.splinepy.splinepy_core.get_orientation(a_s, 3, c_s, 2, 0.001)
+        self.assertTrue(c.np.all([0, 1] == axis_mapping))
+        self.assertTrue(c.np.all([True, True] == axis_orientation))
+        # Left Arm
+        (
+            axis_mapping,
+            axis_orientation,
+        ) = c.splinepy.splinepy_core.get_orientation(a_s, 0, d_s, 1, 0.001)
+        self.assertTrue(c.np.all([0, 1] == axis_mapping))
+        self.assertTrue(c.np.all([True, False] == axis_orientation))
+        # Lower Arm
+        (
+            axis_mapping,
+            axis_orientation,
+        ) = c.splinepy.splinepy_core.get_orientation(a_s, 2, e_s, 2, 0.001)
+        self.assertTrue(c.np.all([0, 1] == axis_mapping))
+        self.assertTrue(c.np.all([False, False] == axis_orientation))
+
+
+if __name__ == "__main__":
+    c.unittest.main()

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -18,7 +18,6 @@ class orientationTest(c.unittest.TestCase):
     """
 
     def test_orientation(self):
-        return True
         # Init Splines to be tested
         a_s = c.splinepy.Bezier(
             degrees=[1, 1], control_points=[[1, 1], [2, 1], [1, 2], [2, 2]]


### PR DESCRIPTION
# Automatic way to determine orientation between two adjacent patches
This PR provides the functionality to determine the orientation in n dimensional space between two adjacent patches

## Addressed issues
*  #81 

## Showcase
see tests/test_orientation for detailed example
```
import splinepy
a = splinepy.Bezier(
            degrees=[1, 1], control_points=[[1, 1], [2, 1], [1, 2], [2, 2]]
        )

b = splinepy.Bezier(
            degrees=[1, 1], control_points=[[1, 2], [2, 2], [1, 3], [2, 3]]
        )

axis_mapping, axis_orientation = splinepy.splinepy_core.get_orientation(a, 3, b, 2, 0.001)
```

It also fully supports gismo export now

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
