### PR TITLE
Bugfix Extract Boundary didn't work properly

### DIFF
--- a/cpp/splinepy/splines/helpers/extract.hpp
+++ b/cpp/splinepy/splines/helpers/extract.hpp
@@ -47,14 +47,16 @@ ExtractControlMeshSliceFromIDs(const SplineType& spline,
       // pure copies of all basis function, which is not high degree friendly.
       Degrees b_degrees;
       KnotVectors b_knot_vectors;
+      int counter{};
       for (int i{}; i < SplineType::kParaDim; ++i) {
         if (i == plane_normal_axis) {
           continue;
         }
-        b_degrees[i] = spline.GetDegrees()[i];
+        b_degrees[counter] = spline.GetDegrees()[i];
         // knotvectors are shared_ptrs. make sure this copies
-        b_knot_vectors[i] =
+        b_knot_vectors[counter] =
             std::make_shared<KnotVector>(*spline.GetKnotVectors()[i]);
+        counter++;
       }
       // create parametric space
       auto pspace = std::make_shared<PSpace>(b_knot_vectors, b_degrees);
@@ -77,14 +79,16 @@ ExtractControlMeshSliceFromIDs(const SplineType& spline,
       using Degrees = typename SelfBoundary::Degrees_;
       Degrees b_degrees{};
       std::size_t ncps{1};
+      int counter{};
       for (int i{}; i < SplineType::kParaDim; ++i) {
         if (i == plane_normal_axis) {
           continue;
         }
         const auto& ds = spline.GetDegrees();
         const auto& d = ds[i];
-        b_degrees[i] = d;
+        b_degrees[counter] = d;
         ncps *= static_cast<std::size_t>(d + 1);
+        counter++;
       }
 
       if constexpr (SplineType::kIsRational) {
@@ -109,6 +113,7 @@ ExtractControlMeshSliceFromIDs(const SplineType& spline,
           // copy control points
           b_coords.push_back(spline.GetControlPoints()[id]);
         }
+
         // assign boundary spline
         boundary_spline = std::make_shared<SelfBoundary>(b_degrees, b_coords);
       }

--- a/cpp/splinepy/utils/grid_points.hpp
+++ b/cpp/splinepy/utils/grid_points.hpp
@@ -102,18 +102,21 @@ public:
     }
 
     auto local_to_global_bd_id = [&](const IndexT& local_id) {
-      IndexT offset{1}, id{local_id}, global_id{};
+      IndexT combined_offsets{1}, id{local_id}, global_id{};
       for (std::size_t i_pdc{}; i_pdc < dim; ++i_pdc) {
         const auto& res = grid_resolutions[i_pdc];
         if (i_pdc == plane_normal_axis) {
-          global_id += offset * plane_id;
+          global_id += combined_offsets * plane_id;
         } else {
-          const IndexT i = id % res;
-          global_id += id * offset;
-          id -= i;
+          // Determine index in coordinate indexing system
+          const IndexT rasterized_index = id % res;
+          // Use the current id to update the global index
+          global_id += rasterized_index * combined_offsets;
+          // Update the copy of the index to search for next slice
+          id -= rasterized_index;
           id /= res;
         }
-        offset *= res;
+        combined_offsets *= res;
       }
       return global_id;
     };

--- a/tests/common.py
+++ b/tests/common.py
@@ -127,6 +127,21 @@ q3D = [
 ]
 
 
+def are_splines_equal(a, b):
+    """returns True if Splines are equivalent"""
+    if not a.whatami == b.whatami:
+        return False
+    for req_prop in a.current_core_properties():
+        if req_prop == "knot_vectors":
+            for aa, bb in zip(a.knot_vectors, b.knot_vectors):
+                if not np.allclose(aa, bb):
+                    return False
+        else:
+            if not np.allclose(getattr(a, req_prop), getattr(b, req_prop)):
+                return False
+    return True
+
+
 def are_items_close(a, b):
     """returns True if items in a and b are close"""
     all_close = True

--- a/tests/test_extract_boundaries.py
+++ b/tests/test_extract_boundaries.py
@@ -1,0 +1,77 @@
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+
+class extractBoundariesTest(c.unittest.TestCase):
+    def testExtraction2D(self):
+        """Create a Spline, extract boundaries and check validity"""
+        # uniform
+        bez_el0 = c.splinepy.Bezier(
+            degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+        )
+        boundary_0 = c.splinepy.Bezier(
+            degrees=[1], control_points=[[0, 0], [0, 1]]
+        )
+        boundary_3 = c.splinepy.Bezier(
+            degrees=[1], control_points=[[0, 1], [1, 1]]
+        )
+        list_of_boundaries = bez_el0.extract_boundaries([0, 3])
+        self.assertTrue(c.are_splines_equal(list_of_boundaries[0], boundary_0))
+        self.assertTrue(c.are_splines_equal(list_of_boundaries[1], boundary_3))
+
+        # non-uniform
+        bez_el0 = c.splinepy.NURBS(
+            knot_vectors=[[0, 0, 0.5, 1, 1], [0, 0, 1, 1]],
+            weights=[1.0, 0.5, 1, 1, 0.5, 1],
+            degrees=[1, 1],
+            control_points=[
+                [0, 0],
+                [0.5, 0.5],
+                [1, 0],
+                [0, 1],
+                [0.5, 1.5],
+                [1, 1],
+            ],
+        )
+        boundary_2 = c.splinepy.NURBS(
+            knot_vectors=[[0, 0, 0.5, 1, 1]],
+            weights=[1.0, 0.5, 1],
+            degrees=[1],
+            control_points=[[0, 0], [0.5, 0.5], [1, 0]],
+        )
+        list_of_boundaries = bez_el0.extract_boundaries([2])
+        self.assertTrue(c.are_splines_equal(list_of_boundaries[0], boundary_2))
+
+    def testExtraction3D(self):
+        """Create a Spline, extract boundaries and check validity"""
+        # uniform
+        bez_el0 = c.splinepy.Bezier(
+            degrees=[1, 1, 1],
+            control_points=[
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [0, 1, 1],
+                [1, 1, 1],
+            ],
+        )
+        boundary_0 = c.splinepy.Bezier(
+            degrees=[1, 1],
+            control_points=[
+                [0, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [0, 1, 1],
+            ],
+        )
+        list_of_boundaries = bez_el0.extract_boundaries([0])
+        self.assertTrue(c.are_splines_equal(list_of_boundaries[0], boundary_0))
+
+
+if __name__ == "__main__":
+    c.unittest.main()


### PR DESCRIPTION
# Bugfix
should have only worked for boundaries that are extracted from the highest parametric dimension (e.g., dimension 1 in 2D).

Now there is an additional test so it won't happen again - hopefully

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
