### PR TITLE
Bugfix: surface interpolation with unequal number of control points

### DIFF
--- a/cpp/splinepy/fitting/fitting.cpp
+++ b/cpp/splinepy/fitting/fitting.cpp
@@ -82,7 +82,7 @@ void FitSurface(const double* points,
   for (v = 0; v < size_v; v++) {
     for (u = 0; u < size_u; u++) {
       for (i = 0; i < dim; i++) {
-        pts_u[u * dim + i] = points[(v + (size_v * u)) * dim + i];
+        pts_u[u * dim + i] = points[(u + (size_u * v)) * dim + i];
       }
     }
     coefficient_matrix =
@@ -94,19 +94,24 @@ void FitSurface(const double* points,
   }
 
   // v - direction global interpolation
-  control_points.clear();
+  control_points.assign(size_u * size_v * dim, 0.0);
   for (u = 0; u < size_u; u++) {
     for (v = 0; v < size_v; v++) {
       for (i = 0; i < dim; i++) {
         pts_v[v * dim + i] = tmp_control_points[(u + (size_u * v)) * dim + i];
       }
     }
+
     coefficient_matrix =
         BuildCoefficientMatrix(degree_v, knot_vector_v, v_l, size_v, size_v);
     tmp_result = LUSolve(coefficient_matrix, pts_v, size_v, dim);
-    std::move(tmp_result.begin(),
-              tmp_result.end(),
-              std::back_inserter(control_points));
+
+    for (int v = 0; v < size_v; v++) {
+      for (int i = 0; i < dim; i++) {
+        control_points[(u + (size_u * v)) * dim + i] =
+            tmp_result[(v * dim) + i];
+      }
+    }
   }
 
   delete[] pts_u;


### PR DESCRIPTION
# Overview
Description
As pointed out in issue #99, the current routine `splinepy.BSpline.interpolate_surface` does not allow an unequal number of sampling points. This is due to a wrong ordering of the sampling points in l.85. 
This code fixes this issue and transposes the control points, as they are otherwise incorrectly ordered. I am happy on feedback to improve the efficiency of l.108-114.

## Addressed issues
*  Issues addressed: #99 

## Showcase
The example illustrated in #99. 
```
import numpy as np
import splinepy


def interpolate_function(f, samples_per_direction):
    """Interpolate the function f with a given number of samples 
    in each direction on the interval [-1, 1] x [-1, 1]

    Parameters
    ----------
    f : function
        Function to interpolate
    samples_per_direction : list
        Number of samples per direction

    Returns
    -------
    np.ndarray, splinepy.BSpline
        Target points and interpolating BSpline
    """

    # Create dataset
    x = [np.linspace(-1, 1, samples_per_direction[0]), 
        np.linspace(-1, 1, samples_per_direction[1])]
    xx, yy = np.meshgrid(x[0], x[1])

    target_points = np.vstack(
        (xx.flatten(), yy.flatten(), h(xx, yy).flatten())
    ).T

    interpolated_surface = splinepy.BSpline.interpolate_surface(
        target_points,
        size_u=samples_per_direction[0],
        size_v=samples_per_direction[1],
        degree_u=2,
        degree_v=2,
    )
    return target_points, interpolated_surface
    
def h(x, y):
    return x + y

if __name__ == "__main__":
    try:
        import gustaf as gus

        gustaf_available = True
    except ImportError:
        gustaf_available = False


    for sample_sizes in [[3, 3], [3, 4], [4, 3], [20, 20], [25, 20]]:
        target_points, interpolated_surface = interpolate_function(h, sample_sizes)
        
        if gustaf_available:
            bspline = gus.BSpline(**interpolated_surface.todict())
            gus.show.show_vedo([bspline])

```
Results:
Number of control points (3,3)
![cps_3_3](https://user-images.githubusercontent.com/18384259/217490909-89339757-df11-4fd2-a771-fd29a642bfe6.png)
Number of control points (3,4)
![cps_3_4](https://user-images.githubusercontent.com/18384259/217490914-b999650f-72d0-44c2-b9e2-a558e9ea1e43.png)
Number of control points (4,3)
![cps_4_3](https://user-images.githubusercontent.com/18384259/217490916-5340f179-5895-4950-9cbd-eca922632aa1.png)
Number of control points (20, 20)
![cps_20_20](https://user-images.githubusercontent.com/18384259/217490922-9f70881d-ba82-49a1-a769-b4585a00c4bc.png)
Number of control points (5, 20)
![cps_5_20](https://user-images.githubusercontent.com/18384259/217490919-995c8c90-3cd4-42b2-8097-59fcb863769a.png)


## Checklists
* [X] Documentations are up-to-date.
* [X] Added example(s)
* [ ] Added test(s)
