### PR TITLE
fix ResourceWarning

### DIFF
--- a/splinepy/io/json.py
+++ b/splinepy/io/json.py
@@ -27,7 +27,7 @@ def load(fname):
     from splinepy.spline import RequiredProperties
 
     # Import data from file into dict format
-    with open(fname, "r") as f:
+    with open(fname) as f:
         jsonbz = json.load(f)
 
     spline_list = []

--- a/splinepy/io/json.py
+++ b/splinepy/io/json.py
@@ -27,7 +27,8 @@ def load(fname):
     from splinepy.spline import RequiredProperties
 
     # Import data from file into dict format
-    jsonbz = json.load(open(fname))
+    with open(fname, "r") as f:
+        jsonbz = json.load(f)
 
     spline_list = []
     base64encoding = jsonbz["Base64Encoding"]


### PR DESCRIPTION
# Overview
fixes resource warning from json io. Uses context instead of raw `open()`

## Addressed issues
*  `splinepy/splinepy/io/json.py:30: ResourceWarning: unclosed file <_io.TextIOWrapper name=.....`
