### PR TITLE
CoordinateReferences

### DIFF
--- a/cpp/splinepy/py/CMakeLists.txt
+++ b/cpp/splinepy/py/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(PYSPLINEPY_SRCS
         init/reader.cpp
         init/exporter.cpp
+        init/coordinate_reference.cpp
         init/core_spline.cpp
         init/fitting.cpp
         splinepy_core.cpp)

--- a/cpp/splinepy/py/init/coordinate_reference.cpp
+++ b/cpp/splinepy/py/init/coordinate_reference.cpp
@@ -2,6 +2,8 @@
 
 namespace splinepy::py::init {
 namespace py = pybind11;
-void init_coordinate_references(py::module_& m) { add_coordinate_references_pyclass(m); }
+void init_coordinate_references(py::module_& m) {
+  add_coordinate_references_pyclass(m);
+}
 
 } // namespace splinepy::py::init

--- a/cpp/splinepy/py/init/coordinate_reference.cpp
+++ b/cpp/splinepy/py/init/coordinate_reference.cpp
@@ -1,0 +1,7 @@
+#include <splinepy/py/py_coordinate_references.hpp>
+
+namespace splinepy::py::init {
+namespace py = pybind11;
+void init_coordinate_references(py::module_& m) { add_coordinate_references_pyclass(m); }
+
+} // namespace splinepy::py::init

--- a/cpp/splinepy/py/py_coordinate_references.hpp
+++ b/cpp/splinepy/py/py_coordinate_references.hpp
@@ -7,7 +7,7 @@
 #include <splinepy/utils/print.hpp>
 #include <splinepy/utils/reference.hpp>
 
-PYBIND11_MAKE_OPAQUE(splinepy::splines::SplinepyBase::CoordinateReferences_);
+// PYBIND11_MAKE_OPAQUE(splinepy::splines::SplinepyBase::CoordinateReferences_);
 
 namespace splinepy::py {
 
@@ -27,12 +27,6 @@ inline void add_coordinate_references_pyclass(py::module_& m) {
       klasse(m, "CoordinateReferences");
   klasse.def(py::init<>())
       .def("__len__", [](const CoordinateReferences& r) { return r.size(); })
-      .def(
-          "__iter__",
-          [](CoordinateReferences& r) {
-            return py::make_iterator(r.begin(), r.end());
-          },
-          py::keep_alive<0, 1>() /* Keep vector alive while iterator is used*/)
       .def("__setitem__",
            [](CoordinateReferences& r,
               const py::array_t<int> ids,
@@ -56,6 +50,16 @@ inline void add_coordinate_references_pyclass(py::module_& m) {
              // assign
              for (py::ssize_t i{}; i < i_size; ++i) {
                r[ids_ptr[i]].value_ = values_ptr[i];
+             }
+           })
+      .def("broadcast_scalar",
+           [](CoordinateReferences& r,
+              const py::array_t<int> ids,
+              const double value) {
+             const py::ssize_t i_size = ids.size();
+             int* ids_ptr = static_cast<int*>(ids.request().ptr);
+             for (py::ssize_t i{}; i < i_size; ++i) {
+               r[ids_ptr[i]].value_ = value;
              }
            })
       .def("numpy", [](const CoordinateReferences& r) {

--- a/cpp/splinepy/py/py_coordinate_references.hpp
+++ b/cpp/splinepy/py/py_coordinate_references.hpp
@@ -7,8 +7,6 @@
 #include <splinepy/utils/print.hpp>
 #include <splinepy/utils/reference.hpp>
 
-// PYBIND11_MAKE_OPAQUE(splinepy::splines::SplinepyBase::CoordinateReferences_);
-
 namespace splinepy::py {
 
 namespace py = pybind11;

--- a/cpp/splinepy/py/py_coordinate_references.hpp
+++ b/cpp/splinepy/py/py_coordinate_references.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
 
+#include <splinepy/splines/splinepy_base.hpp>
 #include <splinepy/utils/print.hpp>
 #include <splinepy/utils/reference.hpp>
-#include <splinepy/splines/splinepy_base.hpp>
 
 PYBIND11_MAKE_OPAQUE(splinepy::splines::SplinepyBase::CoordinateReferences_);
 
@@ -19,50 +19,54 @@ namespace py = pybind11;
 /// probably useful to wrap this once with numpy __getitem__
 /// we name this coordinates, since rational splines will have weighted
 /// control points.
-using CoordinateReferences = splinepy::splines::SplinepyBase::CoordinateReferences_;
+using CoordinateReferences =
+    splinepy::splines::SplinepyBase::CoordinateReferences_;
 
 inline void add_coordinate_references_pyclass(py::module_& m) {
-    py::class_<CoordinateReferences, std::shared_ptr<CoordinateReferences>> klasse(m, "CoordinateReferences");
-        klasse.def(py::init<>())
-        .def("__len__", [](const CoordinateReferences& r) {return r.size();})
-        .def("__iter__", [](CoordinateReferences& r){
+  py::class_<CoordinateReferences, std::shared_ptr<CoordinateReferences>>
+      klasse(m, "CoordinateReferences");
+  klasse.def(py::init<>())
+      .def("__len__", [](const CoordinateReferences& r) { return r.size(); })
+      .def(
+          "__iter__",
+          [](CoordinateReferences& r) {
             return py::make_iterator(r.begin(), r.end());
-        }, py::keep_alive<0, 1>() /* Keep vector alive while iterator is used*/)
-        .def("__setitem__", [] (CoordinateReferences& r,
-                                const py::array_t<int> ids,
-                                const py::array_t<double> values) {
-            // size match check
-            const py::ssize_t i_size = ids.size();
-            const py::ssize_t v_size = values.size();
-    
-            if (i_size != v_size) {
-              splinepy::utils::PrintAndThrowError(
-                "array size mismatch between ids (", i_size,")  and values (", v_size, ")"
-              );
-            }
-            // get ptr
-            int* ids_ptr = static_cast<int*>(ids.request().ptr);
-            double* values_ptr = static_cast<double*>(values.request().ptr);
+          },
+          py::keep_alive<0, 1>() /* Keep vector alive while iterator is used*/)
+      .def("__setitem__",
+           [](CoordinateReferences& r,
+              const py::array_t<int> ids,
+              const py::array_t<double> values) {
+             // size match check
+             const py::ssize_t i_size = ids.size();
+             const py::ssize_t v_size = values.size();
 
-            // assign
-            for (py::ssize_t i{}; i < i_size; ++i) {
-              r[ids_ptr[i]].value_ = values_ptr[i];
-            }
-          }
-        )
-        .def("numpy", [](const CoordinateReferences& r) {
-            const int r_size = r.size();
-            py::array_t<double> copied(r_size);
-            double* copied_ptr = static_cast<double*>(copied.request().ptr);
-            for (int i{}; i < r_size; ++i) {
-              copied_ptr[i] = r[i].value_;
-            }
-            return copied;
-          }
-        )
-        ;
+             if (i_size != v_size) {
+               splinepy::utils::PrintAndThrowError(
+                   "array size mismatch between ids (",
+                   i_size,
+                   ")  and values (",
+                   v_size,
+                   ")");
+             }
+             // get ptr
+             int* ids_ptr = static_cast<int*>(ids.request().ptr);
+             double* values_ptr = static_cast<double*>(values.request().ptr);
+
+             // assign
+             for (py::ssize_t i{}; i < i_size; ++i) {
+               r[ids_ptr[i]].value_ = values_ptr[i];
+             }
+           })
+      .def("numpy", [](const CoordinateReferences& r) {
+        const int r_size = r.size();
+        py::array_t<double> copied(r_size);
+        double* copied_ptr = static_cast<double*>(copied.request().ptr);
+        for (int i{}; i < r_size; ++i) {
+          copied_ptr[i] = r[i].value_;
+        }
+        return copied;
+      });
 }
 
-} // namespace
-
-
+} // namespace splinepy::py

--- a/cpp/splinepy/py/py_coordinate_references.hpp
+++ b/cpp/splinepy/py/py_coordinate_references.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <splinepy/utils/print.hpp>
+#include <splinepy/utils/reference.hpp>
+#include <splinepy/splines/splinepy_base.hpp>
+
+PYBIND11_MAKE_OPAQUE(splinepy::splines::SplinepyBase::CoordinateReferences_);
+
+namespace splinepy::py {
+
+namespace py = pybind11;
+
+/// Access reference of each control point coefficients as if they were
+/// layed out in contiguous manner.
+/// excess by global index.
+/// probably useful to wrap this once with numpy __getitem__
+/// we name this coordinates, since rational splines will have weighted
+/// control points.
+using CoordinateReferences = splinepy::splines::SplinepyBase::CoordinateReferences_;
+
+inline void add_coordinate_references_pyclass(py::module_& m) {
+    py::class_<CoordinateReferences, std::shared_ptr<CoordinateReferences>> klasse(m, "CoordinateReferences");
+        klasse.def(py::init<>())
+        .def("__len__", [](const CoordinateReferences& r) {return r.size();})
+        .def("__iter__", [](CoordinateReferences& r){
+            return py::make_iterator(r.begin(), r.end());
+        }, py::keep_alive<0, 1>() /* Keep vector alive while iterator is used*/)
+        .def("__setitem__", [] (CoordinateReferences& r,
+                                const py::array_t<int> ids,
+                                const py::array_t<double> values) {
+            // size match check
+            const py::ssize_t i_size = ids.size();
+            const py::ssize_t v_size = values.size();
+    
+            if (i_size != v_size) {
+              splinepy::utils::PrintAndThrowError(
+                "array size mismatch between ids (", i_size,")  and values (", v_size, ")"
+              );
+            }
+            // get ptr
+            int* ids_ptr = static_cast<int*>(ids.request().ptr);
+            double* values_ptr = static_cast<double*>(values.request().ptr);
+
+            // assign
+            for (py::ssize_t i{}; i < i_size; ++i) {
+              r[ids_ptr[i]].value_ = values_ptr[i];
+            }
+          }
+        )
+        .def("numpy", [](const CoordinateReferences& r) {
+            const int r_size = r.size();
+            py::array_t<double> copied(r_size);
+            double* copied_ptr = static_cast<double*>(copied.request().ptr);
+            for (int i{}; i < r_size; ++i) {
+              copied_ptr[i] = r[i].value_;
+            }
+            return copied;
+          }
+        )
+        ;
+}
+
+} // namespace
+
+

--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -751,6 +751,12 @@ public:
 
     return successful;
   }
+
+  // coordinate reference
+  std::shared_ptr<splinepy::splines::SplinepyBase::CoordinateReferences_>
+  CoordinateReferences() {
+    return Core()->SplinepyCoordinateReferences();
+  }
 };
 
 /* operations for certain splines */
@@ -1065,6 +1071,8 @@ inline void add_spline_pyclass(py::module& m, const char* class_name) {
            &splinepy::py::PySpline::ReduceDegrees,
            py::arg("para_dims"),
            py::arg("tolerance"))
+      .def("coordinate_references",
+           &splinepy::py::PySpline::CoordinateReferences)
       .def(py::pickle(
           [](splinepy::py::PySpline& spl) {
             return py::make_tuple(spl.CurrentCoreProperties(), spl.data_);

--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -752,7 +752,7 @@ public:
     return successful;
   }
 
-  // coordinate reference
+  /// coordinate reference
   std::shared_ptr<splinepy::splines::SplinepyBase::CoordinateReferences_>
   CoordinateReferences() {
     return Core()->SplinepyCoordinateReferences();

--- a/cpp/splinepy/py/splinepy_core.cpp
+++ b/cpp/splinepy/py/splinepy_core.cpp
@@ -5,6 +5,9 @@ namespace splinepy::py::init {
 
 namespace py = pybind11;
 
+// Coordinate ref
+void init_coordinate_references(py::module_&);
+
 // CORE
 void init_core_spline(py::module_&);
 
@@ -21,7 +24,10 @@ void init_fitting(py::module_&);
 
 namespace py = pybind11;
 
+// PYBIND11_MAKE_OPAQUE(splinepy::py::CoordinateReferences);
+
 PYBIND11_MODULE(splinepy_core, m) {
+  splinepy::py::init::init_coordinate_references(m);
   splinepy::py::init::init_core_spline(m);
   splinepy::py::init::init_reader(m);
   splinepy::py::init::init_exporter(m);

--- a/cpp/splinepy/splines/bezier.hpp
+++ b/cpp/splinepy/splines/bezier.hpp
@@ -148,6 +148,27 @@ public:
     }
   }
 
+  virtual std::shared_ptr<SplinepyBase::CoordinateReferences_>
+  SplinepyCoordinateReferences() {
+    using RefHolder = typename SplinepyBase::CoordinateReferences_::value_type;
+    auto ref_coordinates =
+        std::make_shared<SplinepyBase::CoordinateReferences_>();
+    auto& ref_coords = *ref_coordinates;
+    ref_coords.reserve(Base_::control_points.size());
+
+    for (auto& control_point : Base_::control_points) {
+      if constexpr (kDim == 1) {
+        // already scalar
+        ref_coords.emplace_back(RefHolder{control_point});
+      } else {
+        for (auto& cp : control_point) {
+          ref_coords.emplace_back(RefHolder{cp});
+        }
+      }
+    }
+    return ref_coordinates;
+  }
+
   virtual void SplinepyParametricBounds(double* para_bounds) const {
     for (std::size_t i{}; i < kParaDim; ++i) {
       // lower bounds

--- a/cpp/splinepy/splines/bspline.hpp
+++ b/cpp/splinepy/splines/bspline.hpp
@@ -220,6 +220,25 @@ public:
     }
   }
 
+  virtual std::shared_ptr<SplinepyBase::CoordinateReferences_>
+  SplinepyCoordinateReferences() {
+    // prepare return
+    using RefHolder = typename SplinepyBase::CoordinateReferences_::value_type;
+    auto ref_coordinates =
+        std::make_shared<SplinepyBase::CoordinateReferences_>();
+    auto& ref_coords = *ref_coordinates;
+
+    // get ref
+    auto& coordinates = Base_::vector_space_->GetCoordinates();
+    ref_coords.reserve(coordinates.size());
+    for (auto& control_point : coordinates) {
+      for (auto& cp : control_point) {
+        ref_coords.emplace_back(RefHolder{static_cast<double&>(cp)});
+      }
+    }
+    return ref_coordinates;
+  }
+
   virtual void SplinepyParametricBounds(double* para_bounds) const {
     const auto pbounds = splinepy::splines::helpers::GetParametricBounds(*this);
     for (std::size_t i{}; i < kParaDim; ++i) {

--- a/cpp/splinepy/splines/nurbs.hpp
+++ b/cpp/splinepy/splines/nurbs.hpp
@@ -227,6 +227,26 @@ public:
     }
   }
 
+  virtual std::shared_ptr<SplinepyBase::CoordinateReferences_>
+  SplinepyCoordinateReferences() {
+    using RefHolder = typename SplinepyBase::CoordinateReferences_::value_type;
+    auto ref_coordinates =
+        std::make_shared<SplinepyBase::CoordinateReferences_>();
+    auto& ref_coords = *ref_coordinates;
+
+    // get ref
+    auto& coordinates = Base_::weighted_vector_space_->GetCoordinates();
+    ref_coords.reserve(coordinates.size());
+    for (auto& control_point : coordinates) {
+      // skip the last entry - control_point has kDim + 1 size.
+      for (std::size_t i{}; i < kDim; ++i) {
+        ref_coords.emplace_back(
+            RefHolder{static_cast<double&>(control_point[i])});
+      }
+    }
+    return ref_coordinates;
+  }
+
   virtual void SplinepyParametricBounds(double* para_bounds) const {
     const auto pbounds = splinepy::splines::helpers::GetParametricBounds(*this);
     for (std::size_t i{}; i < kParaDim; ++i) {

--- a/cpp/splinepy/splines/rational_bezier.hpp
+++ b/cpp/splinepy/splines/rational_bezier.hpp
@@ -162,6 +162,28 @@ public:
     }
   }
 
+  virtual std::shared_ptr<SplinepyBase::CoordinateReferences_>
+  SplinepyCoordinateReferences() {
+    using RefHolder = typename SplinepyBase::CoordinateReferences_::value_type;
+    auto ref_coordinates =
+        std::make_shared<SplinepyBase::CoordinateReferences_>();
+    auto& ref_coords = *ref_coordinates;
+    ref_coords.reserve(Base_::GetWeightedControlPoints().size());
+
+    for (auto& control_point : Base_::GetWeightedControlPoints()) {
+      if constexpr (kDim == 1) {
+        // already scalar
+        ref_coords.emplace_back(RefHolder{control_point});
+      } else {
+        for (auto& cp : control_point) {
+          ref_coords.emplace_back(RefHolder{cp});
+        }
+      }
+    }
+
+    return ref_coordinates;
+  }
+
   virtual void SplinepyParametricBounds(double* para_bounds) const {
     for (std::size_t i{}; i < kParaDim; ++i) {
       // lower bounds

--- a/cpp/splinepy/splines/splinepy_base.cpp
+++ b/cpp/splinepy/splines/splinepy_base.cpp
@@ -414,6 +414,16 @@ bool SplinepyBase::SplinepyDimMatches(const SplinepyBase& a,
   return true;
 }
 
+std::shared_ptr<SplinepyBase::CoordinateReferences_>
+SplinepyBase::SplinepyCoordinateReferences() {
+  splinepy::utils::PrintAndThrowError(
+      "SplinepyCoordinateReferences not implemented for",
+      SplinepyWhatAmI());
+
+  // make compiler happy
+  return std::make_shared<SplinepyBase::CoordinateReferences_>();
+};
+
 void SplinepyBase::SplinepyParametricBounds(double* p_bounds) const {
   splinepy::utils::PrintAndThrowError(
       "SplinepyParametricBounds not implemented for",

--- a/cpp/splinepy/splines/splinepy_base.hpp
+++ b/cpp/splinepy/splines/splinepy_base.hpp
@@ -3,12 +3,16 @@
 #include <memory>
 #include <vector>
 
+#include <splinepy/utils/reference.hpp>
+
 namespace splinepy::splines {
 
 /// Spline base to enable dynamic use of template splines.
 /// Member functions are prepended with "Splinepy".
 class SplinepyBase {
 public:
+  using CoordinateReferences_ = std::vector<splinepy::utils::Reference<double>>;
+
   /// default ctor
   SplinepyBase() = default;
   ///
@@ -88,6 +92,8 @@ public:
                             std::vector<std::vector<double>>* knot_vectors,
                             double* control_points,
                             double* weights) const = 0;
+
+  virtual std::shared_ptr<CoordinateReferences_> SplinepyCoordinateReferences();
 
   /// Parameter space AABB
   virtual void SplinepyParametricBounds(double* p_bounds) const;

--- a/cpp/splinepy/utils/reference.hpp
+++ b/cpp/splinepy/utils/reference.hpp
@@ -6,10 +6,10 @@ namespace splinepy::utils {
 
 /// struct to hold reference.
 /// easiler manipulation than reference_wrapper, but better than raw ptr
-template <typename T>
+template<typename T>
 struct Reference {
   using Type_ = T;
   T& value_;
 };
 
-} // end namespace
+} // namespace splinepy::utils

--- a/cpp/splinepy/utils/reference.hpp
+++ b/cpp/splinepy/utils/reference.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <functional>
+
+namespace splinepy::utils {
+
+/// struct to hold reference.
+/// easiler manipulation than reference_wrapper, but better than raw ptr
+template <typename T>
+struct Reference {
+  using Type_ = T;
+  T& value_;
+};
+
+} // end namespace

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -60,7 +60,7 @@ class BSplineBase(spline.Spline):
 
         self._logd(f"Inserted {len(knots)} knot(s).")
 
-        spline.sync_from_core(self)
+        self._data = spline._default_data()
 
     def remove_knots(self, parametric_dimension, knots, tolerance=None):
         """
@@ -104,7 +104,7 @@ class BSplineBase(spline.Spline):
         )
 
         if any(removed):
-            spline.sync_from_core(self)
+            self._data = spline._default_data()
 
         self._logd(f"Tried to remove {len(knots)} knot(s).")
         self._logd(f"Actually removed {sum(removed)} knot(s).")

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -809,7 +809,16 @@ class Spline(SplinepyBase, core.CoreSpline):
         --------
         degrees: (para_dim,) np.ndarray
         """
-        return _get_property(self, "degrees")
+        degrees = _get_property(self, "degrees")
+        if degrees is None:
+            return degrees
+
+        # if core spline exists,
+        # degrees should not be modifiable
+        if core.have_core(self):
+            degrees.mutable = False
+
+        return degrees
 
     @degrees.setter
     def degrees(self, degrees):

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1330,7 +1330,7 @@ class Spline(SplinepyBase, core.CoreSpline):
         self._logd(
             f"Elevated {parametric_dimensions}.-dim. " "degree of the spline."
         )
-        sync_from_core(self)
+        self._data = _default_data()
 
     @_new_core_if_modified
     def reduce_degrees(self, parametric_dimensions, tolerance=None):
@@ -1362,7 +1362,7 @@ class Spline(SplinepyBase, core.CoreSpline):
         )
 
         if any(reduced):
-            sync_from_core(self)
+            self._data = _default_data()
 
         return reduced
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,64 +17,92 @@ __all__ = [
 # b: bspline
 # n: nurbs
 
+
 # initializing a spline should be a test itself, so provide `dict_spline`
 # this is "iga-book"'s fig 2.15.
-b2P2D = dict(
-    degrees=[2, 2],
-    knot_vectors=[
-        [0, 0, 0, 0.5, 1, 1, 1],
-        [0, 0, 0, 1, 1, 1],
-    ],
-    control_points=[
-        [0, 0],
-        [0, 1],
-        [1, 1.5],
-        [3, 1.5],
-        [-1, 0],
-        [-1, 2],
-        [1, 4],
-        [3, 4],
-        [-2, 0],
-        [-2, 2],
-        [1, 5],
-        [3, 5],
-    ],
-)
+def b2p2d():
+    return dict(
+        degrees=[2, 2],
+        knot_vectors=[
+            [0, 0, 0, 0.5, 1, 1, 1],
+            [0, 0, 0, 1, 1, 1],
+        ],
+        control_points=[
+            [0, 0],
+            [0, 1],
+            [1, 1.5],
+            [3, 1.5],
+            [-1, 0],
+            [-1, 2],
+            [1, 4],
+            [3, 4],
+            [-2, 0],
+            [-2, 2],
+            [1, 5],
+            [3, 5],
+        ],
+    )
+
+
+b2P2D = b2p2d()
+
 
 # half-half circle.
-n2P2D = dict(
-    degrees=[2, 1],
-    knot_vectors=[
-        [0, 0, 0, 1, 1, 1],
-        [0, 0, 1, 1],
-    ],
-    control_points=[
-        [-1.0, 0.0],
-        [-1.0, 1.0],
-        [0.0, 1.0],
-        [-2.0, 0.0],
-        [-2.0, 2.0],
-        [0.0, 2.0],
-    ],
-    weights=[
-        [1.0],
-        [2**-0.5],
-        [1.0],
-        [1.0],
-        [2**-0.5],
-        [1.0],
-    ],
-)
+def n2p2d():
+    return dict(
+        degrees=[2, 1],
+        knot_vectors=[
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 1, 1],
+        ],
+        control_points=[
+            [-1.0, 0.0],
+            [-1.0, 1.0],
+            [0.0, 1.0],
+            [-2.0, 0.0],
+            [-2.0, 2.0],
+            [0.0, 2.0],
+        ],
+        weights=[
+            [1.0],
+            [2**-0.5],
+            [1.0],
+            [1.0],
+            [2**-0.5],
+            [1.0],
+        ],
+    )
+
+
+n2P2D = n2p2d()
+
+
+def n2p2d_quarter_circle():
+    """explicit function for quarter circle
+    incase n2p2d changes in the future..."""
+    return n2p2d()
+
 
 #
-z2P2D = dict(degrees=n2P2D["degrees"], control_points=n2P2D["control_points"])
+def z2p2d():
+    return dict(
+        degrees=n2P2D["degrees"], control_points=n2P2D["control_points"]
+    )
+
+
+z2P2D = z2p2d()
+
 
 #
-r2P2D = dict(
-    degrees=n2P2D["degrees"],
-    control_points=n2P2D["control_points"],
-    weights=n2P2D["weights"],
-)
+def r2p2d():
+    return dict(
+        degrees=n2P2D["degrees"],
+        control_points=n2P2D["control_points"],
+        weights=n2P2D["weights"],
+    )
+
+
+r2P2D = r2p2d()
 
 # 3D
 z3P3D = dict(

--- a/tests/common.py
+++ b/tests/common.py
@@ -128,6 +128,37 @@ q3D = [
 ]
 
 
+def raster(bounds, resolutions):
+    """prepares raster points using np.meshgrid"""
+    l_bounds, u_bounds = bounds[0], bounds[1]
+    pts = np.meshgrid(
+        *[
+            np.linspace(lo, up, re)
+            for lo, up, re in zip(l_bounds, u_bounds, resolutions)
+        ],
+        indexing="ij"
+    )
+    #return pts
+    return np.hstack([p.reshape(-1, 1) for p in pts[::-1]])
+
+
+def nd_box(dim):
+    """creates simple box in nd"""
+    ds = [1 for _ in range(dim)]
+    cps = raster(
+        [[0 for _ in range(dim)], [1 for _ in range(dim)]],
+        [2 for _ in range(dim)],
+    )
+    kvs = [[0, 0, 1, 1] for _ in range(dim)]
+    ws = np.ones((len(cps), 1))
+    return {
+        "degrees": ds,
+        "control_points": cps,
+        "knot_vectors": kvs,
+        "weights": ws,
+    }
+
+
 def to_tmpf(tmpd):
     """given tmpd, returns tmpf"""
     return os.path.join(tmpd, "nqv248p90")

--- a/tests/common.py
+++ b/tests/common.py
@@ -136,9 +136,9 @@ def raster(bounds, resolutions):
             np.linspace(lo, up, re)
             for lo, up, re in zip(l_bounds, u_bounds, resolutions)
         ],
-        indexing="ij"
+        indexing="ij",
     )
-    #return pts
+    # return pts
     return np.hstack([p.reshape(-1, 1) for p in pts[::-1]])
 
 

--- a/tests/test_property_modification.py
+++ b/tests/test_property_modification.py
@@ -1,0 +1,45 @@
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+class InplaceModificationTest(c.unittest.TestCase):
+
+    def test_inplace_change_knot_vectors(self):
+        """test inplace change of knot_vectors"""
+        # let's test 3D splines
+        dim = 3
+        box_data = c.nd_box(dim)
+        n = c.splinepy.NURBS(**box_data)
+        box_data.pop("weights")
+        b = c.splinepy.BSpline(**box_data)
+
+        # elevate degrees and insert some knots
+        knot_insert_dims = [1,2]
+        for s in (n, b):
+            s.elevate_degrees([0,0,1,2])
+            for kid in knot_insert_dims:
+                s.insert_knots(kid, c.np.linspace(.1, .9, 9))
+
+        qres = 2
+        raster_query = c.raster([[0] * dim, [1] * dim], [qres] * dim)
+
+        for s in (n, b):
+            # is this valid spline?
+            assert c.np.allclose(raster_query, s.evaluate(raster_query))
+
+            # modify knots and corresponding queries, so that
+            # evaluated points are same as raster_query
+            modified_query = raster_query.copy()
+            factor = 2
+            for kid in knot_insert_dims:
+                s.knot_vectors[kid] *= factor
+                modified_query[:, kid] *= factor
+
+                # check modified flag
+                assert s.knot_vectors[kid]._modified
+                # full modified check
+                assert c.splinepy.spline.is_modified(s)
+
+            # evaluation check
+            assert c.np.allclose(raster_query, s.evaluate(modified_query))

--- a/tests/test_property_modification.py
+++ b/tests/test_property_modification.py
@@ -3,8 +3,8 @@ try:
 except BaseException:
     import common as c
 
-class InplaceModificationTest(c.unittest.TestCase):
 
+class InplaceModificationTest(c.unittest.TestCase):
     def test_inplace_change_knot_vectors(self):
         """test inplace change of knot_vectors"""
         # let's test 3D splines
@@ -15,11 +15,11 @@ class InplaceModificationTest(c.unittest.TestCase):
         b = c.splinepy.BSpline(**box_data)
 
         # elevate degrees and insert some knots
-        knot_insert_dims = [1,2]
+        knot_insert_dims = [1, 2]
         for s in (n, b):
-            s.elevate_degrees([0,0,1,2])
+            s.elevate_degrees([0, 0, 1, 2])
             for kid in knot_insert_dims:
-                s.insert_knots(kid, c.np.linspace(.1, .9, 9))
+                s.insert_knots(kid, c.np.linspace(0.1, 0.9, 9))
 
         qres = 2
         raster_query = c.raster([[0] * dim, [1] * dim], [qres] * dim)

--- a/tests/test_property_modification.py
+++ b/tests/test_property_modification.py
@@ -5,6 +5,33 @@ except BaseException:
 
 
 class InplaceModificationTest(c.unittest.TestCase):
+    def test_inplace_change_degrees(self):
+        """inplace change of degrees should not be allowed if core spline is
+        initialized"""
+        z = c.z2p2d()
+        r = c.r2p2d()
+        b = c.b2p2d()
+        n = c.n2p2d()
+
+        Z, R, B, N = (
+            c.splinepy.Bezier,
+            c.splinepy.RationalBezier,
+            c.splinepy.BSpline,
+            c.splinepy.NURBS,
+        )
+
+        for props, SClass in zip((z, r, b, n), (Z, R, B, N)):
+            # test no core spline
+            # this should be fine
+            s = SClass()
+            s.degrees = props["degrees"]
+            s.degrees += 1
+
+            # this shoundn't be fine
+            s.new_core(**props)
+            with self.assertRaises(ValueError):
+                s.degrees += 1
+
     def test_inplace_change_knot_vectors(self):
         """test inplace change of knot_vectors"""
         # let's test 3D splines
@@ -21,7 +48,7 @@ class InplaceModificationTest(c.unittest.TestCase):
             for kid in knot_insert_dims:
                 s.insert_knots(kid, c.np.linspace(0.1, 0.9, 9))
 
-        qres = 2
+        qres = 5
         raster_query = c.raster([[0] * dim, [1] * dim], [qres] * dim)
 
         for s in (n, b):
@@ -43,3 +70,147 @@ class InplaceModificationTest(c.unittest.TestCase):
 
             # evaluation check
             assert c.np.allclose(raster_query, s.evaluate(modified_query))
+
+    def test_inplace_change_control_points(self):
+        """test inplace changes of control points"""
+        dim = 3
+        res = [3] * dim
+        box_data = c.nd_box(dim)
+
+        n = c.splinepy.NURBS(**box_data)
+        weights = box_data.pop("weights")
+        b = c.splinepy.BSpline(**box_data)
+        box_data.pop("knot_vectors")
+        z = c.splinepy.Bezier(**box_data)
+        r = c.splinepy.RationalBezier(**box_data, weights=weights)
+
+        for s in (z, r, b, n):
+            # init
+            orig = s.copy()
+
+            # check if we are good to start
+            assert c.np.allclose(orig.sample(res), s.sample(res))
+
+            # modify cps
+            s.control_points /= 2
+            assert c.np.allclose(orig.sample(res) / 2, s.sample(res))
+
+    def test_inplace_change_weights(self):
+        """test inplace change of weights by compareing quarter circle"""
+        n_q_circle = c.n2p2d_quarter_circle()
+        res = [4] * 2
+        # init rational
+        n = c.splinepy.NURBS(**n_q_circle)
+        kvs = n_q_circle.pop("knot_vectors")
+        r = c.splinepy.RationalBezier(**n_q_circle)
+        # init non-rational
+        n_q_circle.pop("weights")
+        b = c.splinepy.BSpline(**n_q_circle, knot_vectors=kvs)
+        z = c.splinepy.Bezier(**n_q_circle)
+
+        # make sure they aren't the same
+        assert not c.np.allclose(b.sample(res), n.sample(res))
+        assert not c.np.allclose(z.sample(res), r.sample(res))
+
+        # modify weights of rational splines
+        for rs in (n, r):
+            # set them all to 1
+            rs.weights[abs(rs.weights - 1.0) > 1e-10] = 1.0
+
+        # now, they should be the same
+        assert c.np.allclose(b.sample(res), n.sample(res))
+        assert c.np.allclose(z.sample(res), r.sample(res))
+        assert c.np.allclose(b.sample(res), r.sample(res))
+        assert c.np.allclose(z.sample(res), n.sample(res))
+
+
+class CoordinateReferencesModificationTest(c.unittest.TestCase):
+    def test_coordinate_references(self):
+        dim = 3
+        res = [3] * dim
+        box_data = c.nd_box(dim)
+
+        n = c.splinepy.NURBS(**box_data)
+        weights = box_data.pop("weights")
+        b = c.splinepy.BSpline(**box_data)
+        box_data.pop("knot_vectors")
+        z = c.splinepy.Bezier(**box_data)
+        r = c.splinepy.RationalBezier(**box_data, weights=weights)
+
+        query = c.raster([[0] * dim, [1] * dim], res)
+
+        for s in (z, r, b, n):
+            orig = s.copy()
+
+            # assign all to one value - tests broadcast_scalar
+            # should be okay for rational splines,
+            # since weights are all one
+            s.coordinate_references[:] = 1.0
+            evaluated = s.evaluate(query)
+            assert c.np.allclose(evaluated, c.np.ones_like(evaluated))
+            assert not c.splinepy.spline.is_modified(s)
+
+            s = orig.copy()
+            dim_to_modify = int(dim - 1)
+            factor = 2.3
+            # inplace modification is not supported
+            s.coordinate_references[:, dim_to_modify] = (
+                s.coordinate_references.numpy()[:, dim_to_modify] * factor
+            )
+            ref_eval = query.copy()
+            ref_eval[:, dim_to_modify] *= factor
+            assert c.np.allclose(s.evaluate(query), ref_eval)
+
+            # let's do exactly the same, but see if it also updates
+            s = orig.copy()
+            s.coordinate_references[:, dim_to_modify] = (
+                s.control_points[:, dim_to_modify] * factor
+            )
+            assert c.np.allclose(
+                s.coordinate_references.numpy(), s.control_points
+            )
+            assert c.np.allclose(s.evaluate(query), ref_eval)
+
+    def test_coordinate_references_weight_handling(self):
+        """test if coordiante references reflect weights
+        and handles weight as expected is apply_weight is True."""
+
+        n_q_circle = c.n2p2d_quarter_circle()
+        res = [4] * 2
+        # init rational
+        n = c.splinepy.NURBS(**n_q_circle)
+        n_q_circle.pop("knot_vectors")
+        r = c.splinepy.RationalBezier(**n_q_circle)
+
+        for rs in (n, r):
+            orig_cps = c.np.array(n_q_circle["control_points"])
+            orig_ws = c.np.array(n_q_circle["weights"])
+
+            orig_rs = rs.copy()
+            # check if references are actually weighted
+            assert c.np.allclose(
+                rs.coordinate_references.numpy(), orig_cps * orig_ws
+            )
+
+            # explicitly set apply_weight to False
+            rs.coordinate_references.apply_weight = False
+            rs.coordinate_references[:] = orig_cps
+            # this will result in unweighted reference
+            assert c.np.allclose(rs.coordinate_references.numpy(), orig_cps)
+            # but this means it won't be halfhalf circle
+            assert not c.np.allclose(rs.sample(res), orig_rs.sample(res))
+            # explicitly set apply_weight to True
+            rs = orig_rs.copy()
+            rs.coordinate_references.apply_weight = True
+            weighted = rs.coordinate_references.numpy()
+            rs.coordinate_references[:] = orig_cps  # this should apply weight
+
+            assert c.np.allclose(rs.coordinate_references.numpy(), weighted)
+            assert c.np.allclose(rs.control_points, orig_cps)
+
+            # this will result in same eval
+            assert c.np.allclose(rs.sample(res), orig_rs.sample(res))
+
+
+if __name__ == "__main__":
+    c.unittest.main()


### PR DESCRIPTION
# Overview
- you can now have direct access to underlying cpp coordinates. Don't really have to use it all the time, but if you have a certain operation that uses high dim / high order splines, and need to change only control points, this may save you some time.  Doesn't support inplace operations. 
- Only create local trackable copies on demand. sometimes, there are times where we never need them
- add small set of test utils in tests/common.py


## Addressed issues
*  there are some use cases where cps change a lot, but this always recreates core spline and for complex splines, that's expensive (especially with the approach of SplineLib's creation).
* copied properties would always have modified flags

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
