### PR TITLE
add cartesian prod

### DIFF
--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -2,6 +2,7 @@
 
 Helps helpee to manage data. Some useful data structures.
 """
+from itertools import accumulate, chain, repeat
 
 import numpy as np
 
@@ -261,3 +262,55 @@ def enforce_contiguous_values(dict_):
         dict_with_contiguous[key] = value
 
     return dict_with_contiguous
+
+
+def cartesian_product(arrays, reverse=True):
+    """
+    Fast Cartesian product.
+    Adapted from stackoverflow entry:
+    https://stackoverflow.com/questions/11144513/
+    cartesian-product-of-x-and-y-array-points-into-single-array-of-2d-points/
+    49445693#49445693
+    Answer from `Paul Panzer`.
+
+    In splinepy, we use the ordering, where lowest dimension changes fastest.
+    Thus, a reverse option.
+
+    Parameters
+    ----------
+    arrays: tuple or list
+      tuple or list of array-like
+    reverse: bool
+      Default is True. Reverses order of fastest iterating dimension.
+      If False, highest indexed dimension iterates fastest.
+
+    Returns
+    -------
+    cartesian: (n, len(arrays)) np.ndarray
+    """
+    n_arr = len(arrays)
+
+    shape = *map(len, arrays), n_arr
+    dtype = np.result_type(*arrays)
+    cartesian = np.empty(shape, dtype=dtype)
+
+    # for reverse, use view of reverse ordered arrays
+    # plus, view of reverse ordered cartesian
+    if reverse:
+        arrays = arrays[::-1]
+        _cartesian = cartesian[..., ::-1]
+    else:
+        _cartesian = cartesian
+
+    dim_reducing_views = (
+        *accumulate(
+            chain((_cartesian,), repeat(0, n_arr - 1)), np.ndarray.__getitem__
+        ),
+    )
+    idx = slice(None), *repeat(None, n_arr - 1)
+    for i in range(n_arr - 1, 0, -1):
+        dim_reducing_views[i][..., i] = arrays[i][idx[: n_arr - i]]
+        dim_reducing_views[i - 1][1:] = dim_reducing_views[i]
+    _cartesian[..., 0] = arrays[0][idx]
+
+    return cartesian.reshape(-1, n_arr)

--- a/tests/test_cartesian.py
+++ b/tests/test_cartesian.py
@@ -1,0 +1,42 @@
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+from itertools import product
+
+class CartesianProductTest(c.unittest.TestCase):
+    def test_cartesian_product(self):
+        """
+        Test cartesian product test
+        """
+        # define some array
+        a = c.np.array([0, .5, 1])
+
+        def ref(arrays, reverse):
+            """create reference answers using itertools.product"""
+            
+            prod = c.np.array(list(product(*arrays)))
+            if reverse:
+                return prod[:, ::-1]
+            else:
+                return prod
+
+        # test cartesian product
+        for d in (1,2,3,4,5,6,7,8,9,10):
+            in_arr = [a] * d
+            assert c.np.allclose(
+                ref(in_arr, False),
+                c.splinepy.utils.data.cartesian_product(in_arr, False)
+            ), f"{d}-dim failed"
+
+        # test reversed dim - what's often used in lib
+        for d in (1,2,3,4,5,6,7,8,9,10):
+            in_arr = [a] * d
+            assert c.np.allclose(
+                ref(in_arr, True),
+                c.splinepy.utils.data.cartesian_product(in_arr, True)
+            ), f"{d}-dim failed"
+
+if __name__ == "__main__":
+    c.unittest.main()

--- a/tests/test_cartesian.py
+++ b/tests/test_cartesian.py
@@ -5,17 +5,18 @@ except BaseException:
 
 from itertools import product
 
+
 class CartesianProductTest(c.unittest.TestCase):
     def test_cartesian_product(self):
         """
         Test cartesian product test
         """
         # define some array
-        a = c.np.array([0, .5, 1])
+        a = c.np.array([0, 0.5, 1])
 
         def ref(arrays, reverse):
             """create reference answers using itertools.product"""
-            
+
             prod = c.np.array(list(product(*arrays)))
             if reverse:
                 return prod[:, ::-1]
@@ -23,20 +24,21 @@ class CartesianProductTest(c.unittest.TestCase):
                 return prod
 
         # test cartesian product
-        for d in (1,2,3,4,5,6,7,8,9,10):
+        for d in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10):
             in_arr = [a] * d
             assert c.np.allclose(
                 ref(in_arr, False),
-                c.splinepy.utils.data.cartesian_product(in_arr, False)
+                c.splinepy.utils.data.cartesian_product(in_arr, False),
             ), f"{d}-dim failed"
 
         # test reversed dim - what's often used in lib
-        for d in (1,2,3,4,5,6,7,8,9,10):
+        for d in (1, 2, 3, 4, 5, 6, 7, 8, 9, 10):
             in_arr = [a] * d
             assert c.np.allclose(
                 ref(in_arr, True),
-                c.splinepy.utils.data.cartesian_product(in_arr, True)
+                c.splinepy.utils.data.cartesian_product(in_arr, True),
             ), f"{d}-dim failed"
+
 
 if __name__ == "__main__":
     c.unittest.main()


### PR DESCRIPTION
# Overview
Adds a function for [cartesian product](https://en.wikipedia.org/wiki/Cartesian_product) as well as a version that performs reversed version of the product. Adapted from a [stackoverflow](https://stackoverflow.com/questions/11144513/cartesian-product-of-x-and-y-array-points-into-single-array-of-2d-points/49445693#49445693)'s discussion.

## Showcase
A short / one-liner example to highlight the (new) feature
```python
>>> import numpy as np
>>> import splinepy
>>> a = np.array([0,.5,1])
>>> splinepy.utils.data.cartesian_product((a,a))
array([[0. , 0. ],
       [0.5, 0. ],
       [1. , 0. ],
       [0. , 0.5],
       [0.5, 0.5],
       [1. , 0.5],
       [0. , 1. ],
       [0.5, 1. ],
       [1. , 1. ]])
```

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
