### PR TITLE
helpme & multi index 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,7 @@ setup(
         "splinepy",
         "splinepy.io",
         "splinepy.utils",
+        "splinepy.helpme",
     ],
     install_requires=[
         "numpy",

--- a/splinepy/__init__.py
+++ b/splinepy/__init__.py
@@ -1,6 +1,7 @@
 from splinepy import (
     bezier,
     bspline,
+    helpme,
     io,
     load,
     multipatch,
@@ -10,7 +11,6 @@ from splinepy import (
     spline,
     splinepy_core,
     utils,
-    helpme,
 )
 from splinepy._version import __version__
 from splinepy.bezier import Bezier

--- a/splinepy/__init__.py
+++ b/splinepy/__init__.py
@@ -10,6 +10,7 @@ from splinepy import (
     spline,
     splinepy_core,
     utils,
+    helpme,
 )
 from splinepy._version import __version__
 from splinepy.bezier import Bezier
@@ -39,6 +40,7 @@ __all__ = [
     "splinepy_core",
     "utils",
     "settings",
+    "helpme",
     "Bezier",
     "BSpline",
     "Multipatch",

--- a/splinepy/helpme/__init__.py
+++ b/splinepy/helpme/__init__.py
@@ -1,0 +1,1 @@
+from splinepy.helpme import multi_index

--- a/splinepy/helpme/__init__.py
+++ b/splinepy/helpme/__init__.py
@@ -1,1 +1,3 @@
 from splinepy.helpme import multi_index
+
+__all__ = ["multi_index"]

--- a/splinepy/helpme/multi_index.py
+++ b/splinepy/helpme/multi_index.py
@@ -9,6 +9,7 @@ class MultiIndex:
     Performs same task as `np.ravel_multi_index`. However, you can use it with
     __getitem__ like queries.
     """
+
     __slots__ = ("_raveled_indices", "_ndim")
     _ellipsis_type = type(Ellipsis)
 
@@ -22,7 +23,10 @@ class MultiIndex:
         grid_resolutions: array-like
         """
         if not isinstance(grid_resolutions, (tuple, list, np.ndarray)):
-            raise TypeError("grid_resolutions must be array-like type, not" f"{type(grid_resolutions)}")
+            raise TypeError(
+                "grid_resolutions must be array-like type, not"
+                f"{type(grid_resolutions)}"
+            )
 
         # create raveled indices
         raveled = np.arange(np.product(grid_resolutions), dtype="int32")
@@ -31,7 +35,6 @@ class MultiIndex:
         # grid's shape
         self._raveled_indices = raveled.reshape(*grid_resolutions[::-1])
         self._ndim = self._raveled_indices.ndim
-
 
     def __getitem__(self, args):
         """
@@ -70,5 +73,3 @@ class MultiIndex:
                 args.append(s)
 
         return self._raveled_indices.__getitem__(tuple(args[::-1])).ravel()
-
-

--- a/splinepy/helpme/multi_index.py
+++ b/splinepy/helpme/multi_index.py
@@ -1,0 +1,74 @@
+"""
+Helps you find control point ids.
+"""
+import numpy as np
+
+
+class MultiIndex:
+    """
+    Performs same task as `np.ravel_multi_index`. However, you can use it with
+    __getitem__ like queries.
+    """
+    __slots__ = ("_raveled_indices", "_ndim")
+    _ellipsis_type = type(Ellipsis)
+
+    def __init__(self, grid_resolutions):
+        """
+        Initialize using grid's resolution per dimension. For splines, use
+        `Spline.control_mesh_resolutions`.
+
+        Parameters
+        ----------
+        grid_resolutions: array-like
+        """
+        if not isinstance(grid_resolutions, (tuple, list, np.ndarray)):
+            raise TypeError("grid_resolutions must be array-like type, not" f"{type(grid_resolutions)}")
+
+        # create raveled indices
+        raveled = np.arange(np.product(grid_resolutions), dtype="int32")
+
+        # to allow general __getitem__ like query, turn them into
+        # grid's shape
+        self._raveled_indices = raveled.reshape(*grid_resolutions[::-1])
+        self._ndim = self._raveled_indices.ndim
+
+
+    def __getitem__(self, args):
+        """
+        Retuns raveled indices.
+
+        Parameters
+        ----------
+        args: int, slice, ellipsis, np.newaxis, array-like
+          Any input np.ndarray.__getitem__ would take is valid.
+
+        Returnes
+        --------
+        raveled_indices: np.ndarray
+          raveled indices, which are in a raveled array.
+        """
+        # only interested in __iter__, not __getitem__
+        if not hasattr(args, "__iter__"):
+            args = [args]
+        else:
+            args = list(args)
+
+        # Ellipsis? don't do anything
+        # (Ellipsis not in args) raises ValueError during comparison
+        # if one of them is an array. so, loop and check if any of the entry
+        # are Ellipsis
+        fill_slices = True
+        for a in args:
+            if isinstance(a, self._ellipsis_type):
+                fill_slices = False
+                break
+
+        # no ellipsis? fill in with slices
+        if fill_slices:
+            s = slice(None)
+            for _ in range(len(args), self._ndim):
+                args.append(s)
+
+        return self._raveled_indices.__getitem__(tuple(args[::-1])).ravel()
+
+

--- a/splinepy/helpme/multi_index.py
+++ b/splinepy/helpme/multi_index.py
@@ -10,8 +10,7 @@ class MultiIndex:
     __getitem__ like queries.
     """
 
-    __slots__ = ("_raveled_indices", "_ndim")
-    _ellipsis_type = type(Ellipsis)
+    __slots__ = ("_raveled_indices",)
 
     def __init__(self, grid_resolutions):
         """
@@ -33,8 +32,7 @@ class MultiIndex:
 
         # to allow general __getitem__ like query, turn them into
         # grid's shape
-        self._raveled_indices = raveled.reshape(*grid_resolutions[::-1])
-        self._ndim = self._raveled_indices.ndim
+        self._raveled_indices = raveled.reshape(*grid_resolutions, order="F")
 
     def __getitem__(self, args):
         """
@@ -50,26 +48,4 @@ class MultiIndex:
         raveled_indices: np.ndarray
           raveled indices, which are in a raveled array.
         """
-        # only interested in __iter__, not __getitem__
-        if not hasattr(args, "__iter__"):
-            args = [args]
-        else:
-            args = list(args)
-
-        # Ellipsis? don't do anything
-        # (Ellipsis not in args) raises ValueError during comparison
-        # if one of them is an array. so, loop and check if any of the entry
-        # are Ellipsis
-        fill_slices = True
-        for a in args:
-            if isinstance(a, self._ellipsis_type):
-                fill_slices = False
-                break
-
-        # no ellipsis? fill in with slices
-        if fill_slices:
-            s = slice(None)
-            for _ in range(len(args), self._ndim):
-                args.append(s)
-
-        return self._raveled_indices.__getitem__(tuple(args[::-1])).ravel()
+        return self._raveled_indices.__getitem__(args).T.ravel()

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 import numpy as np
 
-from splinepy import io, settings
+from splinepy import helpme, io, settings
 from splinepy import splinepy_core as core
 from splinepy import utils
 from splinepy._base import SplinepyBase
@@ -1117,6 +1117,31 @@ class Spline(SplinepyBase, core.CoreSpline):
         )
 
         return self._data["coordinate_references"]
+
+    @property
+    def multi_index(self):
+        """
+        Easy control point / weights access using (unraveled) multi index.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        multi_index_helper: MultiIndex
+        """
+        mi = self._data.get("multi_index", None)
+        if mi is not None:
+            return mi
+
+        # not stored, create one
+        # this is okay to be copied together in copy()
+        self._data["multi_index"] = helpme.multi_index.MultiIndex(
+            self.control_mesh_resolutions
+        )
+
+        return self._data["multi_index"]
 
     @property
     def weights(self):

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1122,6 +1122,8 @@ class Spline(SplinepyBase, core.CoreSpline):
     def multi_index(self):
         """
         Easy control point / weights access using (unraveled) multi index.
+        Useful for getting indices if you want to "slice" a control mesh,
+        or find ids that relate to a certain boundary.
 
         Parameters
         ----------

--- a/tests/test_multi_index.py
+++ b/tests/test_multi_index.py
@@ -10,23 +10,22 @@ class MultiIndexTest(c.unittest.TestCase):
         Test MultiIndex using a round trip of np.ravel_multi_index
         """
         # 4d? can actually do anything
-        for d in range(2, 10+1):
+        for d in range(2, 10 + 1):
             resolutions = c.np.random.randint(2, 10, size=d)
 
             multi = c.splinepy.helpme.multi_index.MultiIndex(resolutions)
 
-            # number of ids
-            n_ids = int(c.np.product(resolutions))
-
             # test individual id query
-            n_q = 3 # number of queries
+            n_q = 3  # number of queries
             query = [c.np.random.randint(0, r, size=n_q) for r in resolutions]
 
             # test index round trip
             # note reversed order - alternatively this should also be the same:
             # c.np.ravel_multi_index(query, resolutions, order="F")
-            ref_raveled = c.np.ravel_multi_index(query[::-1], resolutions[::-1])
-            to_test = multi[tuple(query)] # can't unpack inside []
+            ref_raveled = c.np.ravel_multi_index(
+                query[::-1], resolutions[::-1]
+            )
+            to_test = multi[tuple(query)]  # can't unpack inside []
             assert c.np.array_equal(ref_raveled, to_test)
 
             # test first and last slice that's orthogonal to the last dimension
@@ -46,23 +45,17 @@ class MultiIndexTest(c.unittest.TestCase):
             full_ids = c.np.arange(c.np.product(resolutions))
 
             # first slice
-            ref_raveled = full_ids[0::resolutions[0]]
-            to_test = multi[0,...]
+            ref_raveled = full_ids[0 :: resolutions[0]]
+            to_test = multi[0, ...]
             assert c.np.array_equal(ref_raveled, to_test)
             # syntex check - this should hold in np.ndarray.__getitem__ syntax
-            to_rest = multi[0, :]
+            to_test = multi[0, :]
             assert c.np.array_equal(ref_raveled, to_test)
 
             # last slice
-            ref_raveled = full_ids[int(resolutions[0]-1)::resolutions[0]]
+            ref_raveled = full_ids[int(resolutions[0] - 1) :: resolutions[0]]
             to_test = multi[-1, ...]
             assert c.np.array_equal(ref_raveled, to_test)
-            
- 
-
-
-            
-            
 
 
 if __name__ == "__main__":

--- a/tests/test_multi_index.py
+++ b/tests/test_multi_index.py
@@ -1,0 +1,69 @@
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+
+class MultiIndexTest(c.unittest.TestCase):
+    def test_multi_index(self):
+        """
+        Test MultiIndex using a round trip of np.ravel_multi_index
+        """
+        # 4d? can actually do anything
+        for d in range(2, 10+1):
+            resolutions = c.np.random.randint(2, 10, size=d)
+
+            multi = c.splinepy.helpme.multi_index.MultiIndex(resolutions)
+
+            # number of ids
+            n_ids = int(c.np.product(resolutions))
+
+            # test individual id query
+            n_q = 3 # number of queries
+            query = [c.np.random.randint(0, r, size=n_q) for r in resolutions]
+
+            # test index round trip
+            # note reversed order - alternatively this should also be the same:
+            # c.np.ravel_multi_index(query, resolutions, order="F")
+            ref_raveled = c.np.ravel_multi_index(query[::-1], resolutions[::-1])
+            to_test = multi[tuple(query)] # can't unpack inside []
+            assert c.np.array_equal(ref_raveled, to_test)
+
+            # test first and last slice that's orthogonal to the last dimension
+            # first slice
+            ref_raveled = c.np.arange(c.np.product(resolutions[:-1]))
+            to_test = multi[..., 0]
+            assert c.np.array_equal(ref_raveled, to_test)
+
+            # last slice
+            upper = c.np.product(resolutions)
+            lower = upper - c.np.product(resolutions[:-1])
+            ref_raveled = c.np.arange(lower, upper)
+            to_test = multi[..., -1]
+            assert c.np.array_equal(ref_raveled, to_test)
+
+            # test first and last slice that's orthogonal to the first dim
+            full_ids = c.np.arange(c.np.product(resolutions))
+
+            # first slice
+            ref_raveled = full_ids[0::resolutions[0]]
+            to_test = multi[0,...]
+            assert c.np.array_equal(ref_raveled, to_test)
+            # syntex check - this should hold in np.ndarray.__getitem__ syntax
+            to_rest = multi[0, :]
+            assert c.np.array_equal(ref_raveled, to_test)
+
+            # last slice
+            ref_raveled = full_ids[int(resolutions[0]-1)::resolutions[0]]
+            to_test = multi[-1, ...]
+            assert c.np.array_equal(ref_raveled, to_test)
+            
+ 
+
+
+            
+            
+
+
+if __name__ == "__main__":
+    c.unittest.main()


### PR DESCRIPTION
# Overview
Adds `MultiIndex` class that helps to find global ids for data that's sequentially listed, but actually representing grid-like structure. In other words, helps find control point ids using numpy's `__getitem__` syntax. name multi_index is motivated by numpy's function [np.ravel_multi_index](https://numpy.org/doc/stable/reference/generated/numpy.ravel_multi_index.html#numpy.ravel_multi_index). This way you don't have to use `%` or `//`.  
Also, as discussed, added `helpme` module. Will be a place to implement functions that helps some uses cases with splines. This means some of the functions / classes implemented in `spline.py` will be moved there in next PR. It won't change any behavior of `Spline` class.

## Addressed issues
*  Easy access to global control point ids (raveled index) wanted

## Showcase
A short / one-liner example to highlight the (new) feature
```python
import splinepy

...
boundary0_cps = bspline.cps[bspline.multi_index[0, :]]

# as long as nothing changes with in bspline, you can just get ref
multi_index = bspline.multi_index

# boundary 7 would be 4th dim, first slice
boundary7_cps = bspline.cps[multi_index[:, :, :, 0, ...]]

# since this follow's np's  getitem syntax, you don't need the ellipsis at the end 
boundary7_cps_no_ellipsis = bspline.cps[multi_index[:, :, :, 0]]
assert np.allclose(boundary7_cps, boundary7_cps_no_ellipsis)
```


## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s) #126 will use this and add it to examples
* [x] Added test(s)
