### PR TITLE
Uniform return types in IO

### DIFF
--- a/splinepy/io/__init__.py
+++ b/splinepy/io/__init__.py
@@ -1,12 +1,13 @@
-from splinepy.io import gismo, iges, irit, json, mfem, npz, vtk, xml
+from splinepy.io import gismo, iges, ioutils, irit, json, mfem, npz, vtk, xml
 
 __all__ = [
-    "mfem",
-    "json",
-    "npz",
-    "xml",
-    "iges",
-    "irit",
-    "vtk",
     "gismo",
+    "iges",
+    "ioutils",
+    "irit",
+    "json",
+    "mfem",
+    "npz",
+    "vtk",
+    "xml",
 ]

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -2,6 +2,7 @@
 iges io.
 """
 from splinepy import splinepy_core
+from splinepy.io import ioutils
 
 
 def load(fname):
@@ -14,9 +15,10 @@ def load(fname):
 
     Returns
     --------
-    dict_splines: list
+    splines: list
+      Spline Type defined in NAME_TO_TYPE
     """
-    return splinepy_core.read_iges(fname)
+    return ioutils.dict_to_spline(splinepy_core.read_iges(fname))
 
 
 def export(fname, splines):

--- a/splinepy/io/ioutils.py
+++ b/splinepy/io/ioutils.py
@@ -97,3 +97,50 @@ def abs_fname(fname):
         fname = os.path.abspath(fname)
 
     return fname
+
+
+def strip_tabs(fname, overwrite=True, tab_expand=2):
+    """Replaces tabs in a text file with spaces
+
+    Parameters
+    ----------
+    fname : string
+      Filename
+    overwrite : bool
+      Inplace modification, otherwise new file with prefix copy is created
+    tab_expand : int
+      Determines how many spaces to be set for each tab
+
+    Returns
+    -------
+    None
+    """
+    if overwrite:
+        out_name = fname
+    else:
+        out_name = "copy." + fname
+    with open(fname) as inputFile:
+        file_contents = inputFile.read()
+        file_contents.replace("\t", " " * tab_expand)
+    with open(out_name, "w") as exportFile:
+        exportFile.write(file_contents)
+
+
+def dict_to_spline(spline_dictionary):
+    """Create a list of splines from a list of dictionaries
+
+    Parameters
+    ----------
+    spline_dictionary : list
+      List of dictionaries
+
+    Returns
+    -------
+    spline_lits : list
+      List of splines in called format (NAME_TO_TYPE)
+    """
+    from splinepy.settings import NAME_TO_TYPE
+    from splinepy.spline import Spline
+
+    spline_list = [Spline(**spd) for spd in spline_dictionary]
+    return [NAME_TO_TYPE[spd.name](spline=spd) for spd in spline_list]

--- a/splinepy/io/ioutils.py
+++ b/splinepy/io/ioutils.py
@@ -99,7 +99,7 @@ def abs_fname(fname):
     return fname
 
 
-def strip_tabs(fname, overwrite=True, tab_expand=2):
+def expand_tabs(fname, overwrite=True, tab_expand=2):
     """Replaces tabs in a text file with spaces
 
     Parameters
@@ -148,4 +148,4 @@ def dict_to_spline(spline_dictionary):
     from splinepy.spline import Spline
 
     spline_list = [Spline(**spd) for spd in spline_dictionary]
-    return [NAME_TO_TYPE[spd.name](spline=spd) for spd in spline_list]
+    return [NAME_TO_TYPE[spl.name](spline=spl) for spl in spline_list]

--- a/splinepy/io/ioutils.py
+++ b/splinepy/io/ioutils.py
@@ -121,7 +121,7 @@ def strip_tabs(fname, overwrite=True, tab_expand=2):
         out_name = "copy." + fname
     with open(fname) as inputFile:
         file_contents = inputFile.read()
-        file_contents.replace("\t", " " * tab_expand)
+    file_contents.replace("\t", " " * tab_expand)
     with open(out_name, "w") as exportFile:
         exportFile.write(file_contents)
 

--- a/splinepy/io/ioutils.py
+++ b/splinepy/io/ioutils.py
@@ -115,10 +115,15 @@ def strip_tabs(fname, overwrite=True, tab_expand=2):
     -------
     None
     """
+    import os.path as op
+
+    # Safe guard in case an absolut path is handed to the function
     if overwrite:
         out_name = fname
     else:
-        out_name = "copy." + fname
+        dir, file = op.split(fname)
+        out_name = dir + "copy_" + file
+
     with open(fname) as inputFile:
         file_contents = inputFile.read()
     file_contents.replace("\t", " " * tab_expand)

--- a/splinepy/io/irit.py
+++ b/splinepy/io/irit.py
@@ -22,7 +22,7 @@ def load(fname, expand_tabs=True):
     splines: list
       Spline Type defined in NAME_TO_TYPE
     """
-    if save_replace:
+    if expand_tabs:
         ioutils.expand_tabs(fname)
     return ioutils.dict_to_spline(splinepy_core.read_irit(fname))
 

--- a/splinepy/io/irit.py
+++ b/splinepy/io/irit.py
@@ -2,9 +2,10 @@
 irit io.
 """
 from splinepy import splinepy_core
+from splinepy.io import ioutils
 
 
-def load(fname):
+def load(fname, save_replace=True):
     """
     Read spline in `.itd` form.
 
@@ -15,8 +16,11 @@ def load(fname):
     Returns
     --------
     splines: list
+      Spline Type defined in NAME_TO_TYPE
     """
-    return splinepy_core.read_irit(fname)
+    if save_replace:
+        ioutils.strip_tabs(fname)
+    return ioutils.dict_to_spline(splinepy_core.read_irit(fname))
 
 
 def export(fname, splines):

--- a/splinepy/io/irit.py
+++ b/splinepy/io/irit.py
@@ -5,7 +5,7 @@ from splinepy import splinepy_core
 from splinepy.io import ioutils
 
 
-def load(fname, save_replace=True):
+def load(fname, expand_tabs=True):
     """
     Read spline in `.itd` form.
 
@@ -14,7 +14,7 @@ def load(fname, save_replace=True):
     fname: str
 
       Path to the irit file to read in.
-    save_replace: bool
+    expand_tabs: bool
       Replace all tabs in the irit file. Defaults to True.
 
     Returns
@@ -23,7 +23,7 @@ def load(fname, save_replace=True):
       Spline Type defined in NAME_TO_TYPE
     """
     if save_replace:
-        ioutils.strip_tabs(fname)
+        ioutils.expand_tabs(fname)
     return ioutils.dict_to_spline(splinepy_core.read_irit(fname))
 
 

--- a/splinepy/io/irit.py
+++ b/splinepy/io/irit.py
@@ -13,6 +13,10 @@ def load(fname, save_replace=True):
     -----------
     fname: str
 
+      Path to the irit file to read in.
+    save_replace: bool
+      Replace all tabs in the irit file. Defaults to True.
+
     Returns
     --------
     splines: list

--- a/splinepy/io/xml.py
+++ b/splinepy/io/xml.py
@@ -4,6 +4,7 @@ Keyword follows RWTH CATS's spline format.
 Possiblely will be turned into pure python io.
 """
 from splinepy import splinepy_core
+from splinepy.io import ioutils
 
 
 def load(fname):
@@ -18,8 +19,9 @@ def load(fname):
     Returns
     --------
     splines: list
+      Spline Type defined in NAME_TO_TYPE
     """
-    return splinepy_core.read_xml(fname)
+    return ioutils.dict_to_spline(splinepy_core.read_xml(fname))
 
 
 def export(fname, splines):


### PR DESCRIPTION
# Overview
Some of the io routines returned dictionaries of spline data and others returned splines. Now no longer.

Also - save input for irit files

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
