### PR TITLE
Add sparse matrix to iga examples

### DIFF
--- a/examples/iga/collocation_laplace_problem.py
+++ b/examples/iga/collocation_laplace_problem.py
@@ -9,8 +9,9 @@ The refinement will only be applied to the solution field, to make the
 calculations more efficient
 """
 import numpy as np
-from scipy.sparse import csc_matrix
 import scipy
+from scipy.sparse import csc_matrix
+
 import splinepy as sp
 
 try:
@@ -71,9 +72,16 @@ laplacian = np.zeros(
 )
 
 n_dofs = evaluation_points.shape[0]
-row_ids = np.arange(support.shape[0]).reshape(-1,1).repeat(support.shape[1], axis=1).flatten()
+row_ids = (
+    np.arange(support.shape[0])
+    .reshape(-1, 1)
+    .repeat(support.shape[1], axis=1)
+    .flatten()
+)
 col_ids = support.flatten()
-laplacian = scipy.sparse.csc_array((bf_laplacian.flatten(), (row_ids, col_ids)), shape=(n_dofs, n_dofs))
+laplacian = scipy.sparse.csc_array(
+    (bf_laplacian.flatten(), (row_ids, col_ids)), shape=(n_dofs, n_dofs)
+)
 
 # Evaluate RHS function
 physical_points = geometry.evaluate(evaluation_points)
@@ -94,7 +102,9 @@ laplacian[indices, indices] = 1
 rhs[indices] = 0
 
 # Solve linear system
-solution_field.control_points = scipy.sparse.linalg.spsolve(-laplacian, rhs).reshape(-1, 1)
+solution_field.control_points = scipy.sparse.linalg.spsolve(
+    -laplacian, rhs
+).reshape(-1, 1)
 
 if has_gus:
     geometry = gus.spline.BSpline(spline=geometry)

--- a/examples/iga/galerkin_laplace_problem.py
+++ b/examples/iga/galerkin_laplace_problem.py
@@ -143,7 +143,9 @@ system_matrix[indices, :] = 0
 system_matrix[indices, indices] = 1
 system_rhs[indices] = 0
 
-solution_field.control_points = linalg.spsolve(system_matrix.tocsc(), system_rhs).reshape(-1, 1)
+solution_field.control_points = linalg.spsolve(
+    system_matrix.tocsc(), system_rhs
+).reshape(-1, 1)
 
 if has_gus:
     geometry = gus.spline.BSpline(spline=geometry)

--- a/examples/iga/galerkin_laplace_problem.py
+++ b/examples/iga/galerkin_laplace_problem.py
@@ -9,6 +9,7 @@ The refinement will only be applied to the solution field, to make the
 calculations more efficient
 """
 import numpy as np
+from scipy.sparse import lil_matrix, linalg
 
 import splinepy as sp
 
@@ -85,7 +86,7 @@ weights = np.prod(weights, axis=1)
 # Assemble individual elements
 ukv = solution_field.unique_knots
 n_dofs = solution_field.control_points.shape[0]
-system_matrix = np.zeros((n_dofs, n_dofs))
+system_matrix = lil_matrix((n_dofs, n_dofs))
 system_rhs = np.zeros(n_dofs)
 mapper = solution_field.mapper(reference=geometry)
 
@@ -142,10 +143,7 @@ system_matrix[indices, :] = 0
 system_matrix[indices, indices] = 1
 system_rhs[indices] = 0
 
-# Solve linear system
-solution_field.control_points = np.linalg.solve(
-    system_matrix, system_rhs
-).reshape(-1, 1)
+solution_field.control_points = linalg.spsolve(system_matrix.tocsc(), system_rhs).reshape(-1, 1)
 
 if has_gus:
     geometry = gus.spline.BSpline(spline=geometry)


### PR DESCRIPTION
# Overview
In order to reduce storage and increase performance, a sparse matrix from scipy is used in the iga examples instead of numpy.matrix.

## Addressed issues
--

## Showcase
A short / one-liner example to highlight the (new) feature
```
laplacian = scipy.sparse.csc_array((bf_laplacian.flatten(), (row_ids, col_ids)), shape=(n_dofs, n_dofs))

solution_field.control_points = scipy.sparse.linalg.spsolve(-laplacian, rhs).reshape(-1, 1)

```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
