### PR TITLE
Ft list compose

### DIFF
--- a/cpp/splinepy/py/py_spline_extensions.hpp
+++ b/cpp/splinepy/py/py_spline_extensions.hpp
@@ -86,11 +86,11 @@ inline std::shared_ptr<PySpline> Add(const std::shared_ptr<PySpline>& a,
 
 /// spline composition - currently only for bezier
 inline std::shared_ptr<PySpline>
-Compose(const std::shared_ptr<PySpline>& inner,
-        const std::shared_ptr<PySpline>& outer) {
+Compose(const std::shared_ptr<PySpline>& outer,
+        const std::shared_ptr<PySpline>& inner) {
   // performs runtime checks and throws error
   return std::make_shared<PySpline>(
-      inner->Core()->SplinepyCompose(outer->Core()));
+      outer->Core()->SplinepyCompose(inner->Core()));
 }
 
 /// spline derivative spline

--- a/cpp/splinepy/py/py_spline_list.hpp
+++ b/cpp/splinepy/py/py_spline_list.hpp
@@ -735,7 +735,18 @@ inline void add_spline_list_pyclass(py::module& m) {
            py::arg("spline_list"),
            py::arg("nthreads"),
            py::arg("same_parametric_bounds"),
-           py::arg("check_dims"));
+           py::arg("check_dims"))
+      .def("compose",
+           &ListCompose,
+           py::arg("inner_splines"),
+           py::arg("cartesian_product"),
+           py::arg("nthreads"))
+      .def("composition_derivatives",
+           &ListCompositionDerivative,
+           py::arg("inner_splines"),
+           py::arg("inner_derivatives"),
+           py::arg("cartesian_product"),
+           py::arg("nthreads"));
 }
 
 } // namespace splinepy::py

--- a/cpp/splinepy/py/py_spline_list.hpp
+++ b/cpp/splinepy/py/py_spline_list.hpp
@@ -737,7 +737,8 @@ inline void add_spline_list_pyclass(py::module& m) {
 
   auto list_module = m.def_submodule(
       "lists",
-      "Module for list based queries with multithreading capabilities.");
+      "Module for list based queries with multithreading capabilities. Please "
+      "make sure splines don't have any inplace modifications.");
 
   list_module
       .def("raise_dim_mismatch",

--- a/cpp/splinepy/py/py_spline_list.hpp
+++ b/cpp/splinepy/py/py_spline_list.hpp
@@ -534,7 +534,7 @@ CoreSplineVectorCompose(const CoreSplineVector& outer_splines,
       }
     };
     splinepy::utils::NThreadExecution(compose_step,
-                                      n_outer,
+                                      n_total,
                                       nthreads,
                                       splinepy::utils::NThreadQueryType::Step);
   }

--- a/cpp/splinepy/splines/rational_bezier.hpp
+++ b/cpp/splinepy/splines/rational_bezier.hpp
@@ -522,7 +522,7 @@ public:
 
   virtual std::shared_ptr<SplinepyBase>
   SplinepyExtractDim(const int& phys_dim) const {
-    return std::make_shared<Bezier<para_dim, 1>>(
+    return std::make_shared<RationalBezier<para_dim, 1>>(
         Base_::ExtractDimension(static_cast<std::size_t>(phys_dim)));
   }
 

--- a/cpp/splinepy/splines/splinepy_base.cpp
+++ b/cpp/splinepy/splines/splinepy_base.cpp
@@ -364,8 +364,8 @@ bool SplinepyBase::SplinepySplineNameMatches(const SplinepyBase& a,
       splinepy::utils::PrintAndThrowError(description,
                                           "Spline name mismatch -"
                                           "Spline0:",
-                                          "/",
                                           a.SplinepySplineName(),
+                                          "/",
                                           "Spline1:",
                                           b.SplinepySplineName());
     }
@@ -384,8 +384,8 @@ bool SplinepyBase::SplinepyParaDimMatches(const SplinepyBase& a,
           description,
           "Spline parametric dimension mismatch - "
           "Spline0:",
-          "/",
           a.SplinepyParaDim(),
+          "/",
           "Spline1:",
           b.SplinepyParaDim());
     }
@@ -404,8 +404,8 @@ bool SplinepyBase::SplinepyDimMatches(const SplinepyBase& a,
           description,
           "Spline parametric dimension mismatch - "
           "Spline0:",
-          "/",
           a.SplinepyDim(),
+          "/",
           "Spline1:",
           b.SplinepyDim());
     }

--- a/tests/test_spline_list.py
+++ b/tests/test_spline_list.py
@@ -178,7 +178,7 @@ class SplineListTest(c.unittest.TestCase):
         box3d.pop("knot_vectors")
         rbox3d = c.splinepy.RationalBezier(**box3d)
         box3d.pop("weights")
-        zbox3d = c.splinepy.Bezier(**box2d)
+        zbox3d = c.splinepy.Bezier(**box3d)
 
         outer = [zbox2d, rbox2d, zbox3d, rbox3d]
         # add some noise
@@ -191,61 +191,66 @@ class SplineListTest(c.unittest.TestCase):
         r2 = c.splinepy.RationalBezier(**c.r2p2d())
         r3 = c.splinepy.RationalBezier(**c.r3p3d())
 
-        return outer[:2], outer[2:], [z2, r2], [z3, r3]
-
-    def test_list_compose(self):
-        """check if list compose yield same spline as spline compose"""
-        pass
-
-    def _bezier_noisy_boxes_and_test_shapes(self):
-        # prepare boxes with some noise
-        box2d = c.nd_box(2)
-        box2d.pop("knot_vectors")
-        rbox2d = c.splinepy.RationalBezier(**box2d)
-        box2d.pop("weights")
-        zbox2d = c.splinepy.Bezier(**box2d)
-        box3d = c.nd_box(3)
-        box3d.pop("knot_vectors")
-        rbox3d = c.splinepy.RationalBezier(**box3d)
-        box3d.pop("weights")
-        zbox3d = c.splinepy.Bezier(**box2d)
-
-        outer = [zbox2d, rbox2d, zbox3d, rbox3d]
-        # add some noise
-        for o in outer:
-            o.cps = o.cps + c.np.random.normal(0, 0.025, o.cps.shape)
-
-        # test shapes
-        z2 = c.splinepy.Bezier(**c.z2p2d())
-        z3 = c.splinepy.Bezier(**c.z3p3d())
-        r2 = c.splinepy.RationalBezier(**c.r2p2d())
-        r3 = c.splinepy.RationalBezier(**c.r3p3d())
+        # fit into unit box
+        for bez in [z2, z3, r2, r3]:
+            # offset
+            bez.cps -= bez.cps.min(axis=0)
+            # scale
+            bez.cps = bez.cps * (1 / bez.cps.max(axis=0))
 
         return outer[:2], outer[2:], [z2, r2], [z3, r3]
 
     def test_list_compose(self):
         """check if list compose yield same spline as spline compose"""
         # prepare boxes with some noise
-        outer_2d, outer_3d, inner_2d, inner_3d = (
-            c.splinepy.splinepy_core.SplineList(beziers)
-            for beziers in self._bezier_noisy_boxes_and_test_shapes()
-        )
-
-        t = []
-        for beziers in self._bezier_noisy_boxes_and_test_shapes():
-            sl = c.splinepy.splinepy_core.SplineList(beziers)
-            print(sl[0])
-            t.append(sl)
+        (
+            outer_2d,
+            outer_3d,
+            inner_2d,
+            inner_3d,
+        ) = self._bezier_noisy_boxes_and_test_shapes()
 
         ref_composed = [o.compose(i) for o, i in zip(outer_2d, inner_2d)]
 
         # list compose
-        list_composed = outer_2d.compose(
-            inner_2d, cartesian_product=False, nthreads=2
+        list_composed = c.splinepy.splinepy_core.lists.compose(
+            outer_2d, inner_2d, cartesian_product=False, nthreads=2
+        )
+
+        # add 3d
+        ref_composed.extend([o.compose(i) for o, i in zip(outer_3d, inner_3d)])
+        list_composed.extend(
+            c.splinepy.splinepy_core.lists.compose(
+                outer_3d, inner_3d, cartesian_product=False, nthreads=2
+            )
         )
 
         for r, l in zip(ref_composed, list_composed):
-            assert c.are_splines_equal(r, l)
+            assert c.are_splines_equal(c.to_derived(r), c.to_derived(l))
+
+        # test cartesian
+        ref_composed = []
+        for o in outer_2d:
+            for i in inner_2d:
+                ref_composed.append(o.compose(i))
+        for o in outer_3d:
+            for i in inner_3d:
+                ref_composed.append(o.compose(i))
+
+        list_composed = c.splinepy.splinepy_core.lists.compose(
+            outer_2d, inner_2d, cartesian_product=True, nthreads=2
+        )
+        list_composed.extend(
+            c.splinepy.splinepy_core.lists.compose(
+                outer_3d, inner_3d, cartesian_product=True, nthreads=2
+            )
+        )
+
+        for r, l in zip(ref_composed, list_composed):
+            assert c.are_splines_equal(c.to_derived(r), c.to_derived(l))
+
+    def test_list_compose_derivatives(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/test_spline_list.py
+++ b/tests/test_spline_list.py
@@ -226,17 +226,16 @@ class SplineListTest(c.unittest.TestCase):
     def test_list_compose(self):
         """check if list compose yield same spline as spline compose"""
         # prepare boxes with some noise
-        outer_2d, outer_3d, inner_2d, inner_3d = [
+        outer_2d, outer_3d, inner_2d, inner_3d = (
             c.splinepy.splinepy_core.SplineList(beziers)
             for beziers in self._bezier_noisy_boxes_and_test_shapes()
-        ]
+        )
 
         t = []
         for beziers in self._bezier_noisy_boxes_and_test_shapes():
             sl = c.splinepy.splinepy_core.SplineList(beziers)
             print(sl[0])
             t.append(sl)
-
 
         ref_composed = [o.compose(i) for o, i in zip(outer_2d, inner_2d)]
 

--- a/tests/test_spline_list.py
+++ b/tests/test_spline_list.py
@@ -250,7 +250,52 @@ class SplineListTest(c.unittest.TestCase):
             assert c.are_splines_equal(c.to_derived(r), c.to_derived(l))
 
     def test_list_compose_derivatives(self):
-        pass
+        # prepare boxes with some noise
+        (
+            outer_2d,
+            outer_3d,
+            inner_2d,
+            inner_3d,
+        ) = self._bezier_noisy_boxes_and_test_shapes()
+
+        ref_composed = [o.composition_derivatives(i, i_d) for o, i, i_d in zip(outer_2d, inner_2d, inner_2d)]
+
+        # list compose
+        list_composed = c.splinepy.splinepy_core.lists.composition_derivatives(
+            outer_2d, inner_2d, inner_2d cartesian_product=False, nthreads=2
+        )
+
+        # add 3d
+        ref_composed.extend([o.composition_derivatives(i, i_d) for o, i, i_d in zip(outer_3d, inner_3d, inner_3d)])
+        list_composed.extend(
+            c.splinepy.splinepy_core.lists.compose(
+                outer_3d, inner_3d, inner_3d cartesian_product=False, nthreads=2
+            )
+        )
+
+        for r, l in zip(ref_composed, list_composed):
+            assert c.are_splines_equal(c.to_derived(r), c.to_derived(l))
+
+        # test cartesian
+        ref_composed = []
+        for o in outer_2d:
+            for i in inner_2d:
+                ref_composed.append(o.compose(i))
+        for o in outer_3d:
+            for i in inner_3d:
+                ref_composed.append(o.compose(i))
+
+        list_composed = c.splinepy.splinepy_core.lists.compose(
+            outer_2d, inner_2d, cartesian_product=True, nthreads=2
+        )
+        list_composed.extend(
+            c.splinepy.splinepy_core.lists.compose(
+                outer_3d, inner_3d, cartesian_product=True, nthreads=2
+            )
+        )
+
+        for r, l in zip(ref_composed, list_composed):
+            assert c.are_splines_equal(c.to_derived(r), c.to_derived(l))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview
* Adds `compose` and `composition_derivative` to list functions.
* `cartesian_product` option is added to avoid nested for loop. 
* Adds `NThreadQueryType` option to `NThreadExecution` to support "step" execution 
* fixes #148
* fixes #152

WIP - bindings and tests .......

## Addressed issues
* slow to loop in python

## Showcase
A short / one-liner example to highlight the (new) feature
```python
import splinepy
from splinepy.splinepy_core import lists

outer_splines = [<list-of-splines0>]
inner_splines = [<list-of-splines1>]
composed = lists.compose(outer_splines, inner_splines, cartesian_product=True, nthreads=300)

assert len(composed) = len(outer_splines) * len(inner_splines)
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
