### PR TITLE
Update README.md file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     args: [--extend-ignore=E203]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v15.0.7
+  rev: v16.0.2
   hooks:
   - id: clang-format
     types_or: [c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     args: [--extend-ignore=E203]
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v16.0.2
+  rev: v15.0.7
   hooks:
   - id: clang-format
     types_or: [c++]

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ bspline = splinepy.BSpline(
         [0.0, 0.0, 1.0, 1.0],
     ],
     control_points=[
+        [0. , 0.5 ],
+        [1., 0. ],
+        [0.5 , 1. ],
         [0. , 0. ],
-        [0.5, 0. ],
-        [1. , 0. ],
-        [0. , 1. ],
-        [0.5, 1. ],
+        [0., 1. ],
         [1. , 1. ],
     ],
 )
@@ -60,13 +60,14 @@ bspline = splinepy.BSpline(
 # (total_number_of_control_points, physical_dimension) shape.
 # They fill control grid by iterating lower-indexed dimensions first.
 # But if you prefer the grid-like structure, this should hold
-grid_cps = np.empty(2, 3, 2)  # (dim, n_cps_u, n_cps_v)
-gird_cps[:, 0, 0] = [0. , 0. ]
-gird_cps[:, 0, 1] = [0.5, 0. ]
-gird_cps[:, 0, 2] = [1. , 0. ]
-gird_cps[:, 1, 0] = [0. , 1. ]
-gird_cps[:, 1, 1] = [0.5, 1. ]
-gird_cps[:, 1, 2] = [1. , 1. ]
+grid_cps = np.empty([2, 3, 2])  # (dim, n_cps_u, n_cps_v)
+grid_cps[:, 0, 0] = [0. , 0. ]
+grid_cps[:, 0, 1] = [0.5, 0. ]
+grid_cps[:, 1, 0] = [1. , 0. ]
+grid_cps[:, 1, 1] = [0. , 1. ]
+grid_cps[:, 2, 0] = [0.5, 1. ]
+grid_cps[:, 2, 1] = [1. , 1. ]
+
 
 assert np.allclose(
     bspline.control_points,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bspline = splinepy.BSpline(
         [0.0, 0.0, 1.0, 1.0],
     ],
     control_points=[
-        [0.0, 0.0],  # [0, 0]
+        [0.0, 0.0],  # [0, 0] (control grid index)
         [0.5, 0.0],  # [1, 0]
         [1.0, 0.0],  # [2, 0]
         [0.0, 1.0],  # [0, 1]
@@ -62,7 +62,7 @@ bspline = splinepy.BSpline(
 # lower-indexed dimensions first. But if you prefer a
 # grid-like structure, try
 multi_index = bspline.multi_index
-grid_cps = np.empty((6, 2))
+grid_cps = np.empty(bspline.control_points.shape)
 grid_cps[multi_index[0, 0]] = [0.0, 0.0]
 grid_cps[multi_index[1, 0]] = [0.5, 0.0]
 grid_cps[multi_index[2, 0], 0] = 1.0


### PR DESCRIPTION
# Overview
The example (Quick Start) in the README.md file no longer worked. There were typos and other errors. These bugs have been fixed here. 
Since pre-commit didn't work for me, I downgraded mirrors-clang-formats to 15.0.7

## Addressed issues
*  #155 

## Showcase


## Checklists
* [x] Documentations are up-to-date.
* [x] Added example(s)
* [x] Added test(s)
