### PR TITLE
Clean up - Rename CoreSpline to PySpline

### DIFF
--- a/cpp/splinepy/py/py_spline.hpp
+++ b/cpp/splinepy/py/py_spline.hpp
@@ -911,7 +911,7 @@ public:
 
 inline void add_spline_pyclass(py::module& m) {
   py::class_<splinepy::py::PySpline, std::shared_ptr<splinepy::py::PySpline>>
-      klasse(m, "CoreSpline");
+      klasse(m, "PySpline");
 
   klasse.def(py::init<>())
       .def(py::init<py::kwargs>()) // doc here?

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -580,9 +580,9 @@ def _get_property(spl, property_):
     return sync_from_core(spl)._data["properties"][property_]
 
 
-class Spline(SplinepyBase, core.CoreSpline):
+class Spline(SplinepyBase, core.PySpline):
     r"""
-    Spline base class. Extends :class:`.CoreSpline` with documentation.
+    Spline base class. Extends :class:`.PySpline` with documentation.
 
     Generally, all types of splines can be seen as mappings from a
     :math:`N_{param}`-dimensional parametric domain
@@ -632,7 +632,7 @@ class Spline(SplinepyBase, core.CoreSpline):
             return None
 
         # current core spline based init if given spline has no local changes
-        if spline is not None and isinstance(spline, core.CoreSpline):
+        if spline is not None and isinstance(spline, core.PySpline):
             # if spline is modified, update this spline first
             if is_modified(spline):
                 spline.new_core(


### PR DESCRIPTION
# Overview
There were duplicating typename `CoreSpline`. It means:
- in python -> `splinepy::py::PySpline`
- in cpp -> `std::shared_ptr<splinepy::splines::SplinepyBase>`

Now, in python `CoreSpline` is renamed to `PySpline` to avoid confusion.