### PR TITLE
Cu pyreader

### DIFF
--- a/cpp/splinepy/py/init/reader.cpp
+++ b/cpp/splinepy/py/init/reader.cpp
@@ -2,6 +2,6 @@
 
 namespace splinepy::py::init {
 
-void init_reader(py::module_& m) { add_spline_reader(m); }
+void init_reader(py::module_& m) { AddSplineReader(m); }
 
 } // namespace splinepy::py::init

--- a/cpp/splinepy/py/init/reader.cpp
+++ b/cpp/splinepy/py/init/reader.cpp
@@ -2,6 +2,6 @@
 
 namespace splinepy::py::init {
 
-void init_reader(py::module_& m) { AddSplineReader(m); }
+void init_reader(py::module_& m) { add_spline_reader(m); }
 
 } // namespace splinepy::py::init

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -287,82 +287,82 @@ public:
     switch (para_dim) {
     case 1:
       switch (dim) {
-      case 1:
-        {auto bsparser = BSplineParser<1, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 2:
-        {auto bsparser = BSplineParser<1, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 3:
-        {auto bsparser = BSplineParser<1, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 4:
-        {auto bsparser = BSplineParser<1, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
+      case 1: {
+        auto bsparser = BSplineParser<1, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 2: {
+        auto bsparser = BSplineParser<1, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 3: {
+        auto bsparser = BSplineParser<1, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 4: {
+        auto bsparser = BSplineParser<1, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
       }
       break;
     case 2:
       switch (dim) {
-      case 1:
-        {auto bsparser = BSplineParser<2, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 2:
-        {auto bsparser = BSplineParser<2, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 3:
-        {auto bsparser = BSplineParser<2, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 4:
-        {auto bsparser = BSplineParser<2, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
+      case 1: {
+        auto bsparser = BSplineParser<2, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 2: {
+        auto bsparser = BSplineParser<2, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 3: {
+        auto bsparser = BSplineParser<2, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 4: {
+        auto bsparser = BSplineParser<2, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
       }
       break;
     case 3:
       switch (dim) {
-      case 1:
-        {auto bsparser = BSplineParser<3, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 2:
-        {auto bsparser = BSplineParser<3, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 3:
-        {auto bsparser = BSplineParser<3, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 4:
-        {auto bsparser = BSplineParser<3, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
+      case 1: {
+        auto bsparser = BSplineParser<3, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 2: {
+        auto bsparser = BSplineParser<3, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 3: {
+        auto bsparser = BSplineParser<3, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 4: {
+        auto bsparser = BSplineParser<3, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
       }
       break;
     case 4:
       switch (dim) {
-      case 1:
-        {auto bsparser = BSplineParser<4, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 2:
-        {auto bsparser = BSplineParser<4, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 3:
-        {auto bsparser = BSplineParser<4, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
-      case 4:
-        {auto bsparser = BSplineParser<4, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));}
-        break;
+      case 1: {
+        auto bsparser = BSplineParser<4, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 2: {
+        auto bsparser = BSplineParser<4, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 3: {
+        auto bsparser = BSplineParser<4, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
+      case 4: {
+        auto bsparser = BSplineParser<4, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+      } break;
       }
       break;
     }
@@ -380,82 +380,82 @@ public:
     switch (para_dim) {
     case 1:
       switch (dim) {
-      case 1:
-        {auto nparser = NurbsParser<1, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 2:
-        {auto nparser = NurbsParser<1, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 3:
-        {auto nparser = NurbsParser<1, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 4:
-        {auto nparser = NurbsParser<1, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
+      case 1: {
+        auto nparser = NurbsParser<1, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 2: {
+        auto nparser = NurbsParser<1, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 3: {
+        auto nparser = NurbsParser<1, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 4: {
+        auto nparser = NurbsParser<1, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
       }
       break;
     case 2:
       switch (dim) {
-      case 1:
-        {auto nparser = NurbsParser<2, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 2:
-        {auto nparser = NurbsParser<2, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 3:
-        {auto nparser = NurbsParser<2, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 4:
-        {auto nparser = NurbsParser<2, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
+      case 1: {
+        auto nparser = NurbsParser<2, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 2: {
+        auto nparser = NurbsParser<2, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 3: {
+        auto nparser = NurbsParser<2, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 4: {
+        auto nparser = NurbsParser<2, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
       }
       break;
     case 3:
       switch (dim) {
-      case 1:
-        {auto nparser = NurbsParser<3, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 2:
-        {auto nparser = NurbsParser<3, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 3:
-        {auto nparser = NurbsParser<3, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 4:
-        {auto nparser = NurbsParser<3, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
+      case 1: {
+        auto nparser = NurbsParser<3, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 2: {
+        auto nparser = NurbsParser<3, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 3: {
+        auto nparser = NurbsParser<3, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 4: {
+        auto nparser = NurbsParser<3, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
       }
       break;
     case 4:
       switch (dim) {
-      case 1:
-        {auto nparser = NurbsParser<4, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 2:
-        {auto nparser = NurbsParser<4, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 3:
-        {auto nparser = NurbsParser<4, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
-      case 4:
-        {auto nparser = NurbsParser<4, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));}
-        break;
+      case 1: {
+        auto nparser = NurbsParser<4, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 2: {
+        auto nparser = NurbsParser<4, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 3: {
+        auto nparser = NurbsParser<4, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
+      case 4: {
+        auto nparser = NurbsParser<4, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+      } break;
       }
       break;
     }

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -285,86 +285,86 @@ public:
 
     // Find appropriate BSplines
     switch (para_dim) {
+    case 1:
+      switch (dim) {
       case 1:
-        switch (dim) {
-          case 1:
-            auto bsparser = BSplineParser<1, 1>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 2:
-            auto bsparser = BSplineParser<1, 2>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 3:
-            auto bsparser = BSplineParser<1, 3>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 4:
-            auto bsparser = BSplineParser<1, 4>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-        }
+        auto bsparser = BSplineParser<1, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
         break;
       case 2:
-        switch (dim) {
-          case 1:
-            auto bsparser = BSplineParser<2, 1>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 2:
-            auto bsparser = BSplineParser<2, 2>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 3:
-            auto bsparser = BSplineParser<2, 3>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 4:
-            auto bsparser = BSplineParser<2, 4>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-        }
+        auto bsparser = BSplineParser<1, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
         break;
       case 3:
-        switch (dim) {
-          case 1:
-            auto bsparser = BSplineParser<3, 1>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 2:
-            auto bsparser = BSplineParser<3, 2>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 3:
-            auto bsparser = BSplineParser<3, 3>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 4:
-            auto bsparser = BSplineParser<3, 4>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-        }
+        auto bsparser = BSplineParser<1, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
         break;
       case 4:
-        switch (dim) {
-          case 1:
-            auto bsparser = BSplineParser<4, 1>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 2:
-            auto bsparser = BSplineParser<4, 2>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 3:
-            auto bsparser = BSplineParser<4, 3>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-          case 4:
-            auto bsparser = BSplineParser<4, 4>();
-            p_splines.append(bsparser.BsplineToDict(bspline));
-            break;
-        }
+        auto bsparser = BSplineParser<1, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
         break;
+      }
+      break;
+    case 2:
+      switch (dim) {
+      case 1:
+        auto bsparser = BSplineParser<2, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 2:
+        auto bsparser = BSplineParser<2, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 3:
+        auto bsparser = BSplineParser<2, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 4:
+        auto bsparser = BSplineParser<2, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      }
+      break;
+    case 3:
+      switch (dim) {
+      case 1:
+        auto bsparser = BSplineParser<3, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 2:
+        auto bsparser = BSplineParser<3, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 3:
+        auto bsparser = BSplineParser<3, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 4:
+        auto bsparser = BSplineParser<3, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      }
+      break;
+    case 4:
+      switch (dim) {
+      case 1:
+        auto bsparser = BSplineParser<4, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 2:
+        auto bsparser = BSplineParser<4, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 3:
+        auto bsparser = BSplineParser<4, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      case 4:
+        auto bsparser = BSplineParser<4, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));
+        break;
+      }
+      break;
     }
   }
 
@@ -378,86 +378,86 @@ public:
 
     // Find appropriate Nurbs
     switch (para_dim) {
+    case 1:
+      switch (dim) {
       case 1:
-        switch (dim) {
-          case 1:
-            auto nparser = NurbsParser<1, 1>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 2:
-            auto nparser = NurbsParser<1, 2>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 3:
-            auto nparser = NurbsParser<1, 3>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 4:
-            auto nparser = NurbsParser<1, 4>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-        }
+        auto nparser = NurbsParser<1, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
         break;
       case 2:
-        switch (dim) {
-          case 1:
-            auto nparser = NurbsParser<2, 1>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 2:
-            auto nparser = NurbsParser<2, 2>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 3:
-            auto nparser = NurbsParser<2, 3>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 4:
-            auto nparser = NurbsParser<2, 4>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-        }
+        auto nparser = NurbsParser<1, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
         break;
       case 3:
-        switch (dim) {
-          case 1:
-            auto nparser = NurbsParser<3, 1>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 2:
-            auto nparser = NurbsParser<3, 2>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 3:
-            auto nparser = NurbsParser<3, 3>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 4:
-            auto nparser = NurbsParser<3, 4>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-        }
+        auto nparser = NurbsParser<1, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
         break;
       case 4:
-        switch (dim) {
-          case 1:
-            auto nparser = NurbsParser<4, 1>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 2:
-            auto nparser = NurbsParser<4, 2>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 3:
-            auto nparser = NurbsParser<4, 3>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-          case 4:
-            auto nparser = NurbsParser<4, 4>();
-            p_splines.append(nparser.NurbsToDict(nurbs));
-            break;
-        }
+        auto nparser = NurbsParser<1, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
         break;
+      }
+      break;
+    case 2:
+      switch (dim) {
+      case 1:
+        auto nparser = NurbsParser<2, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 2:
+        auto nparser = NurbsParser<2, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 3:
+        auto nparser = NurbsParser<2, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 4:
+        auto nparser = NurbsParser<2, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      }
+      break;
+    case 3:
+      switch (dim) {
+      case 1:
+        auto nparser = NurbsParser<3, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 2:
+        auto nparser = NurbsParser<3, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 3:
+        auto nparser = NurbsParser<3, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 4:
+        auto nparser = NurbsParser<3, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      }
+      break;
+    case 4:
+      switch (dim) {
+      case 1:
+        auto nparser = NurbsParser<4, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 2:
+        auto nparser = NurbsParser<4, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 3:
+        auto nparser = NurbsParser<4, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      case 4:
+        auto nparser = NurbsParser<4, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));
+        break;
+      }
+      break;
     }
   }
 

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -15,6 +15,7 @@
 #include <Sources/InputOutput/xml.hpp>
 #include <Sources/Splines/b_spline.hpp>
 #include <Sources/Utilities/named_type.hpp>
+
 #include <splinepy/utils/print.hpp>
 
 namespace splinepy::py {
@@ -45,7 +46,7 @@ public:
 
   /// @brief Convert BSpline to Python dictionary
   /// @param bspline BSpline object
-  py::dict BsplineToDict(SplineEntry const& bspline) {
+  py::dict BSplineToDict(SplineEntry const& bspline) {
     int i, j;
 
     py::dict spline; //  to return
@@ -278,7 +279,7 @@ public:
 
   /// @brief Parse BSpline
   /// @param bspline BSpline object
-  void ParseBspline(SplineEntry const& bspline) {
+  void ParseBSpline(SplineEntry const& bspline) {
 
     // Get paradim and dim
     int const& para_dim = bspline->parametric_dimensionality_;
@@ -290,23 +291,23 @@ public:
       switch (dim) {
       case 1: {
         auto bsparser = BSplineParser<1, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 2: {
         auto bsparser = BSplineParser<1, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 3: {
         auto bsparser = BSplineParser<1, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 4: {
         auto bsparser = BSplineParser<1, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       default:
         splinepy::utils::PrintAndThrowError(
-            "ParseBspline() does not support physical dimension of ",
+            "ParseBSpline() does not support physical dimension of ",
             dim,
             ". Only dimensions 1 to 4 are supported.");
         break;
@@ -316,23 +317,23 @@ public:
       switch (dim) {
       case 1: {
         auto bsparser = BSplineParser<2, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 2: {
         auto bsparser = BSplineParser<2, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 3: {
         auto bsparser = BSplineParser<2, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 4: {
         auto bsparser = BSplineParser<2, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       default:
         splinepy::utils::PrintAndThrowError(
-            "ParseBspline() does not support physical dimension of ",
+            "ParseBSpline() does not support physical dimension of ",
             dim,
             ". Only dimensions 1 to 4 are supported.");
         break;
@@ -342,23 +343,23 @@ public:
       switch (dim) {
       case 1: {
         auto bsparser = BSplineParser<3, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 2: {
         auto bsparser = BSplineParser<3, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 3: {
         auto bsparser = BSplineParser<3, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 4: {
         auto bsparser = BSplineParser<3, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       default:
         splinepy::utils::PrintAndThrowError(
-            "ParseBspline() does not support physical dimension of ",
+            "ParseBSpline() does not support physical dimension of ",
             dim,
             ". Only dimensions 1 to 4 are supported.");
         break;
@@ -368,23 +369,23 @@ public:
       switch (dim) {
       case 1: {
         auto bsparser = BSplineParser<4, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 2: {
         auto bsparser = BSplineParser<4, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 3: {
         auto bsparser = BSplineParser<4, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       case 4: {
         auto bsparser = BSplineParser<4, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        p_splines.append(bsparser.BSplineToDict(bspline));
       } break;
       default:
         splinepy::utils::PrintAndThrowError(
-            "ParseBspline() does not support physical dimension of ",
+            "ParseBSpline() does not support physical dimension of ",
             dim,
             ". Only dimensions 1 to 4 are supported.");
         break;
@@ -392,7 +393,7 @@ public:
       break;
     default:
       splinepy::utils::PrintAndThrowError(
-          "ParseBspline() does not support parametric dimension of ",
+          "ParseBSpline() does not support parametric dimension of ",
           para_dim,
           ". Only dimensions 1 to 4 are supported.");
       break;
@@ -541,7 +542,7 @@ public:
         ParseNurbs(spline);
       } else {
         // BSpline
-        ParseBspline(spline);
+        ParseBSpline(spline);
       }
     }
   }
@@ -569,7 +570,7 @@ py::list ReadIrit(std::string fname) {
 ///  @brief Adds spline reader. Keys are
 /// ["knot_vectors", "control_points", "degrees"] (+ ["weights"])
 /// @param m Python module
-inline void AddSplineReader(py::module& m) {
+inline void add_spline_reader(py::module& m) {
   m.def("read_iges", &ReadIges, py::arg("fname"))
       .def("read_xml", &ReadXml, py::arg("fname"))
       .def("read_irit", &ReadIrit, py::arg("fname"));

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -261,7 +261,7 @@ public:
   /// @param fname File name
   py::list ReadIrit(std::string fname) {
     c_splines = input_output::irit::Read(fname);
-    read(c_splines);
+    Read(c_splines);
 
     return p_splines;
   }
@@ -270,7 +270,7 @@ public:
   /// @param fname File name
   py::list ReadXml(std::string fname) {
     c_splines = input_output::xml::Read(fname);
-    read(c_splines);
+    Read(c_splines);
 
     return p_splines;
   }
@@ -288,80 +288,80 @@ public:
     case 1:
       switch (dim) {
       case 1:
-        auto bsparser = BSplineParser<1, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<1, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 2:
-        auto bsparser = BSplineParser<1, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<1, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 3:
-        auto bsparser = BSplineParser<1, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<1, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 4:
-        auto bsparser = BSplineParser<1, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<1, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       }
       break;
     case 2:
       switch (dim) {
       case 1:
-        auto bsparser = BSplineParser<2, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<2, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 2:
-        auto bsparser = BSplineParser<2, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<2, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 3:
-        auto bsparser = BSplineParser<2, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<2, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 4:
-        auto bsparser = BSplineParser<2, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<2, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       }
       break;
     case 3:
       switch (dim) {
       case 1:
-        auto bsparser = BSplineParser<3, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<3, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 2:
-        auto bsparser = BSplineParser<3, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<3, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 3:
-        auto bsparser = BSplineParser<3, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<3, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 4:
-        auto bsparser = BSplineParser<3, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<3, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       }
       break;
     case 4:
       switch (dim) {
       case 1:
-        auto bsparser = BSplineParser<4, 1>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<4, 1>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 2:
-        auto bsparser = BSplineParser<4, 2>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<4, 2>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 3:
-        auto bsparser = BSplineParser<4, 3>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<4, 3>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       case 4:
-        auto bsparser = BSplineParser<4, 4>();
-        p_splines.append(bsparser.BsplineToDict(bspline));
+        {auto bsparser = BSplineParser<4, 4>();
+        p_splines.append(bsparser.BsplineToDict(bspline));}
         break;
       }
       break;
@@ -381,80 +381,80 @@ public:
     case 1:
       switch (dim) {
       case 1:
-        auto nparser = NurbsParser<1, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<1, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 2:
-        auto nparser = NurbsParser<1, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<1, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 3:
-        auto nparser = NurbsParser<1, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<1, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 4:
-        auto nparser = NurbsParser<1, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<1, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       }
       break;
     case 2:
       switch (dim) {
       case 1:
-        auto nparser = NurbsParser<2, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<2, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 2:
-        auto nparser = NurbsParser<2, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<2, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 3:
-        auto nparser = NurbsParser<2, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<2, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 4:
-        auto nparser = NurbsParser<2, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<2, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       }
       break;
     case 3:
       switch (dim) {
       case 1:
-        auto nparser = NurbsParser<3, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<3, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 2:
-        auto nparser = NurbsParser<3, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<3, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 3:
-        auto nparser = NurbsParser<3, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<3, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 4:
-        auto nparser = NurbsParser<3, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<3, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       }
       break;
     case 4:
       switch (dim) {
       case 1:
-        auto nparser = NurbsParser<4, 1>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<4, 1>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 2:
-        auto nparser = NurbsParser<4, 2>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<4, 2>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 3:
-        auto nparser = NurbsParser<4, 3>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<4, 3>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       case 4:
-        auto nparser = NurbsParser<4, 4>();
-        p_splines.append(nparser.NurbsToDict(nurbs));
+        {auto nparser = NurbsParser<4, 4>();
+        p_splines.append(nparser.NurbsToDict(nurbs));}
         break;
       }
       break;
@@ -463,7 +463,7 @@ public:
 
   /// @brief Reads spline
   /// @param splines
-  void read(Splines splines) {
+  void Read(Splines splines) {
 
     // Assign a new list
     //   - with `clear`, one object can't be reused: it alters all returned
@@ -508,7 +508,7 @@ py::list ReadIrit(std::string fname) {
 ///  @brief Adds spline reader. Keys are
 /// ["knot_vectors", "control_points", "degrees"] (+ ["weights"])
 /// @param m Python module
-inline void add_spline_reader(py::module& m) {
+inline void AddSplineReader(py::module& m) {
   m.def("read_iges", &ReadIges, py::arg("fname"))
       .def("read_xml", &ReadXml, py::arg("fname"))
       .def("read_irit", &ReadIrit, py::arg("fname"));

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -40,16 +40,12 @@ public:
 
   using SplineEntry = input_output::SplineEntry;
 
-  /// Counter variable
-  int i;
-  /// Counter variable for inner loops
-  int j;
-
   BSplineParser() {}
 
   /// @brief Convert BSpline to Python dictionary
   /// @param bspline BSpline object
-  py::dict bspline_to_dict(SplineEntry const& bspline) {
+  py::dict BsplineToDict(SplineEntry const& bspline) {
+    int i, j;
 
     py::dict spline; //  to return
 
@@ -142,16 +138,12 @@ public:
 
   using SplineEntry = input_output::SplineEntry;
 
-  /// Counter variable
-  int i;
-  /// Counter variable for inner loops
-  int j;
-
   NurbsParser() {}
 
   /// @brief Convert Nurbs to Python dictionary
   /// @param nurbs Nurbs object
-  py::dict nurbs_to_dict(SplineEntry const& nurbs) {
+  py::dict NurbsToDict(SplineEntry const& nurbs) {
+    int i, j;
 
     py::dict spline; //  to return
 
@@ -247,11 +239,6 @@ public:
   using Splines = input_output::Splines;
   using SplineEntry = input_output::SplineEntry;
 
-  /// Counter variable
-  int i;
-  /// Counter variable for inner loops
-  int j;
-
   /// @brief Spline object in C
   Splines c_splines;
 
@@ -261,17 +248,18 @@ public:
 
   /// @brief Read spline in .iges form.
   /// @param fname File name
-  py::list read_iges(std::string fname) {
+  py::list ReadIges(std::string fname) {
+    int i, j;
 
     c_splines = input_output::iges::Read(fname);
-    read(c_splines);
+    Read(c_splines);
 
     return p_splines;
   }
 
   /// @brief Read spline in .itd form.
   /// @param fname File name
-  py::list read_irit(std::string fname) {
+  py::list ReadIrit(std::string fname) {
     c_splines = input_output::irit::Read(fname);
     read(c_splines);
 
@@ -280,7 +268,7 @@ public:
 
   /// @brief Read spline in .xml form. RWTH CATS spline format.
   /// @param fname File name
-  py::list read_xml(std::string fname) {
+  py::list ReadXml(std::string fname) {
     c_splines = input_output::xml::Read(fname);
     read(c_splines);
 
@@ -289,137 +277,187 @@ public:
 
   /// @brief Parse BSpline
   /// @param bspline BSpline object
-  void parse_bspline(SplineEntry const& bspline) {
+  void ParseBspline(SplineEntry const& bspline) {
 
     // Get paradim and dim
     int const& para_dim = bspline->parametric_dimensionality_;
     int const& dim = bspline->dimensionality_;
 
-    // `if`s to find appropriate BSplines
-    if (para_dim == 1) {
-      if (dim == 1) {
-        auto bsparser = BSplineParser<1, 1>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 2) {
-        auto bsparser = BSplineParser<1, 2>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 3) {
-        auto bsparser = BSplineParser<1, 3>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 4) {
-        auto bsparser = BSplineParser<1, 4>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      }
-    } else if (para_dim == 2) {
-      if (dim == 1) {
-        auto bsparser = BSplineParser<2, 1>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 2) {
-        auto bsparser = BSplineParser<2, 2>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 3) {
-        auto bsparser = BSplineParser<2, 3>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 4) {
-        auto bsparser = BSplineParser<2, 4>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      }
-    } else if (para_dim == 3) {
-      if (dim == 1) {
-        auto bsparser = BSplineParser<3, 1>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 2) {
-        auto bsparser = BSplineParser<3, 2>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 3) {
-        auto bsparser = BSplineParser<3, 3>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 4) {
-        auto bsparser = BSplineParser<3, 4>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      }
-    } else if (para_dim == 4) {
-      if (dim == 1) {
-        auto bsparser = BSplineParser<4, 1>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 2) {
-        auto bsparser = BSplineParser<4, 2>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 3) {
-        auto bsparser = BSplineParser<4, 3>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      } else if (dim == 4) {
-        auto bsparser = BSplineParser<4, 4>();
-        p_splines.append(bsparser.bspline_to_dict(bspline));
-      }
+    // Find appropriate BSplines
+    switch (para_dim) {
+      case 1:
+        switch (dim) {
+          case 1:
+            auto bsparser = BSplineParser<1, 1>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 2:
+            auto bsparser = BSplineParser<1, 2>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 3:
+            auto bsparser = BSplineParser<1, 3>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 4:
+            auto bsparser = BSplineParser<1, 4>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+        }
+        break;
+      case 2:
+        switch (dim) {
+          case 1:
+            auto bsparser = BSplineParser<2, 1>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 2:
+            auto bsparser = BSplineParser<2, 2>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 3:
+            auto bsparser = BSplineParser<2, 3>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 4:
+            auto bsparser = BSplineParser<2, 4>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+        }
+        break;
+      case 3:
+        switch (dim) {
+          case 1:
+            auto bsparser = BSplineParser<3, 1>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 2:
+            auto bsparser = BSplineParser<3, 2>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 3:
+            auto bsparser = BSplineParser<3, 3>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 4:
+            auto bsparser = BSplineParser<3, 4>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+        }
+        break;
+      case 4:
+        switch (dim) {
+          case 1:
+            auto bsparser = BSplineParser<4, 1>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 2:
+            auto bsparser = BSplineParser<4, 2>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 3:
+            auto bsparser = BSplineParser<4, 3>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+          case 4:
+            auto bsparser = BSplineParser<4, 4>();
+            p_splines.append(bsparser.BsplineToDict(bspline));
+            break;
+        }
+        break;
     }
   }
 
   /// @brief Parse Nurbs
   /// @param nurbs Nurbs object
-  void parse_nurbs(SplineEntry const& nurbs) {
+  void ParseNurbs(SplineEntry const& nurbs) {
 
     // Get paradim and dim
     int const& para_dim = nurbs->parametric_dimensionality_;
     int const& dim = nurbs->dimensionality_;
 
-    // `if`s to find appropriate Nurbs
-    if (para_dim == 1) {
-      if (dim == 1) {
-        auto nparser = NurbsParser<1, 1>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 2) {
-        auto nparser = NurbsParser<1, 2>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 3) {
-        auto nparser = NurbsParser<1, 3>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 4) {
-        auto nparser = NurbsParser<1, 4>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      }
-    } else if (para_dim == 2) {
-      if (dim == 1) {
-        auto nparser = NurbsParser<2, 1>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 2) {
-        auto nparser = NurbsParser<2, 2>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 3) {
-        auto nparser = NurbsParser<2, 3>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 4) {
-        auto nparser = NurbsParser<2, 4>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      }
-    } else if (para_dim == 3) {
-      if (dim == 1) {
-        auto nparser = NurbsParser<3, 1>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 2) {
-        auto nparser = NurbsParser<3, 2>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 3) {
-        auto nparser = NurbsParser<3, 3>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 4) {
-        auto nparser = NurbsParser<3, 4>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      }
-    } else if (para_dim == 4) {
-      if (dim == 1) {
-        auto nparser = NurbsParser<4, 1>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 2) {
-        auto nparser = NurbsParser<4, 2>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 3) {
-        auto nparser = NurbsParser<4, 3>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      } else if (dim == 4) {
-        auto nparser = NurbsParser<4, 4>();
-        p_splines.append(nparser.nurbs_to_dict(nurbs));
-      }
+    // Find appropriate Nurbs
+    switch (para_dim) {
+      case 1:
+        switch (dim) {
+          case 1:
+            auto nparser = NurbsParser<1, 1>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 2:
+            auto nparser = NurbsParser<1, 2>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 3:
+            auto nparser = NurbsParser<1, 3>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 4:
+            auto nparser = NurbsParser<1, 4>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+        }
+        break;
+      case 2:
+        switch (dim) {
+          case 1:
+            auto nparser = NurbsParser<2, 1>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 2:
+            auto nparser = NurbsParser<2, 2>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 3:
+            auto nparser = NurbsParser<2, 3>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 4:
+            auto nparser = NurbsParser<2, 4>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+        }
+        break;
+      case 3:
+        switch (dim) {
+          case 1:
+            auto nparser = NurbsParser<3, 1>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 2:
+            auto nparser = NurbsParser<3, 2>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 3:
+            auto nparser = NurbsParser<3, 3>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 4:
+            auto nparser = NurbsParser<3, 4>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+        }
+        break;
+      case 4:
+        switch (dim) {
+          case 1:
+            auto nparser = NurbsParser<4, 1>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 2:
+            auto nparser = NurbsParser<4, 2>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 3:
+            auto nparser = NurbsParser<4, 3>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+          case 4:
+            auto nparser = NurbsParser<4, 4>();
+            p_splines.append(nparser.NurbsToDict(nurbs));
+            break;
+        }
+        break;
     }
   }
 
@@ -439,10 +477,10 @@ public:
 
       if (is_rational) {
         // Nurbs
-        parse_nurbs(spline);
+        ParseNurbs(spline);
       } else {
         // BSpline
-        parse_bspline(spline);
+        ParseBspline(spline);
       }
     }
   }
@@ -450,30 +488,30 @@ public:
 
 /* direct load calls */
 /// Load iges
-py::list read_iges(std::string fname) {
+py::list ReadIges(std::string fname) {
   auto sr = SplineReader();
-  return sr.read_iges(fname);
+  return sr.ReadIges(fname);
 }
 
 /// Load xml
-py::list read_xml(std::string fname) {
+py::list ReadXml(std::string fname) {
   auto sr = SplineReader();
-  return sr.read_xml(fname);
+  return sr.ReadXml(fname);
 }
 
 /// Load irit
-py::list read_irit(std::string fname) {
+py::list ReadIrit(std::string fname) {
   auto sr = SplineReader();
-  return sr.read_irit(fname);
+  return sr.ReadIrit(fname);
 }
 
 ///  @brief Adds spline reader. Keys are
 /// ["knot_vectors", "control_points", "degrees"] (+ ["weights"])
 /// @param m Python module
 inline void add_spline_reader(py::module& m) {
-  m.def("read_iges", &read_iges, py::arg("fname"))
-      .def("read_xml", &read_xml, py::arg("fname"))
-      .def("read_irit", &read_irit, py::arg("fname"));
+  m.def("read_iges", &ReadIges, py::arg("fname"))
+      .def("read_xml", &ReadXml, py::arg("fname"))
+      .def("read_irit", &ReadIrit, py::arg("fname"));
 }
 
 } // namespace splinepy::py

--- a/cpp/splinepy/py/py_spline_reader.hpp
+++ b/cpp/splinepy/py/py_spline_reader.hpp
@@ -15,6 +15,7 @@
 #include <Sources/InputOutput/xml.hpp>
 #include <Sources/Splines/b_spline.hpp>
 #include <Sources/Utilities/named_type.hpp>
+#include <splinepy/utils/print.hpp>
 
 namespace splinepy::py {
 
@@ -303,6 +304,12 @@ public:
         auto bsparser = BSplineParser<1, 4>();
         p_splines.append(bsparser.BsplineToDict(bspline));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseBspline() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 2:
@@ -323,6 +330,12 @@ public:
         auto bsparser = BSplineParser<2, 4>();
         p_splines.append(bsparser.BsplineToDict(bspline));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseBspline() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 3:
@@ -343,6 +356,12 @@ public:
         auto bsparser = BSplineParser<3, 4>();
         p_splines.append(bsparser.BsplineToDict(bspline));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseBspline() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 4:
@@ -363,7 +382,19 @@ public:
         auto bsparser = BSplineParser<4, 4>();
         p_splines.append(bsparser.BsplineToDict(bspline));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseBspline() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
+      break;
+    default:
+      splinepy::utils::PrintAndThrowError(
+          "ParseBspline() does not support parametric dimension of ",
+          para_dim,
+          ". Only dimensions 1 to 4 are supported.");
       break;
     }
   }
@@ -396,6 +427,12 @@ public:
         auto nparser = NurbsParser<1, 4>();
         p_splines.append(nparser.NurbsToDict(nurbs));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseNurbs() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 2:
@@ -416,6 +453,12 @@ public:
         auto nparser = NurbsParser<2, 4>();
         p_splines.append(nparser.NurbsToDict(nurbs));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseNurbs() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 3:
@@ -436,6 +479,12 @@ public:
         auto nparser = NurbsParser<3, 4>();
         p_splines.append(nparser.NurbsToDict(nurbs));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseNurbs() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
       break;
     case 4:
@@ -456,7 +505,19 @@ public:
         auto nparser = NurbsParser<4, 4>();
         p_splines.append(nparser.NurbsToDict(nurbs));
       } break;
+      default:
+        splinepy::utils::PrintAndThrowError(
+            "ParseNurbs() does not support physical dimension of ",
+            dim,
+            ". Only dimensions 1 to 4 are supported.");
+        break;
       }
+      break;
+    default:
+      splinepy::utils::PrintAndThrowError(
+          "ParseNurbs() does not support parametric dimension of ",
+          para_dim,
+          ". Only dimensions 1 to 4 are supported.");
       break;
     }
   }


### PR DESCRIPTION
# Overview
Changed two things in `cpp/splinepy/py/py_spline_reader.hpp`:
- function names to fit C++ convention (e.g. from `read_xml` to `ReadXml`) and 
- If elses in `ParseBspline` and `ParseNurbs` to switches