### PR TITLE
Replace np.product to np.prod

### DIFF
--- a/splinepy/helpme/multi_index.py
+++ b/splinepy/helpme/multi_index.py
@@ -28,7 +28,7 @@ class MultiIndex:
             )
 
         # create raveled indices
-        raveled = np.arange(np.product(grid_resolutions), dtype="int32")
+        raveled = np.arange(np.prod(grid_resolutions), dtype="int32")
 
         # to allow general __getitem__ like query, turn them into
         # grid's shape

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1391,9 +1391,7 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         results: (math.product(resolutions), dim) np.ndarray
         """
-        self._logd(
-            f"Sampling {np.product(resolutions)} " "points from spline."
-        )
+        self._logd(f"Sampling {np.prod(resolutions)} " "points from spline.")
 
         return super().sample(
             resolutions, nthreads=_default_if_none(nthreads, settings.NTHREADS)

--- a/tests/test_multi_index.py
+++ b/tests/test_multi_index.py
@@ -30,19 +30,19 @@ class MultiIndexTest(c.unittest.TestCase):
 
             # test first and last slice that's orthogonal to the last dimension
             # first slice
-            ref_raveled = c.np.arange(c.np.product(resolutions[:-1]))
+            ref_raveled = c.np.arange(c.np.prod(resolutions[:-1]))
             to_test = multi[..., 0]
             assert c.np.array_equal(ref_raveled, to_test)
 
             # last slice
-            upper = c.np.product(resolutions)
-            lower = upper - c.np.product(resolutions[:-1])
+            upper = c.np.prod(resolutions)
+            lower = upper - c.np.prod(resolutions[:-1])
             ref_raveled = c.np.arange(lower, upper)
             to_test = multi[..., -1]
             assert c.np.array_equal(ref_raveled, to_test)
 
             # test first and last slice that's orthogonal to the first dim
-            full_ids = c.np.arange(c.np.product(resolutions))
+            full_ids = c.np.arange(c.np.prod(resolutions))
 
             # first slice
             ref_raveled = full_ids[0 :: resolutions[0]]


### PR DESCRIPTION
# Overview
Since the numpy `product` will be removed in `NumPy 2.0`, a DeprecationWarning is thrown: (DeprecationWarning: `product` is deprecated as of NumPy 1.25.0, and will be removed in` NumPy 2.0`. Please use `prod` instead.)
To remove this warning all numpy `products` have been replaced by numpy `prod` .

## Addressed issues

## Showcase


## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
