### PR TITLE
Copy of C++ spline lead to 2 splines sharing core

### DIFF
--- a/splinepy/bezier.py
+++ b/splinepy/bezier.py
@@ -342,12 +342,12 @@ class Bezier(BezierBase):
 
     @property
     def bezier(self):
-        return settings.NAME_TO_TYPE["Bezier"](spline=self)
+        return settings.NAME_TO_TYPE["Bezier"](**self.todict())
 
     @property
     def rationalbezier(self):
         return settings.NAME_TO_TYPE["RationalBezier"](
-            **self.todict(), weights=np.ones((len(self.cps), 1))
+            **self.todict(), weights=np.ones((self.cps.shape[0], 1))
         )
 
     @property

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -677,7 +677,7 @@ class BSpline(BSplineBase):
 
     @property
     def bspline(self):
-        return settings.NAME_TO_TYPE["BSpline"](spline=self)
+        return settings.NAME_TO_TYPE["BSpline"](**self.todict())
 
     @property
     def nurbs(self):

--- a/splinepy/microstructure/microstructure.py
+++ b/splinepy/microstructure/microstructure.py
@@ -289,7 +289,9 @@ class Microstructure(SplinepyBase):
 
         # Prepare the deformation function
         # Transform into a non-uniform splinetype and make sure to work on copy
-        if hasattr(self._deformation_function, "bspline"):
+        if "BSpline" in self._deformation_function.whatami:
+            deformation_function_copy = self._deformation_function.copy()
+        elif hasattr(self._deformation_function, "bspline"):
             deformation_function_copy = self._deformation_function.bspline
         else:
             deformation_function_copy = self._deformation_function.nurbs

--- a/splinepy/nurbs.py
+++ b/splinepy/nurbs.py
@@ -148,4 +148,4 @@ class NURBS(BSplineBase):
 
     @property
     def nurbs(self):
-        return settings.NAME_TO_TYPE["NURBS"](spline=self)
+        return settings.NAME_TO_TYPE["NURBS"](**self.todict())


### PR DESCRIPTION
This is more readable and avoids copy bugs. Transformation operations should always end in copies of the original, regardless of whether the type was changed or not



## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
