### PR TITLE
Change numbering system of interfaces

### DIFF
--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -86,6 +86,31 @@ class Multipatch(SplinepyBase, PyMultipatch):
         Returns its interfaces in the form as an array of size
         n_patches x n_sides_per_patch
 
+        The interfaces are stored as indices. If the index is negative, the ID
+        is referring to a boundary (e.g. for boundary conditions). If the
+        number is positive, the ID refers to the global face-id, which is
+        composed of the element ID and the local face ID :
+        global_face = local_face + number_of_faces_per_element * element_id
+
+        Example:
+
+        .. code-block ::
+
+          O -- 3 -- O O -- 3 -- O
+          |         | |         |
+          0    0    1 0    1    1
+          |         | |         |
+          O -- 2 -- O O -- 2 -- O
+
+        would be stored as:
+
+        .. code-block ::
+
+          [
+            [-1, 5, -1, -1],
+            [1, -1, -1, -1]
+          ]
+
         Returns
         -------
         interfaces : np.ndarray

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -107,7 +107,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         .. code-block ::
 
           [
-            [-1, 5, -1, -1],
+            [-1, 4, -1, -1],
             [1, -1, -1, -1]
           ]
 

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -501,7 +501,6 @@ FindConnectivityFromCenters(const py::array_t<double>& face_center_vertices,
     //    already have a neighbor, that means that more than one point connect
     //    -> Error
     if (found_duplicate) {
-      // Check 1. (@todo EXCEPTION)
       if (connectivity_ptr[metric_order_indices[lower_limit]] != -2) {
         splinepy::utils::PrintAndThrowError(
             "Found conflicting interceptions, where more than two points are "
@@ -511,11 +510,9 @@ FindConnectivityFromCenters(const py::array_t<double>& face_center_vertices,
 
       // If both tests passed, update connectivity
       connectivity_ptr[metric_order_indices[lower_limit]] =
-          static_cast<int>(metric_order_indices[upper_limit])
-          / number_of_element_faces;
+          static_cast<int>(metric_order_indices[upper_limit]);
       connectivity_ptr[metric_order_indices[upper_limit]] =
-          static_cast<int>(metric_order_indices[lower_limit])
-          / number_of_element_faces;
+          static_cast<int>(metric_order_indices[lower_limit]);
     } else {
       // set Boundary-ID
       if (connectivity_ptr[metric_order_indices[lower_limit]] == -2) {

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -841,25 +841,6 @@ int AddBoundariesFromContinuity(const py::list& boundary_splines,
     return (tolerance > abs(1 - abs(dot_p) / std::sqrt(norm0 * norm1)));
   };
 
-  // Identify face_id in adjacent patch
-  auto face_id_in_neighbor =
-      [&boundary_interfaces_ptr,
-       &n_faces_per_boundary_patch](const int& base_patch_id,
-                                    const int& neighbor_patch_id) -> int {
-    // Loop over adjacent elements until base_patch_id is found
-    for (int i{}; i < n_faces_per_boundary_patch; i++) {
-      if (boundary_interfaces_ptr[neighbor_patch_id * n_faces_per_boundary_patch
-                                  + i]
-          == base_patch_id) {
-        return i;
-      }
-    }
-    // This part should never be reached
-    splinepy::utils::PrintAndThrowError("Interface connectivity has errors, "
-                                        "unidirectional interface detected.");
-    return -1;
-  };
-
   // Tangential Vector on boundary based on its derivative
   auto tangential_vector = [&cpp_spline_list, &para_dim_, &dim_](
                                const int& patch_id,
@@ -901,27 +882,32 @@ int AddBoundariesFromContinuity(const py::list& boundary_splines,
     for (int i{start}; i < end; i++) {
       // Loop over faces
       for (int j{}; j < n_faces_per_boundary_patch; j++) {
-        const int& adjacent_id =
+        // Interface refers to the global face id (see interface documentation)
+        const int& connected_face_id =
             boundary_interfaces_ptr[i * n_faces_per_boundary_patch + j];
 
-        if (adjacent_id < i) {
-          // only compute if the adjacent neighbor has higher id to prevent
-          // double the work
+        // Retrieve patch and face ID of neighbor
+        const int adjacent_element_id =
+            connected_face_id / n_faces_per_boundary_patch;
+        const int adjacent_face_id =
+            connected_face_id % n_faces_per_boundary_patch;
+
+        // only compute if the adjacent neighbor has higher id to prevent double
+        // the work
+        if (adjacent_element_id < i) {
           continue;
         }
         // Get tangential vector of current patch
         const std::vector<double> vec0 = tangential_vector(i, j);
 
         // Get corresponding tangential vector of neighbor patch
-        const int adjacent_face_id = face_id_in_neighbor(i, adjacent_id);
         const std::vector<double> vec1 =
-            tangential_vector(adjacent_id, adjacent_face_id);
+            tangential_vector(adjacent_element_id, adjacent_face_id);
 
         // Check tolerance
         const bool is_g1 = areG1(vec0, vec1);
         faces_are_g1[i * n_faces_per_boundary_patch + j] = is_g1;
-        faces_are_g1[adjacent_id * n_faces_per_boundary_patch
-                     + adjacent_face_id] = is_g1;
+        faces_are_g1[connected_face_id] = is_g1;
       }
     }
   };
@@ -956,15 +942,20 @@ int AddBoundariesFromContinuity(const py::list& boundary_splines,
             current_id * n_faces_per_boundary_patch + i_face;
         // Is the neighborface G1
         if (faces_are_g1[combined_index]) {
-          const int& adjacent_id = boundary_interfaces_ptr[combined_index];
+          // Adjacent global face id
+          const int& adjacent_global_face_id =
+              boundary_interfaces_ptr[combined_index];
+          const int adjacent_patch_id =
+              adjacent_global_face_id / n_faces_per_boundary_patch;
+
           // Check if the adjacent patch is already assigned
-          if (is_assigned[adjacent_id]) {
+          if (is_assigned[adjacent_patch_id]) {
             continue;
           } else {
             // Assign a BID and continue
-            new_boundary_id[adjacent_id] = current_max_id;
-            is_assigned[adjacent_id] = true;
-            queued_splines.push_back(adjacent_id);
+            new_boundary_id[adjacent_patch_id] = current_max_id;
+            is_assigned[adjacent_patch_id] = true;
+            queued_splines.push_back(adjacent_patch_id);
           }
         }
       }

--- a/tests/test_gismo.py
+++ b/tests/test_gismo.py
@@ -367,10 +367,10 @@ _gismo_export_ref_2d_indent_labeled = [
 _gismo_export_ref_3d = [
     (
         '<xml><MultiPatch parDim="3" id="0"><patches type="id_range">100 103</'
-        "patches><interfaces>100 4 101 3 0 1 2 1 1 1\n"
+        "patches><interfaces>100 2 103 1 0 1 2 1 1 1\n"
     ),
+    "100 4 101 3 0 1 2 1 1 1\n",
     "101 2 102 1 0 1 2 1 1 1\n",
-    "100 2 103 1 0 1 2 1 1 1\n",
     "102 3 103 4 0 1 2 1 1 1</interfaces><boundary>100 1\n",
     "100 3\n",
     "100 5\n",
@@ -541,9 +541,9 @@ _gismo_export_ref_3d_indent = [
     "<xml>\n",
     '  <MultiPatch parDim="3" id="0">\n',
     '    <patches type="id_range">100 103</patches>\n',
-    "    <interfaces>100 4 101 3 0 1 2 1 1 1\n",
+    "    <interfaces>100 2 103 1 0 1 2 1 1 1\n",
+    "100 4 101 3 0 1 2 1 1 1\n",
     "101 2 102 1 0 1 2 1 1 1\n",
-    "100 2 103 1 0 1 2 1 1 1\n",
     "102 3 103 4 0 1 2 1 1 1</interfaces>\n",
     "    <boundary>100 1\n",
     "100 3\n",

--- a/tests/test_multipatch.py
+++ b/tests/test_multipatch.py
@@ -61,14 +61,16 @@ class MultipatchTest(c.unittest.TestCase):
         self.assertTrue(
             (
                 single_p_multipatch.interfaces
-                == c.np.array([[0, 0, -1, -1]], dtype=int)
+                == c.np.array([[1, 0, -1, -1]], dtype=int)
             ).all()
         )
         self.assertTrue(
             (
                 multipatch.interfaces
                 == c.np.array(
-                    [[-1, 1, 2, -1], [0, -1, -1, -1], [-1, -1, -1, 0]],
+                    # Global Face IDs and their connectivity
+                    # [0  1   2   3]  [4   5   6   7]   [8   9  10  11]
+                    [[-1, 4, 11, -1], [1, -1, -1, -1], [-1, -1, -1, 2]],
                     dtype=int,
                 )
             ).all()
@@ -90,7 +92,9 @@ class MultipatchTest(c.unittest.TestCase):
             (
                 multipatch.interfaces
                 == c.np.array(
-                    [[-2, 1, 2, -1], [0, -1, -1, -1], [-2, -1, -1, 0]],
+                    # Global Face IDs and their connectivity
+                    # [0  1   2   3]  [4   5   6   7]   [8   9  10  11]
+                    [[-2, 4, 11, -1], [1, -1, -1, -1], [-2, -1, -1, 2]],
                     dtype=int,
                 )
             ).all()
@@ -102,7 +106,9 @@ class MultipatchTest(c.unittest.TestCase):
             (
                 multipatch.interfaces
                 == c.np.array(
-                    [[-2, 1, 2, -3], [0, -4, -1, -3], [-2, -1, -1, 0]],
+                    # Global Face IDs and their connectivity
+                    # [0  1   2   3]  [4   5   6   7]   [8   9  10  11]
+                    [[-2, 4, 11, -3], [1, -4, -1, -3], [-2, -1, -1, 2]],
                     dtype=int,
                 )
             ).all()
@@ -114,7 +120,9 @@ class MultipatchTest(c.unittest.TestCase):
             (
                 multipatch.interfaces
                 == c.np.array(
-                    [[-1, 1, 2, -2], [0, -3, -4, -5], [-1, -6, -7, 0]],
+                    # Global Face IDs and their connectivity
+                    # [0  1   2   3]  [4   5   6   7]   [8   9  10  11]
+                    [[-1, 4, 11, -2], [1, -3, -4, -5], [-1, -6, -7, 2]],
                     dtype=int,
                 )
             ).all()
@@ -192,10 +200,10 @@ class MultipatchTest(c.unittest.TestCase):
                 multipatch.interfaces
                 == c.np.array(
                     [
-                        [-1, 2, 1, -2, -3, -4],
-                        [3, -1, -5, 0, -4, -3],
-                        [-6, 0, -2, 3, -3, -4],
-                        [2, -5, 1, -6, -4, -3],
+                        [-1, 13, 9, -2, -3, -4],
+                        [20, -1, -5, 2, -4, -3],
+                        [-6, 1, -2, 18, -3, -4],
+                        [15, -5, 6, -6, -4, -3],
                     ],
                     dtype=int,
                 )


### PR DESCRIPTION
# Overview
Up to this point, interfaces were stored in the `mrng`-style. This had two major downfalls. 
1. The adjacent face ID had to be calculated separately
2. The adjacent face ID was not uniquely identifiable if more than one intersection existed with the same patch.

These issues can be solved if the interfaces do not refer to the neighboring patch ID, but rather to the neighboring face ID in the global counting system.

## Addressed issues
*  Issue was communicated via Rocket.Chat

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
