### PR TITLE
add conform flag to parametric_view

### DIFF
--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -91,6 +91,9 @@ class BSplineBase(spline.Spline):
         if isinstance(knots, float):
             knots = [knots]
 
+        if len(knots) == 0:
+            raise ValueError("Empty knot query.")
+
         if max(knots) > max(self.knot_vectors[parametric_dimension]):
             raise ValueError(
                 "One of the query knots not in valid knot range. (Too big)"
@@ -103,7 +106,7 @@ class BSplineBase(spline.Spline):
             )
 
         inserted = splinepy_core.insert_knots(
-            self, parametric_dimension, knots
+            self, parametric_dimension, utils.data.enforce_contiguous(knots)
         )
 
         self._logd(f"Inserted {len(knots)} knot(s).")
@@ -220,6 +223,9 @@ class BSplineBase(spline.Spline):
         if isinstance(knots, float):
             knots = [knots]
 
+        if len(knots) == 0:
+            raise ValueError("Empty knot query.")
+
         if max(knots) > max(self.knot_vectors[parametric_dimension]):
             raise ValueError(
                 "One of the query knots not in valid knot range. (Too big)"
@@ -234,7 +240,7 @@ class BSplineBase(spline.Spline):
         removed = splinepy_core.remove_knots(
             self,
             parametric_dimension,
-            knots,
+            utils.data.enforce_contiguous(knots),
             tolerance=spline._default_if_none(tolerance, settings.TOLERANCE),
         )
 

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -264,27 +264,35 @@ def from_bounds(parametric_bounds, physical_bounds):
     bspline_box.cps += physical_bounds[0]  # apply offset
 
     # update parametric bounds
+    new_kvs = []
     for i, kv in enumerate(bspline_box.kvs):
         # apply scale and offset
         new_kv = (kv * parametric_bounds[1][i]) + parametric_bounds[0][i]
-        bspline_box.kvs[i] = new_kv
+        new_kvs.append(new_kv)
+
+    # update at once
+    bspline_box.kvs = new_kvs
 
     return bspline_box
 
 
-def parametric_view(spline, axes=True):
+def parametric_view(spline, axes=True, conform=False):
     """Create parametric view of given spline. Previously called
     `naive_spline()`. Degrees are always 1 and knot multiplicity is not
     preserved. Returns BSpline, as BSpline and NURBS should look the same as
     parametric view.
     Will take shallow copy of underlying data of spline_data and show_options
     from original spline.
+    However, if conforming basis is desired, set confrom=True.
 
     Parameters
     -----------
     spline: BSpline or NURBS
     axes: bool
-     If True, will configure axes settings, it is supported.
+      If True, will configure axes settings, it is supported.
+    conform: bool
+      Default is False
+
 
     Returns
     --------
@@ -295,10 +303,47 @@ def parametric_view(spline, axes=True):
         parametric_bounds=p_bounds, physical_bounds=p_bounds
     )
 
-    # loop through knot vectors and insert missing knots
-    for i, kv in enumerate(spline.unique_knots):
-        if len(kv) > 2:
-            para_spline.insert_knots(i, kv[1:-1])
+    # process to create conforming para_view splines
+    if conform:
+        # conforming spline - rational?
+        if spline.is_rational:
+            para_spline = para_spline.nurbs
+
+        # conforming spline - bezier?
+        if not spline.has_knot_vectors:
+            dict_spline = para_spline.todict()
+            dict_spline.pop("knot_vectors")
+            para_spline = type(spline)(**dict_spline)
+
+        # conforming degrees
+        d_diff = spline.degrees - para_spline.degrees
+        if any(d_diff):
+            # turn difference in degrees into degree query
+            d_query = []
+            for i, dq in enumerate(d_diff):
+                d_query += [i] * dq
+            para_spline.elevate_degrees(d_query)
+
+        # process knots to insert
+        if spline.has_knot_vectors:
+            for i, (kv, d) in enumerate(
+                zip(spline.knot_vectors, spline.degrees)
+            ):
+                n_repeating = int(d + 1)
+                query = kv[n_repeating:-n_repeating]
+                if len(query) > 0:
+                    para_spline.insert_knots(i, query)
+
+        # conforming weights
+        if spline.is_rational:
+            para_spline.ws[:] = spline.ws
+
+    elif spline.has_knot_vectors:
+        # in non-conform case, we can just add missing unique knots
+        for i, uk in enumerate(spline.unique_knots):
+            query = uk[1:-1]
+            if len(query) > 0:
+                para_spline.insert_knots(i, query)
 
     # take shallow copy
     para_spline.spline_data._saved = spline.spline_data._saved.copy()

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -265,9 +265,10 @@ def from_bounds(parametric_bounds, physical_bounds):
 
     # update parametric bounds
     new_kvs = []
+    para_size = parametric_bounds[1] - parametric_bounds[0]
     for i, kv in enumerate(bspline_box.kvs):
         # apply scale and offset
-        new_kv = (kv * parametric_bounds[1][i]) + parametric_bounds[0][i]
+        new_kv = (kv * para_size[i]) + parametric_bounds[0][i]
         new_kvs.append(new_kv)
 
     # update at once

--- a/tests/common.py
+++ b/tests/common.py
@@ -424,17 +424,31 @@ def get_spline_dictionaries():
 
 
 class SplineBasedTestCase(unittest.TestCase):
+    def bezier_2p2d(self):
+        return bezier_2p2d()
+
+    def rational_bezier_2p2d(self):
+        return rational_bezier_2p2d()
+
     def bspline_2p2d(self):
         return bspline_2p2d()
 
     def nurbs_2p2d(self):
         return nurbs_2p2d()
 
-    def rational_bezier_2p2d(self):
-        return rational_bezier_2p2d()
+    def all_2p2d_splines(self):
+        return (
+            self.bezier_2p2d(),
+            self.rational_bezier_2p2d(),
+            self.bspline_2p2d(),
+            self.nurbs_2p2d(),
+        )
 
-    def bezier_2p2d(self):
-        return bezier_2p2d()
+    def bezier_3p3d(self):
+        return bezier_3p3d()
+
+    def rational_bezier_3p3d(self):
+        return rational_bezier_3p3d()
 
     def bspline_3p3d(self):
         return bspline_3p3d()
@@ -442,8 +456,10 @@ class SplineBasedTestCase(unittest.TestCase):
     def nurbs_3p3d(self):
         return nurbs_3p3d()
 
-    def bezier_3p3d(self):
-        return bezier_3p3d()
-
-    def rational_bezier_3p3d(self):
-        return rational_bezier_3p3d()
+    def all_3p3d_splines(self):
+        return (
+            self.bezier_3p3d(),
+            self.rational_bezier_3p3d(),
+            self.bspline_3p3d(),
+            self.nurbs_3p3d(),
+        )

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -198,6 +198,5 @@ class CreatorTest(c.SplineBasedTestCase):
             check_parametric_view(spl, True)
 
 
-
 if __name__ == "__main__":
     c.unittest.main()

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -157,6 +157,51 @@ class CreatorTest(c.SplineBasedTestCase):
                 f"{spline_g.whatami} failed revolution around center",
             )
 
+    def test_create_parametric_view(self):
+        """test parametric view"""
+
+        def check_parametric_view(spline, conform):
+            p_spl = spline.create.parametric_view(conform=conform)
+
+            # for both conform and pure view
+            # spl's pbounds and para's physbound are same
+            assert c.np.allclose(
+                p_spl.control_point_bounds, spl.parametric_bounds
+            )
+
+            if conform:
+                # same spline type
+                assert type(p_spl) == type(spline)
+
+                # same degrees
+                assert c.np.allclose(p_spl.ds, spline.ds)
+
+                # same knot_vectors
+                if spline.has_knot_vectors:
+                    for p_kv, kv in zip(p_spl.kvs, spline.kvs):
+                        assert c.np.allclose(p_kv, kv)
+
+                # same weights
+                if spline.is_rational:
+                    assert c.np.allclose(p_spl.ws, spline.ws)
+
+            else:
+                # degrees are one - subtracting 1 should make it all zero
+                assert not any(p_spl.ds - 1)
+
+                # same unique knots - implies same p_bounds
+                for p_ukv, ukv in zip(p_spl.unique_knots, spline.unique_knots):
+                    assert c.np.allclose(p_ukv, ukv)
+
+        for spl in [*self.all_2p2d_splines(), *self.all_3p3d_splines()]:
+            check_parametric_view(spl, False)
+            check_parametric_view(spl, True)
+
+        self.bspline_2p2d()
+        self.nurbs_2p2d()
+        self.bezier_2p2d()
+        self.rational_bezier_2p2d()
+
 
 if __name__ == "__main__":
     c.unittest.main()

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -197,10 +197,6 @@ class CreatorTest(c.SplineBasedTestCase):
             check_parametric_view(spl, False)
             check_parametric_view(spl, True)
 
-        self.bspline_2p2d()
-        self.nurbs_2p2d()
-        self.bezier_2p2d()
-        self.rational_bezier_2p2d()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview
add conform flag to parametric_view. then resulting spline has conforming parametric space and cps are placed on parametric space "box". Expected use case is in interactive mode, where you can set boundary conditions based on difference in control point locations in parametric view. Added test
Also fixes some errors in create

## Addressed issues
*  wrong scaling in `from_bounds()`

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
