### PR TITLE
fix microstructure

### DIFF
--- a/splinepy/microstructure/microstructure.py
+++ b/splinepy/microstructure/microstructure.py
@@ -630,7 +630,7 @@ class Microstructure(SplinepyBase):
                     # derivatives of the composed spline with respect to a
                     # component of a control point within the bezier patch
                     # of the deformation function.
-                    cps = np.hstack(p.cps for p in patch_info)
+                    cps = np.hstack([p.cps for p in patch_info])
                     # We use the matrices to map the contributions of the
                     # bezier ctps to the deformation functions
                     mapped_cps = cps @ knot_insertion_matrices[i_patch]


### PR DESCRIPTION
show_microstructure.py caused TypeError


```bash
Traceback (most recent call last):
  File "splinepy/examples/show_microstructures.py", line 28, in <module>
    ms = generator.create(macro_sensitivities=True)
  File "splinepy/splinepy/microstructure/microstructure.py", line 633, in create
    cps = np.hstack(p.cps for p in patch_info)
  File "lib/python3.10/site-packages/numpy/core/shape_base.py", line 216, in _vhstack_dispatcher
    return _arrays_for_stack_dispatcher(tup)
  File "lib/python3.10/site-packages/numpy/core/shape_base.py", line 209, in _arrays_for_stack_dispatcher
    raise TypeError('arrays to stack must be passed as a "sequence" type '
TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.
```