### PR TITLE
Add gmsh io

### DIFF
--- a/examples/gmsh_from_spline.py
+++ b/examples/gmsh_from_spline.py
@@ -1,0 +1,90 @@
+import gmsh
+
+import splinepy
+
+try:
+    import gustaf as gus
+
+    gus_exists = True
+except ModuleNotFoundError:
+    gus_exists = False
+
+
+if __name__ == "__main__":
+    """Splines are a great parametrization for easy and complex shapes.
+    Isogeometric analysis allows to calculate direct on spline parametrization.
+    However, not every simulation is equipped with the options to use
+    splines for analysis. Thus, it can be necessary to create computational
+    meshes from splines. In this example, we demonstrate how to use gmsh
+    for meshing splinepy splines.
+    """
+
+    ## For simple shapes
+
+    # Init gmsh
+    gmsh.initialize()
+
+    # Create two splines
+    disk = splinepy.helpme.create.disk(1, angle=180)
+    box = splinepy.helpme.create.box(1, 1.2)
+
+    # Add both splines to gmsh, it is necessary to use distinct point IDs
+    dtag, point_tags = splinepy.io.gmsh.spline_to_gmsh(disk)
+    ltag, lpoint_tags = splinepy.io.gmsh.spline_to_gmsh(
+        box, startid=max(point_tags) + 5
+    )
+
+    # Generate mesh
+    gmsh.model.occ.synchronize()
+    gmsh.model.mesh.generate(2)
+    gmsh.write("splines.brep")
+    gmsh.write("splines.msh")
+
+    gmsh.finalize()
+
+    if gus_exists:
+        gus.show(
+            ["Splines", disk, box],
+            ["Mesh", gus.io.load("splines.msh").to_edges()],
+        )
+
+    ## For complex geometries
+
+    # In more complex geometry scripts, it might be necessary
+    # to have more control about the associated point numbers and entities.
+    # For this usecase we provide the data and recommend the user to
+    # add it manually to the geometry
+
+    gmsh.initialize()
+    new_model = gmsh.model
+
+    # Create line
+    line = splinepy.helpme.create.line(
+        [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0.1, 0.8, 0], [0, 0.0, 0.0]]
+    )
+    line.elevate_degrees(0)
+
+    # Add line to gmsh
+    gmsh_points, gmsh_dict = splinepy.io.gmsh.gmsh_data([line])[0]
+
+    tags = list(range(100, 100 + len(gmsh_points)))
+    for tag, point in zip(tags, gmsh_points):
+        new_model.occ.addPoint(*point, tag=tag)
+    linetag = new_model.occ.addBSpline(tags, **gmsh_dict)
+
+    # Create curve line
+    looptag = new_model.occ.addCurveLoop([linetag])
+    # Create surface filling
+    new_model.occ.addSurfaceFilling(looptag)
+
+    new_model.occ.synchronize()
+    new_model.mesh.generate(2)
+
+    # Write files
+    gmsh.write("line.brep")
+    gmsh.write("line.msh")
+
+    if gus_exists:
+        gus.show(
+            ["Spline", line], ["Mesh", gus.io.load("line.msh").to_edges()]
+        )

--- a/splinepy/io/__init__.py
+++ b/splinepy/io/__init__.py
@@ -1,4 +1,15 @@
-from splinepy.io import cats, gismo, iges, ioutils, irit, json, mfem, npz, vtk
+from splinepy.io import (
+    cats,
+    gismo,
+    gmsh,
+    iges,
+    ioutils,
+    irit,
+    json,
+    mfem,
+    npz,
+    vtk,
+)
 
 __all__ = [
     "cats",
@@ -10,4 +21,5 @@ __all__ = [
     "mfem",
     "npz",
     "vtk",
+    "gmsh",
 ]

--- a/splinepy/io/gmsh.py
+++ b/splinepy/io/gmsh.py
@@ -1,0 +1,128 @@
+import gmsh
+import numpy as np
+
+
+def spline_to_gmsh(spline, model=None, startid=1):
+    if model is None:
+        model = gmsh.model
+
+    points, gmsh_dict = gmsh_data([spline])[0]
+
+    for i, point in enumerate(points):
+        model.occ.addPoint(*point, tag=startid + i)
+
+    if spline.para_dim == 1:
+        tag = gmsh.model.occ.addBSpline(
+            pointTags=np.arange(startid, startid + points.shape[0]),
+            **gmsh_dict,
+        )
+
+    elif spline.para_dim == 2:
+        tag = gmsh.model.occ.addBSplineSurface(
+            pointTags=np.arange(startid, startid + points.shape[0]),
+            **gmsh_dict,
+        )
+    else:
+        raise ValueError(
+            f"Spline has parametric dimension {spline.para_dim} and is not supported."
+        )
+    return tag, np.arange(startid, startid + points.shape[0])
+
+
+def gmsh_data(splines):
+    gmsh_data = []
+    for spline in splines:
+        # Line
+        if spline.para_dim == 1:
+            gmsh_data.append(gmsh_line(spline))
+        # Surface
+        elif spline.para_dim == 2:
+            gmsh_data.append(gmsh_surface(spline))
+        else:
+            raise ValueError(
+                f"""Gmsh meshing only supports line and surface splines,
+                your spline is of degree {spline.para_dim}"""
+            )
+    return gmsh_data
+
+
+def gmsh_line(spline):
+    if spline.para_dim != 1:
+        raise ValueError(
+            f"Spline has parametric dimension {spline.para_dim} and is not supported."
+        )
+    if spline.control_points.shape[1] > 3:
+        raise ValueError(
+            "Gmsh export supports only three-dimensional geometries."
+        )
+
+    # Embed control points in 3D
+    cps = np.hstack(
+        [
+            spline.control_points,
+            np.zeros(
+                [
+                    spline.control_points.shape[0],
+                    3 - spline.control_points.shape[1],
+                ]
+            ),
+        ]
+    )
+
+    # Get knov values and multiplities
+    kv0, km0 = np.unique(spline.nurbs.knot_vectors[0], return_counts=True)
+
+    properties = {
+        "degree": spline.degrees[0],
+        "knots": kv0,
+        "multiplicities": km0,
+        "weights": spline.nurbs.weights.flatten(),
+    }
+
+    return cps, properties
+
+
+def gmsh_surface(spline):
+    if spline.para_dim != 2:
+        raise ValueError(
+            f"Spline has parametric dimension {spline.para_dim} and is not supported."
+        )
+    if spline.control_points.shape[1] > 3:
+        raise ValueError(
+            "Gmsh export supports only three-dimensional geometries."
+        )
+
+    # Embed control points in 3D
+    cps = np.hstack(
+        [
+            spline.control_points,
+            np.zeros(
+                [
+                    spline.control_points.shape[0],
+                    3 - spline.control_points.shape[1],
+                ]
+            ),
+        ]
+    )
+
+    # Number of control points in first direction
+    len(spline.nurbs.knot_vectors[0]) - spline.degrees[0] - 1
+
+    # Get knov values and multiplities
+    kv0, km0 = np.unique(spline.nurbs.knot_vectors[0], return_counts=True)
+    kv1, km1 = np.unique(spline.nurbs.knot_vectors[1], return_counts=True)
+
+    properties = {
+        "numPointsU": len(spline.nurbs.knot_vectors[0])
+        - spline.degrees[0]
+        - 1,
+        "degreeU": spline.degrees[0],
+        "degreeV": spline.degrees[1],
+        "knotsU": kv0,
+        "knotsV": kv1,
+        "multiplicitiesU": km0,
+        "multiplicitiesV": km1,
+        "weights": spline.nurbs.weights.flatten(),
+    }
+
+    return cps, properties

--- a/splinepy/io/gmsh.py
+++ b/splinepy/io/gmsh.py
@@ -3,6 +3,26 @@ import numpy as np
 
 
 def spline_to_gmsh(spline, model=None, startid=1):
+    """Add a spline as an entity to a gmsh model.
+
+    Parameters
+    ----------
+    spline : splinepy.spline
+        Input spline
+    model : gmsh.model, optional
+    startid : int, optional
+        Start id of gmsh points, by default 1
+
+    Returns
+    -------
+    int, np.ndarray(int)
+        tag of gmsh object and of point ids
+
+    Raises
+    ------
+    ValueError
+        Raises exception if spline dimension is not supported.
+    """
     if model is None:
         model = gmsh.model
 
@@ -30,6 +50,24 @@ def spline_to_gmsh(spline, model=None, startid=1):
 
 
 def gmsh_data(splines):
+    """Create gmsh data for splines lies
+
+    Parameters
+    ----------
+    splines : list
+        Input splines
+
+    Returns
+    -------
+    iterable
+        Iterable of points and gmsh dict
+
+    Raises
+    ------
+    ValueError
+        Raises exception if spline dimension is not supported.
+    """
+
     gmsh_data = []
     for spline in splines:
         # Line
@@ -47,6 +85,24 @@ def gmsh_data(splines):
 
 
 def gmsh_line(spline):
+    """Create gmsh data for lines pline
+
+    Parameters
+    ----------
+    spline : splinepy.spline
+
+    Returns
+    -------
+    np.ndarray, dict
+        points, gmsh arguments
+
+    Raises
+    ------
+    ValueError
+        Spline dimension is wrong.
+    ValueError
+        Control point coordinates are larger than three.
+    """
     if spline.para_dim != 1:
         raise ValueError(
             f"Spline has parametric dimension {spline.para_dim} and is not supported."
@@ -83,6 +139,25 @@ def gmsh_line(spline):
 
 
 def gmsh_surface(spline):
+    """Create gmsh data for surface spline
+
+    Parameters
+    ----------
+    spline : splinepy.spline
+
+    Returns
+    -------
+    np.ndarray, dict
+        points, gmsh arguments
+
+    Raises
+    ------
+    ValueError
+        Spline dimension is wrong.
+    ValueError
+        Control point coordinates are larger than three.
+    """
+
     if spline.para_dim != 2:
         raise ValueError(
             f"Spline has parametric dimension {spline.para_dim} and is not supported."


### PR DESCRIPTION
# Overview
Splines are a great parametrization for easy and complex shapes.  Isogeometric analysis allows to calculate direct on spline parametrization.  However, not every simulation is equipped with the options to use splines for analysis. Thus, it can be necessary to create computational  meshes from splines. In this example, we demonstrate how to use gmsh  for meshing splinepy splines. In this sense, a connection to gmsh can allow connection between the users of these OpenSource tools. 

## Addressed issues
*  None


## Showcase
A short / one-liner example to highlight the (new) feature
```
import splinepy
import gmsh

gmsh.initialize()
dtag, point_tags = splinepy.io.gmsh.spline_to_gmsh(splinepy.helpme.create.disk(1, angle=180))
    
```

## Checklists
* [x] Documentations are up-to-date.
* [x] Added example(s)
* [x] Added test(s)

![screenshot](https://github.com/tataratat/splinepy/assets/18384259/1b614cb6-c851-4a5a-8378-182ea33d9657)
