### PR TITLE
add shortcut to gus.show

### DIFF
--- a/splinepy/__init__.py
+++ b/splinepy/__init__.py
@@ -1,3 +1,5 @@
+from gustaf import show  # shortcut for frequently used module / func
+
 from splinepy import (
     bezier,
     bspline,
@@ -72,4 +74,5 @@ __all__ = [
     "load_splines",
     "load_solution",
     "to_derived",
+    "show",
 ]


### PR DESCRIPTION
# Overview
often, I need to import gustaf separately just to use `gus.show()` let's save that step

## Showcase
A short / one-liner example to highlight the (new) feature
```python
import splinepy

splinepy.show(splinepy.helpme.create.surface_circle(12), splinepy.helpme.create.box(1,2,3))
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
