### PR TITLE
fix unused function warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,17 @@ jobs:
     - name: build splinepy linux - gcc10
       if: matrix.os == 'ubuntu-20.04'
       run: |
-        CC=gcc-10 CXX=g++-10 python3 setup.py install --minimal --debug
+        CC=gcc-10 CXX=g++-10 python3 setup.py install --minimal --debug --enable_warning
 
     - name: build splinepy macos
       if: matrix.os == 'macos-latest'
       run: |
-        python3 setup.py develop --minimal --debug
+        python3 setup.py develop --minimal --debug --enable_warning
 
     - name: build splinepy windows
       if: matrix.os == 'windows-latest'
       run: |
-        python3 setup.py develop --minimal
+        python3 setup.py develop --minimal --enable_warning
 
     - name: test
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,12 @@ endif()
 
 # compiler specific flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  set(SPLINEPY_WARNING_FLAGS -Wall -Wextra -Wpedantic
+  set(SPLINEPY_WARNING_FLAGS -Werror -Wall -Wextra -Wpedantic
                              -Wzero-as-null-pointer-constant -Wno-unused)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(SPLINEPY_WARNING_FLAGS
+      -Werror
       -Wall
-      -Wextra
       -Wmost
       -Wextra
       -Wpedantic

--- a/include/splinepy/py/py_spline_extensions.hpp
+++ b/include/splinepy/py/py_spline_extensions.hpp
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 
 #include "splinepy/py/py_spline.hpp"
+#include "splinepy/splines/null_spline.hpp"
 
 namespace splinepy::py {
 
@@ -99,7 +100,10 @@ bool HasCore(const std::shared_ptr<PySpline>& spline);
 void AnnulCore(std::shared_ptr<PySpline>& spline);
 
 /// null spline creator
-static std::shared_ptr<PySpline> CreateNullSpline(const int para_dim,
-                                                  const int dim);
+static inline std::shared_ptr<PySpline> CreateNullSpline(const int para_dim,
+                                                         const int dim) {
+  return std::make_shared<PySpline>(
+      splinepy::splines::kNullSplineLookup[para_dim - 1][dim - 1]);
+}
 
 } // namespace splinepy::py

--- a/src/py/py_spline_extensions.cpp
+++ b/src/py/py_spline_extensions.cpp
@@ -1,6 +1,5 @@
 #include "splinepy/py/py_spline_extensions.hpp"
 #include "splinepy/splines/helpers/scalar_type_wrapper.hpp"
-#include "splinepy/splines/null_spline.hpp"
 
 namespace splinepy::py {
 
@@ -235,12 +234,6 @@ void AnnulCore(std::shared_ptr<PySpline>& spline) {
   spline->c_spline_ = nullptr;
   spline->para_dim_ = -1;
   spline->dim_ = -1;
-}
-
-static std::shared_ptr<PySpline> CreateNullSpline(const int para_dim,
-                                                  const int dim) {
-  return std::make_shared<PySpline>(
-      splinepy::splines::kNullSplineLookup[para_dim - 1][dim - 1]);
 }
 
 void init_spline_extensions(py::module& m) {

--- a/src/splines/splinepy_base.cpp
+++ b/src/splines/splinepy_base.cpp
@@ -419,7 +419,7 @@ SplinepyBase::SplinepyKnotVector(const int p_dim) {
   splinepy::utils::PrintAndThrowError("SplinepyKnotVector not implemented for",
                                       SplinepyWhatAmI());
   return nullptr;
-};
+}
 
 std::shared_ptr<typename SplinepyBase::ControlPointPointers_>
 SplinepyBase::SplinepyControlPointPointers() {


### PR DESCRIPTION
# Overview
- fixes unused function warning use by making the function `static inline`. 
- adds `Werror` to `--enable_warning`