### PR TITLE
Add quotation marks around splinepy[all]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library supports Bezier, Rational Bezier, BSpline and NURBS with fast and ea
 ## Install guide
 splinepy wheels are available for python3.6+ for MacOS, Linux, and Windows:
 ```bash
-pip install splinepy[all]  # including all optional dependencies
+pip install "splinepy[all]"  # including all optional dependencies
 # or
 pip install splinepy
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The library supports Bezier, Rational Bezier, BSpline and NURBS with fast and ea
 ## Install guide
 splinepy wheels are available for python3.6+ for MacOS, Linux, and Windows:
 ```bash
-pip install "splinepy[all]"  # including all optional dependencies
+# including all optional dependencies
+pip install "splinepy[all]"  # quotation marks required for some shells
 # or
 pip install splinepy
 ```


### PR DESCRIPTION
# Overview
Fixed a small issue in the `README.md` file, where the installation of splinepy with all dependencies was displayed a little misleadingly as 

```bash
pip install splinepy[all]
```

while this for instance does not work on the Mac shell. Instead, it will now be displayed as

```bash
pip install "splinepy[all]"
```

which should work both on Mac and other OS.