### PR TITLE
fix shared lib build

### DIFF
--- a/src/explicit/CMakeLists.txt
+++ b/src/explicit/CMakeLists.txt
@@ -47,7 +47,7 @@ if(SPLINEPY_MORE)
                              ${SPLINEPY_MORE_EXPLICIT_SRCS})
 endif(SPLINEPY_MORE)
 
-add_library(explicit ${SPLINEPY_LIB_TYPE} ${SPLINEPY_EXPLICIT_SRCS})
+add_library(explicit OBJECT ${SPLINEPY_EXPLICIT_SRCS})
 
 # include
 target_include_directories(


### PR DESCRIPTION
# Overview
make splinepy::explicit object target.
Otherwise this will have to be a circular dependency.
