### PR TITLE
added export check to splinepy/io/iges.py

### DIFF
--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -56,6 +56,8 @@ def export(fname, splines):
             )
         else:
             valid_splines.append(spline)
-    if not valid_splines:
-        log.warning("No valid splines found in the given input")
+
+    if len(valid_splines) == 0:
+        raise ValueError("No valid splines found in the given input")
+
     return splinepy_core.export_iges(fname, valid_splines)

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -36,7 +36,9 @@ def export(fname, splines):
     """
     # check if any spline contains volume elements
     for ispl, spline in enumerate(splines):
-      if spline.para_dim == 3:
-          raise ValueError(f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the .iges file format \n"
-                           "Use a boundary representation instead by calling e.g. multipatch.boundary_multipatch()")
+        if spline.para_dim == 3:
+            raise ValueError(
+                f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the .iges file format \n"
+                "Use a boundary representation instead by calling e.g. multipatch.boundary_multipatch()"
+            )
     return splinepy_core.export_iges(fname, splines)

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -38,7 +38,9 @@ def export(fname, splines):
     for ispl, spline in enumerate(splines):
         if spline.para_dim > 2 or spline.dim > 3:
             raise ValueError(
-                f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the .iges file format \n"
-                "Use a boundary representation instead by calling e.g. multipatch.boundary_multipatch()"
+                f"Volumetric {type(spline)} found at splines[{ispl}]"
+                 "which cannot be handled by the .iges file format \n"
+                "Use a boundary representation instead by calling e.g."
+                "multipatch.boundary_multipatch()"
             )
     return splinepy_core.export_iges(fname, splines)

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -41,6 +41,6 @@ def export(fname, splines):
                 f"Volumetric {type(spline)} found at splines[{ispl}]"
                 "which cannot be handled by the .iges file format \n"
                 "Use a boundary representation instead by calling e.g."
-                "multipatch.boundary_multipatch()"
+                "spline.extract.boundaries()"
             )
     return splinepy_core.export_iges(fname, splines)

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -39,7 +39,7 @@ def export(fname, splines):
         if spline.para_dim > 2 or spline.dim > 3:
             raise ValueError(
                 f"Volumetric {type(spline)} found at splines[{ispl}]"
-                 "which cannot be handled by the .iges file format \n"
+                "which cannot be handled by the .iges file format \n"
                 "Use a boundary representation instead by calling e.g."
                 "multipatch.boundary_multipatch()"
             )

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -34,4 +34,9 @@ def export(fname, splines):
     --------
     None
     """
+    # check if any spline contains volume elements
+    for ispl, spline in enumerate(splines):
+      if spline.para_dim == 3:
+          raise ValueError(f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the .iges file format \n"
+                           "Use a boundary representation instead by calling e.g. multipatch.boundary_multipatch()")
     return splinepy_core.export_iges(fname, splines)

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -35,29 +35,29 @@ def export(fname, splines):
     --------
     None
     """
-    # create empty valid spline array
-    valid_splines = []
-    # check if any spline contains volume elements
-    for ispl, spline in enumerate(splines):
-        if spline.para_dim > 2 or spline.dim > 3:
-            log.warning(
-                f"Skipping volumetric {type(spline)} found at splines[{ispl}]"
-                "which cannot be handled by the .iges file format \n"
-                "To include this spline, use a boundary representation "
-                "instead, by calling e.g. spline.extract.boundaries()"
-            )
-        elif spline.para_dim > spline.dim:
-            log.warning(
-                f"Skipping {type(spline)} at splines[{ispl}]\n"
-                f"Parametric dimension ({spline.para_dim}) is higher than the"
-                f" physical dimension ({spline.dim}) at splines[{ispl}]\n"
-                " Parametric dimension must be smaller or equal to the"
-                " physical dimension."
-            )
-        else:
-            valid_splines.append(spline)
+    try:
+        return splinepy_core.export_iges(fname, splines)
 
-    if len(valid_splines) == 0:
-        raise ValueError("No valid splines found in the given input")
+    except RuntimeError:
+        # create empty valid spline array
+        valid_splines = []
+        # check if any spline contains volume elements
+        for ispl, spline in enumerate(splines):
+            if spline.para_dim > 2:
+                log.warning(
+                    f"Skipping volumetric {type(spline)} at splines[{ispl}]"
+                    "which cannot be handled by the .iges file format \n"
+                    "To include this spline, use a boundary representation "
+                    "instead, by calling e.g. spline.extract.boundaries()"
+                )
+            elif spline.dim > 3:
+                log.warning(
+                    f"Skipping high dim {type(spline)} at splines[{ispl}]"
+                    "which cannot be handled by the .iges file format."
+                    "iges supports up to dim=3."
+                )
+            else:
+                valid_splines.append(spline)
 
-    return splinepy_core.export_iges(fname, valid_splines)
+        if len(valid_splines) == 0:
+            raise ValueError("No valid splines found in the given input")

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -36,7 +36,7 @@ def export(fname, splines):
     """
     # check if any spline contains volume elements
     for ispl, spline in enumerate(splines):
-        if spline.para_dim == 3:
+        if spline.para_dim > 2 or spline.dim > 3:
             raise ValueError(
                 f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the .iges file format \n"
                 "Use a boundary representation instead by calling e.g. multipatch.boundary_multipatch()"

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -2,6 +2,7 @@
 iges io.
 """
 from splinepy import splinepy_core
+from splinepy.utils import log
 
 
 def load(fname):
@@ -34,13 +35,27 @@ def export(fname, splines):
     --------
     None
     """
+    # create empty valid spline array
+    valid_splines = []
     # check if any spline contains volume elements
     for ispl, spline in enumerate(splines):
         if spline.para_dim > 2 or spline.dim > 3:
-            raise ValueError(
-                f"Volumetric {type(spline)} found at splines[{ispl}]"
+            log.warning(
+                f"Skipping volumetric {type(spline)} found at splines[{ispl}]"
                 "which cannot be handled by the .iges file format \n"
-                "Use a boundary representation instead by calling e.g."
-                "spline.extract.boundaries()"
+                "To include this spline, use a boundary representation "
+                "instead, by calling e.g. spline.extract.boundaries()"
             )
-    return splinepy_core.export_iges(fname, splines)
+        elif spline.para_dim > spline.dim:
+            log.warning(
+                f"Skipping {type(spline)} at splines[{ispl}]\n"
+                f"Parametric dimension ({spline.para_dim}) is higher than the"
+                f" physical dimension ({spline.dim}) at splines[{ispl}]\n"
+                " Parametric dimension must be smaller or equal to the"
+                " physical dimension."
+            )
+        else:
+            valid_splines.append(spline)
+    if not valid_splines:
+        log.warning("No valid splines found in the given input")
+    return splinepy_core.export_iges(fname, valid_splines)

--- a/tests/test_iges.py
+++ b/tests/test_iges.py
@@ -1,0 +1,57 @@
+import tempfile
+
+try:
+    from . import common as c
+except BaseException:
+    import common as c
+
+
+class IGESExportTest(c.unittest.TestCase):
+    def test_iges_round_trip_bsplines(self):
+        """
+        Test npz export-import routine
+        """
+        bsp_el2 = c.splinepy.BSpline(
+            degrees=[1, 1],
+            control_points=[[0, 1], [1, 1], [0, 2], [1, 2]],
+            knot_vectors=[[0, 0, 1, 1], [0, 0, 1, 1]],
+        )
+        nur_el3 = c.splinepy.NURBS(
+            degrees=[1, 1],
+            control_points=[[1, 1], [2, 1], [1, 2], [2, 2]],
+            weights=[1, 1, 1, 1],
+            knot_vectors=[[0, 0, 1, 1], [0, 0, 1, 1]],
+        )
+
+        # Make it more tricky
+        bsp_el2.elevate_degrees(0)
+        bsp_el2.elevate_degrees(1)
+        nur_el3.elevate_degrees(0)
+        nur_el3.elevate_degrees(1)
+        bsp_el2.insert_knots(1, [0.5])
+        nur_el3.insert_knots(1, [0.5])
+
+        # Test output against input
+        list_of_splines = [bsp_el2, nur_el3]
+        with tempfile.TemporaryDirectory() as tmpd:
+            tmpf = c.to_tmpf(tmpd)
+            c.splinepy.io.iges.export(tmpf, list_of_splines)
+            list_of_splines_loaded = c.splinepy.io.iges.load(tmpf)
+
+            # to compare we need 3d "bumped" splines of originals
+            splines_in_3d = []
+            for s in list_of_splines:
+                tmp_s = s.copy()
+                tmp_s.cps = c.np.hstack(
+                    [tmp_s.cps, c.np.zeros((len(tmp_s.cps), 1))]
+                )
+                splines_in_3d.append(tmp_s)
+
+            assert all(
+                c.are_splines_equal(a, b)
+                for a, b in zip(splines_in_3d, list_of_splines_loaded)
+            )
+
+
+if __name__ == "__main__":
+    c.unittest.main()


### PR DESCRIPTION
# Overview
iges export now checks parametric dimension of spline, if it is 3, then a value error is raised and a suggestion for a solution is presented

## Addressed issues
*  solved issue #272

## Showcase
calling the example from the issue now gives the following error:
```
ValueError                                Traceback (most recent call last)
[c:\Users\mkofler\miniconda3\envs\splinepy_dev\Lib\site-packages\splinepy\microstructure_fix.ipynb](file:///C:/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb) Cell 3 line 1
     [13](vscode-notebook-cell:/c%3A/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb#W0sZmlsZQ%3D%3D?line=12) microstructure.microtile = getattr(sp.microstructure.tiles, "NutTile3D")().create_tile()[0]
     [14](vscode-notebook-cell:/c%3A/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb#W0sZmlsZQ%3D%3D?line=13) microstructure.tiling = [8, 4, 1]
---> [16](vscode-notebook-cell:/c%3A/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb#W0sZmlsZQ%3D%3D?line=15) sp.io.iges.export("test.igs",microstructure.create().patches)
     [17](vscode-notebook-cell:/c%3A/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb#W0sZmlsZQ%3D%3D?line=16) ig = sp.io.iges.load("test.igs")
     [18](vscode-notebook-cell:/c%3A/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/microstructure_fix.ipynb#W0sZmlsZQ%3D%3D?line=17) ig.show(control_points=False)

File [c:\Users\mkofler\miniconda3\envs\splinepy_dev\Lib\site-packages\splinepy\io\iges.py:41](file:///C:/Users/mkofler/miniconda3/envs/splinepy_dev/Lib/site-packages/splinepy/io/iges.py:41), in export(fname, splines)
     39 for ispl, spline in enumerate(splines):
     40   if spline.para_dim == 3:
---> 41       raise ValueError(f"Volumetric {type(spline)} found at splines[{ispl}], which cannot be handled by the Iges file format \n"
     42                        "Use a boundary representation instead by calling e.g. spline.boundary_multipatch()")
     44 return splinepy_core.export_iges(fname, splines)

ValueError: Volumetric <class 'splinepy.bezier.Bezier'> found at splines[0], which cannot be handled by the Iges file format 
Use a boundary representation instead by calling e.g. spline.boundary_multipatch()
```
## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s), is this necessary?

