### PR TITLE
Add: Move configurations from precommit to  pyproject.toml.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: "23.9.1"
   hooks:
   - id: black
-    args: [--line-length=79]
+    additional_dependencies: [tomli]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.292
@@ -65,10 +65,11 @@ repos:
   rev: v2.2.6
   hooks:
   - id: codespell
-    args: [-w, "-L connec"]
+    args: [-w]
+    additional_dependencies: [tomli]
 
 - repo: https://github.com/keewis/blackdoc
   rev: v0.3.8
   hooks:
   - id: blackdoc
-    args: [--line-length=75]
+    additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,10 @@ repos:
   - id: check-toml
   - id: check-yaml
   - id: debug-statements
+  - id: end-of-file-fixer
   - id: mixed-line-ending
   - id: requirements-txt-fixer
+  - id: trailing-whitespace
 
 - repo: https://github.com/psf/black
   rev: "23.9.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,21 +22,8 @@ repos:
   - id: check-toml
   - id: check-yaml
   - id: debug-statements
-  - id: end-of-file-fixer
   - id: mixed-line-ending
   - id: requirements-txt-fixer
-  - id: trailing-whitespace
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: "v3.15.0"
-  hooks:
-  - id: pyupgrade
-    args: [--py36-plus]
-
-- repo: https://github.com/PyCQA/isort
-  rev: "5.12.0"
-  hooks:
-  - id: isort
 
 - repo: https://github.com/psf/black
   rev: "23.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,14 @@ ignore = [
 "setup.py" = ["T201"]
 "examples/*.py" = ["T201"]
 "tests/common.py" = ["T201"]
+
+[tool.codespell]
+ignore-words-list = "connec"
+skip="./docs/source/_generated/**,./docs/build/*,./build/*,./third_party/*"
+
+[tool.black]
+line-length = 79
+exclude = "third_party"
+
+[tool.blackdoc]
+line-length = 75

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ select = [
   "SIM",         # flake8-simplify
   "T20",         # flake8-print
   "NPY",         # numpy specific rules
+  "I",           # isort specific rules
+  "UP",          # pyupdate specific rules
+  "C400","C401","C402","C403","C404","C405" # additional pyupgrade rules
 ]
 fixable = ["ALL"]
 target-version = "py37"

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -257,7 +257,7 @@ def export(
 
     # All entries in gismo xml file have a unique ID
     xml_data = ET.Element("xml")
-    index_offset = int(100)
+    index_offset = 100
 
     # First export Multipatch information
     multipatch_element = ET.SubElement(

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -6,9 +6,8 @@ import os
 
 import numpy as np
 
-from splinepy import helpme, io, settings
+from splinepy import helpme, io, settings, utils
 from splinepy import splinepy_core as core
-from splinepy import utils
 from splinepy._base import SplinepyBase
 from splinepy.helpme import visualize
 from splinepy.helpme.check import Checker


### PR DESCRIPTION
# Overview
Move the configuration of the tools used in our pre-commit to the `pyproject` file. This will enable us to have more consistent results running these tools outside the pre-commit environment.

The tools will look for a possible configuration in the `pyproject` file therefore, if we configure them there the configuration is consistent between different invocations of these tools.

## Addressed issues
*  configuration differs when running a tool defined in the pre-commit on its own without invoking pre-commit.

## Still existing issue
* Configuration can only be read in if the package `tomli` is installed. I have added the need for this package to the pre-commit configuration, but if a tool is invoked on its own, the user might (depended on the python version/package is installed due to other dependencies) need to install the package own their own.

## Checklists
* [ ] Documentations are up-to-date.
 * The only thing is that dependent on the python version the configuration only gets picked up if `tomli` is installed so that the `pyproject.toml` can be read in.
* [x] Added example(s)
 * No need
* [x] Added test(s)
 * No need