### PR TITLE
tparam-free proximity

### DIFF
--- a/include/splinepy/proximity/proximity.hpp
+++ b/include/splinepy/proximity/proximity.hpp
@@ -3,6 +3,7 @@
 #include <napf.hpp>
 
 #include <splinepy/splines/helpers/properties.hpp>
+#include <splinepy/splines/splinepy_base.hpp>
 #include <splinepy/utils/arrays.hpp>
 #include <splinepy/utils/grid_points.hpp>
 #include <splinepy/utils/nthreads.hpp>
@@ -20,63 +21,33 @@ namespace splinepy::proximity {
  * For detailed information, please take a look at splinepy python
  * documentation.
  */
-template<typename SplineType>
 class Proximity {
 public:
-  /// Options for initial guess
-  enum class InitialGuess : int { MidPoint = 0, KdTree = 1 };
+  /// @brief array cloud that wraps data of Array
+  using Cloud_ = napf::ArrayCloud<double, int>;
+  /// @brief metric is L2 and this returns squared distance
+  using Tree_ = napf::ArrayTree<double, double, int, 2>;
 
-  // Frequently used array alias
-  using DArrayD_ = std::array<double, SplineType::kDim>;
-  using PArrayD_ = std::array<double, SplineType::kParaDim>;
-  using DArrayI_ = std::array<int, SplineType::kDim>;
-  using PArrayI_ = std::array<int, SplineType::kParaDim>;
-  using PxPMatrixD_ = std::array<std::array<double, SplineType::kParaDim>,
-                                 SplineType::kParaDim>;
-  using PxDMatrixD_ =
-      std::array<std::array<double, SplineType::kDim>, SplineType::kParaDim>;
-  // kdtree related alias
-  // C-Array instead of vector to avoid default init
-  using Coordinates_ = typename SplineType::Coordinate_[];
-  using Cloud_ = typename napf::
-      CoordinatesCloud<std::unique_ptr<Coordinates_>, int, SplineType::kDim>;
-  // metric is L2 and returned distance will be squared.
-  using Tree_ =
-      typename std::conditional<(SplineType::kDim < 4),
-                                napf::CoordinatesTree<double, /* DataT */
-                                                      double, /* DistT */
-                                                      int,    /* IndexType */
-                                                      SplineType::kDim, /* dim
-                                                                         */
-                                                      2,       /* metric (L2) */
-                                                      Cloud_>, /* Cloud T */
-                                napf::CoordinatesHighDimTree<double,
-                                                             double,
-                                                             int,
-                                                             SplineType::kDim,
-                                                             2,
-                                                             Cloud_>>::type;
-  using GridPoints_ =
-      splinepy::utils::GridPoints<double, int, SplineType::kParaDim>;
+  using RealArray_ = splinepy::utils::Array<double>;
+  using RealArray2D_ = splinepy::utils::Array<double, 2>;
+  using RealArray3D_ = splinepy::utils::Array<double, 3>;
+  using IndexArray_ = splinepy::utils::Array<int>;
 
+  using SystemMatrix = splinepy::utils::Matrix<double, int>;
+
+protected:
+  // helpee spline
+  const splinepy::splines::SplinepyBase& spline_;
+
+  // kdtree related variables
+  splinepy::utils::CStyleArrayPointerGridPoints grid_points_;
+  RealArray_ sampled_spline_;
+  std::unique_ptr<Cloud_> cloud_;
+  std::unique_ptr<Tree_> kdtree_;
+
+public:
   /// Constructor. As a spline helper class, always need a spline.
-  Proximity(SplineType const& spline) : spline_(spline){};
-
-  /*!
-   * Computes difference between physical query and current parametric guess.
-   *
-   * @param[in] query
-   * @param[in] guess
-   * @param[out] difference query - guess
-   */
-  void GuessMinusQuery(const typename SplineType::ParametricCoordinate_& guess,
-                       const double* query,
-                       DArrayD_& difference) const {
-
-    splinepy::utils::FirstMinusSecondEqualsThird(spline_(guess),
-                                                 query,
-                                                 difference);
-  }
+  Proximity(const splinepy::splines::SplinepyBase& spline) : spline_(spline){};
 
   /*!
    * Plants a kdtree with given resolution.
@@ -88,26 +59,35 @@ public:
    * @param resolutions parameter space sampling resolution
    * @param n_thread number of threads to be used for sampling
    */
-  void PlantNewKdTree(const PArrayI_& resolutions, const int n_thread = 1) {
-    // create fresh grid_points_ and coordinates_
-    const auto parametric_bounds =
-        splinepy::splines::helpers::GetParametricBounds(spline_);
-    grid_points_ = GridPoints_(parametric_bounds, resolutions);
-    coordinates_ = std::make_unique<Coordinates_>(grid_points_.Size());
+  void PlantNewKdTree(const int* resolutions, const int n_thread = 1) {
+    const int para_dim = spline_.SplinepyParaDim();
+    const int dim = spline_.SplinepyDim();
+
+    // get parametric bounds
+    RealArray_ parametric_bounds(para_dim * 2);
+    spline_.SplinepyParametricBounds(parametric_bounds.data());
+
+    // create grid_points
+    grid_points_.SetUp(para_dim, parametric_bounds.data(), resolutions);
+
+    const int n_queries = grid_points_.Size();
+
+    // reallocate sampled spline
+    sampled_spline_.Reallocate(n_queries * dim);
 
     // lambda function to allow n-thread execution
     auto sample_coordinates = [&](int begin, int end) {
-      typename SplineType::ParametricCoordinate_ parametric_coordinate;
+      RealArray_ query(para_dim);
+      double* query_data = query.data();
+
       for (int i{begin}; i < end; ++i) {
-        grid_points_.IndexToGridPoint(i, parametric_coordinate);
-        coordinates_[i] = spline_(parametric_coordinate);
+        grid_points_.IdToGridPoint(i, query_data);
+        spline_.SplinepyEvaluate(query_data, &sampled_spline_[i * dim]);
       }
     };
 
-    // n-thread execution
-    splinepy::utils::NThreadExecution(sample_coordinates,
-                                      grid_points_.Size(),
-                                      n_thread);
+    // n-thread execution for sampling
+    splinepy::utils::NThreadExecution(sample_coordinates, n_queries, n_thread);
 
     // nanoflann supports concurrent build
     nanoflann::KDTreeSingleIndexAdaptorParams params{};
@@ -116,231 +96,147 @@ public:
         (n_thread < 0) ? 0 : n_thread);
 
     // plant a new tree
-    coordinates_cloud_ =
-        std::make_unique<Cloud_>(coordinates_, grid_points_.Size());
-    kdtree_ = std::make_unique<Tree_>(SplineType::kDim, *coordinates_cloud_);
-    kdtree_planted_ = true;
+    cloud_ = std::make_unique<Cloud_>(sampled_spline_.data(),
+                                      sampled_spline_.size(),
+                                      dim);
+    kdtree_ = std::make_unique<Tree_>(dim, *cloud_, params);
   }
 
-  /// Make initial guess of choice
-  typename SplineType::ParametricCoordinate_
-  MakeInitialGuess(const int& initial_guess, const double* goal) const {
+  /// @brief difference = spline(guess) - query. In current formulation, this is
+  /// our objective function.
+  /// @param guess
+  /// @param query
+  /// @param difference
+  void GuessMinusQuery(const RealArray_& guess,
+                       const RealArray_& query,
+                       RealArray_& difference) const {
+    // evaluate guess and sett to difference
+    spline_.SplinepyEvaluate(guess.data(), difference.data());
+    // subtract query from evaluated guess
+    difference.Subtract(query);
+  }
 
-    if (initial_guess == static_cast<int>(InitialGuess::MidPoint)) {
-      const auto parametric_bounds =
-          splinepy::splines::helpers::GetParametricBounds(spline_);
+  /// @brief difference = spline(guess) - query.
+  /// This returns spline(guess)
+  /// @param guess
+  /// @param query
+  /// @param guess_phys
+  /// @param difference
+  void GuessMinusQuery(const RealArray_& guess,
+                       const RealArray_& query,
+                       RealArray_& guess_phys,
+                       RealArray_& difference) const {
+    spline_.SplinepyEvaluate(guess.data(), guess_phys.data());
+    splinepy::utils::Subtract(guess_phys, query, difference);
+  }
 
-      typename SplineType::ParametricCoordinate_ mean;
-      splinepy::utils::Mean(parametric_bounds[0], parametric_bounds[1], mean);
-
-      return mean;
-
-    } else if (initial_guess == static_cast<int>(InitialGuess::KdTree)) {
-      if (!kdtree_planted_) {
-        // hate to be aggressive, but here it is.
-        splinepy::utils::PrintAndThrowError(
-            "to use InitialGuess::Kdtree option,"
-            "please first plant a kdtree.",
-            "For example:\n",
-            "  SplineType spline{ ... /* spline init */ };\n",
-            "  std::array<int, SplineType::kParaDim>",
-            "resolutions{ ... /* kdtree sample resolutions*/ };\n",
-            "  const int nthreads = ... /* number of threads */;\n",
-            "  spline.GetProximity().PlantNewKdTree(resolutions, nthreads);\n",
-            "\n  /* For SplinepyBase */\n"
-            "  SplinepyBase spline{... /* splinepybase init */};\n",
-            "  std::vector<int> resolutions(spline.SplinepyParaDim());\n",
-            "  ... /* fill resolutions */ ...\n",
-            "  const int nthreads = ... /* number of threads */;\n",
-            "  spline.SplinepyPlantNewKdtreeForProximity(resolutions.data(),",
-            "nthreads);\n");
-      }
-
-      // good to go. ask the tree
-      int id;
-      double distance;
-      kdtree_->knnSearch(goal, 1 /* closest neighbor */, &id, &distance);
-
-      using ReturnType = typename SplineType::ParametricCoordinate_;
-
-      return grid_points_.template IndexToGridPoint<ReturnType>(id);
-    } else {
-      // well, shouldn't reach here, but to fight a warning, here it is
-      splinepy::utils::PrintAndThrowError("Invalid option for initial guess!");
-      return typename SplineType::ParametricCoordinate_{};
+  void MakeInitialGuess(const RealArray_& goal, RealArray_& guess) const {
+    if (!kdtree_) {
+      // hate to be aggressive, but here it is.
+      splinepy::utils::PrintAndThrowError("to use InitialGuess::Kdtree option,"
+                                          "please first plant a kdtree.");
     }
+
+    // good to go. ask the tree
+    int id;
+    double distance;
+    kdtree_->knnSearch(goal.data(), 1 /* closest neighbor */, &id, &distance);
+
+    grid_points_.IdToGridPoint(id, guess.data());
   }
 
   /*!
    * Builds RHS and fills spline_gradient, which is also required in LHS.
+   * RHS is what's internally called as "df_dxi"
    *
    * @param[in] guess current parametric coordinate guess
    * @param[in] difference result of `GuessMinusQuery()`
    * @param[out] spline_gradient
    * @param[out] rhs
    */
-  void FillSplineGradientAndRhs(
-      const typename SplineType::ParametricCoordinate_& guess,
-      const DArrayD_& difference,
-      PxDMatrixD_& spline_gradient,
-      PArrayD_& rhs) const {
-    // btw, RHS is what's internally called as "df_dxi"
-    double df_dxi_i; // temporary variable to hold sum
+  void FillSplineGradientAndRhs(const RealArray_& guess,
+                                const RealArray_& difference,
+                                RealArray2D_& spline_gradient,
+                                RealArray_& rhs) const {
+    const int para_dim = guess.size();
+    const int dim = difference.size();
 
-    typename SplineType::Derivative_ derivative_query;
-    using DerivativeValueType = typename SplineType::Derivative_::value_type;
+    IndexArray_ derivative_query(para_dim);
+    derivative_query.Fill(0);
 
-    for (int i{}; i < SplineType::kParaDim; ++i) {
-      // spline derivative query formulation
-      derivative_query.fill(DerivativeValueType{0});
-      ++derivative_query[i];
+    // this is just to view and apply inner product
+    RealArray_ gradient_row_view;
+    gradient_row_view.SetShape(dim);
+
+    for (int i{}; i < para_dim; ++i) {
+      // set query - this should be all zero here
+      derivative_query[i] = 1;
+
+      // set row view
+      gradient_row_view.SetData(&spline_gradient(i, 0));
+
       // derivative evaluation
-      auto const derivative = spline_(guess, derivative_query);
+      spline_.SplinepyDerivative(guess.data(),
+                                 derivative_query.data(),
+                                 gradient_row_view.data());
 
-      df_dxi_i = 0.;
-      for (int j{}; j < SplineType::kDim; ++j) {
-        // cast, since d may be a NamedType.
-        double d_value;
-        if constexpr (std::is_scalar<decltype(derivative)>::value) {
-          d_value = derivative;
-        } else {
-          d_value = static_cast<double>(derivative[j]);
-        }
-        df_dxi_i += difference[j] * d_value;
-        spline_gradient[i][j] = d_value;
-      }
-      rhs[i] = -2. * df_dxi_i; // apply minus here already!
+      // fill rhs_i and apply minus here already!
+      rhs[i] = -2. * difference.InnerProduct(gradient_row_view);
+
+      // reset query to zero
+      derivative_query[i] = 0;
     }
   }
 
-  /*!
-   * Builds LHS
-   *
-   * @param[in] guess
-   * @param[in] difference
-   * @param[in] spline_gradient
-   * @param[out] lhs
-   */
-  void FillLhs(const typename SplineType::ParametricCoordinate_& guess,
-               const DArrayD_& difference,
-               const PxDMatrixD_& spline_gradient,
-               PxPMatrixD_& lhs) const {
+  void FillLhs(const RealArray_& guess,
+               const RealArray_& difference,
+               const RealArray2D_& spline_gradient_AAt,
+               RealArray3D_& spline_hessian,
+               RealArray2D_& lhs) const {
+    const int para_dim = guess.size();
+    const int dim = difference.size();
 
-    const PxPMatrixD_ spline_gradientAAt =
-        splinepy::utils::AAt(spline_gradient);
+    IndexArray_ derivative_query(para_dim);
+    derivative_query.Fill(0);
 
-    typename SplineType::Derivative_ derivative_query;
-    using DerivativeValueType = typename SplineType::Derivative_::value_type;
-    for (int i{}; i < SplineType::kParaDim; ++i) {
-      for (int j{i}; j < SplineType::kParaDim; ++j) {
-        derivative_query.fill(DerivativeValueType{0});
-        ++derivative_query[i];
-        ++derivative_query[j];
+    // derivative result is a view to the hessian array
+    RealArray_ derivative;
+    derivative.SetShape(dim);
 
-        auto const derivative = spline_(guess, derivative_query);
+    // lambda to compute each element
+    auto compute = [&](const int& i, const int& j) {
+      // adjust derivative query
+      ++derivative_query[i];
+      ++derivative_query[j];
 
-        lhs[i][j] = 2
-                    * (splinepy::utils::Dot(difference, derivative)
-                       + spline_gradientAAt[i][j]);
+      // adjust view on hessian array
+      derivative.SetData(&spline_hessian(i, j, 0));
 
-        if (i != j)
-          lhs[j][i] = lhs[i][j]; // fill symmetric part
+      // compute
+      spline_.SplinepyDerivative(guess.data(),
+                                 derivative_query.data(),
+                                 derivative.data());
+
+      // fill lhs_ij
+      lhs(i, j) =
+          2.
+          * (difference.InnerProduct(derivative) + spline_gradient_AAt(i, j));
+
+      // reset derivative query
+      --derivative_query[i];
+      --derivative_query[j];
+    };
+
+    for (int i{}; i < para_dim; ++i) {
+      for (int j{i + 1}; j < para_dim; ++j) {
+        // upper triangle without diagonal
+        compute(i, j);
+        // copy to the lower
+        lhs(j, i) = lhs(i, j);
       }
+      // diagonal
+      compute(i, i);
     }
-  }
-
-  /// @brief Given physical coordinate, finds closest parametric coordinate
-  /// @param query
-  /// @param initial_guess
-  /// @param tolerance
-  /// @param aggressive_bounds
-  typename SplineType::ParametricCoordinate_
-  FindNearestParametricCoordinate(const double* query,
-                                  InitialGuess initial_guess,
-                                  double tolerance = 1e-12,
-                                  bool aggressive_bounds = false) const {
-
-    PxPMatrixD_ lhs;
-    PArrayD_ rhs;
-    PArrayD_ delta_guess;
-    DArrayD_ difference;
-    PxDMatrixD_ spline_gradient;
-    PArrayI_ clipped{}; /* clip status after most recent update */
-    PArrayI_ previous_clipped{};
-    PArrayI_ solver_skip_mask{}; /* tell solver to skip certain entry */
-    bool solver_skip_mask_activated = false;
-
-    // search_bounds is parametric bounds.
-    auto search_bounds =
-        splinepy::splines::helpers::GetParametricBounds(spline_);
-
-    typename SplineType::ParametricCoordinate_ current_guess =
-        MakeInitialGuess(static_cast<int>(initial_guess), query);
-
-    // Be optimistic and check if initial guess was awesome
-    // If it is awesome, return and have feierabend
-    GuessMinusQuery(current_guess, query, difference);
-    if (splinepy::utils::NormL2(difference) < tolerance) {
-      return current_guess;
-    }
-
-    // Let's try aggressive search bounds
-    if (initial_guess == InitialGuess::KdTree && aggressive_bounds) {
-      // you need to be sure that you have sampled your spline fine enough
-      for (std::size_t i{}; i < SplineType::kParaDim; ++i) {
-        // adjust lower (0) and upper (1) bounds aggressively
-        // but of course, not so aggressive that it is out of bound.
-        search_bounds[0][i] =
-            std::max(search_bounds[0][i],
-                     current_guess[i] - grid_points_.step_size_[i]);
-        search_bounds[1][i] =
-            std::min(search_bounds[1][i],
-                     current_guess[i] + grid_points_.step_size_[i]);
-      }
-    }
-
-    const int max_iteration = SplineType::kParaDim * 20;
-    double previous_norm{}, current_norm;
-
-    // newton iteration
-    for (int i{}; i < max_iteration; ++i) {
-      // build systems to solve
-      FillSplineGradientAndRhs(current_guess, difference, spline_gradient, rhs);
-      FillLhs(current_guess, difference, spline_gradient, lhs);
-
-      // solve and update
-      // 1. set solver skip mask if clipping happened twice at the same place.
-      if (previous_clipped == clipped && !solver_skip_mask_activated) {
-        solver_skip_mask = clipped;
-        solver_skip_mask_activated = true;
-        // if skip mask is on for all entries, return now.
-        if (splinepy::utils::NonZeros(solver_skip_mask)
-            == SplineType::kParaDim) {
-          // current_guess should be clipped at this point.
-          return current_guess;
-        }
-      }
-
-      // GaussWithPivot may swap and modify enties of all the input
-      // -> can't use lhs and rhs afterwards, and we don't need them.
-      // -> solver_skip_mask and delta_guess is reordered to rewind swaps
-      splinepy::utils::GaussWithPivot(lhs, rhs, solver_skip_mask, delta_guess);
-      // Update
-      splinepy::utils::AddSecondToFirst(current_guess, delta_guess);
-      // Clip
-      previous_clipped = clipped; // swap?
-      splinepy::utils::Clip(search_bounds, current_guess, clipped);
-      // Converged?
-      current_norm = splinepy::utils::NormL2(rhs);
-      GuessMinusQuery(current_guess, query, difference);
-      if (std::abs(previous_norm - current_norm) < tolerance
-          || splinepy::utils::NormL2(difference) < tolerance)
-        break;
-
-      // prepare next round
-      previous_norm = current_norm;
-    }
-    return current_guess;
   }
 
   /// @brief First order fall back
@@ -372,160 +268,113 @@ public:
                     double* first_derivatives /* spline jacobian */,
                     double* second_derivatives /* spline hessian */) const {
 
-    PxPMatrixD_ lhs;
-    PArrayD_ rhs;
-    PArrayD_ delta_guess;
-    DArrayD_ difference;
-    PxDMatrixD_ spline_gradient;
-    PArrayI_ clipped{}; /* clip status after most recent update */
-    PArrayI_ previous_clipped{};
-    PArrayI_ solver_skip_mask{}; /* tell solver to skip certain entry */
-    typename SplineType::Coordinate_ current_phys{};
-    double current_distance{};
-    double previous_norm{}, current_norm{};
+    const int para_dim = spline_.SplinepyParaDim();
+    const int dim = spline_.SplinepyDim();
+
+    // view arrays - we will use this memory for IO
+    // this avoid unnecessary copy, but if it slows down the process
+    // significantly we will just alloc and copy at the end
+    RealArray_ phys_query(query, dim);
+    RealArray_ current_guess(final_guess, para_dim);
+    RealArray_ current_phys(nearest, dim);
+    RealArray_ difference(nearest_minus_query, dim);
+    RealArray2D_ spline_gradient(first_derivatives, para_dim, dim);
+    RealArray3D_ spline_hessian(second_derivatives, para_dim, para_dim, dim);
+
+    // allocate aux real arrays
+    RealArray2D_ lhs(para_dim, para_dim);
+    SystemMatrix system(lhs);
+    RealArray_ rhs(para_dim);
+    RealArray_ delta_guess(para_dim);
+    RealArray2D_ spline_gradient_AAt(para_dim, para_dim);
+    RealArray2D_ search_bounds(2, para_dim);
+
+    // get pointers to beginning of each bound
+    RealArray_ lower_bound(search_bounds.begin(), para_dim);
+    RealArray_ upper_bound(search_bounds.begin() + para_dim, para_dim);
+
+    // allocate index arrays
+    IndexArray_ clipped(para_dim);
+    IndexArray_ previous_clipped(para_dim);
 
     // search_bounds is parametric bounds here
-    auto search_bounds =
-        splinepy::splines::helpers::GetParametricBounds(spline_);
+    spline_.SplinepyParametricBounds(search_bounds.data());
 
-    // for verbose, we don't return right away even this is the best guess
-    // already, so that we can fill out all the other infos.
-    typename SplineType::ParametricCoordinate_ current_guess =
-        MakeInitialGuess(static_cast<int>(InitialGuess::KdTree), query);
+    // initial guess
+    MakeInitialGuess(phys_query, current_guess);
 
     // Let's try aggressive search bounds
     if (aggressive_bounds) {
       // you need to be sure that you have sampled your spline fine enough
-      for (std::size_t i{}; i < SplineType::kParaDim; ++i) {
+      for (int i{}; i < para_dim; ++i) {
         // adjust lower (0) and upper (1) bounds aggressively
         // but of course, not so aggressive that it is out of bound.
-        search_bounds[0][i] =
-            std::max(search_bounds[0][i],
+        search_bounds(0, i) =
+            std::max(search_bounds(0, i),
                      current_guess[i] - grid_points_.step_size_[i]);
-        search_bounds[1][i] =
-            std::min(search_bounds[1][i],
+        search_bounds(1, i) =
+            std::min(search_bounds(1, i),
                      current_guess[i] + grid_points_.step_size_[i]);
       }
     }
-    const int max_iter =
-        max_iterations < 0 ? SplineType::kParaDim * 20 : max_iterations;
 
-    // build systems to solve
-    GuessMinusQuery(current_guess, query, difference);
+    // get initial status - call both rhs and lhs to fill gradients
+    GuessMinusQuery(current_guess, phys_query, difference);
     FillSplineGradientAndRhs(current_guess, difference, spline_gradient, rhs);
+    spline_gradient.AAt(spline_gradient_AAt);
+    FillLhs(current_guess,
+            difference,
+            spline_gradient_AAt,
+            spline_hessian,
+            lhs);
 
-    // 0 iteration returns initial guess.
-    // compute rest of verbose info here.
-    if (max_iterations == 0) {
-      current_phys = spline_(current_guess);
-      splinepy::utils::FirstMinusSecondEqualsThird(current_phys,
-                                                   query,
-                                                   difference);
-      current_distance = splinepy::utils::NormL2(difference);
-      current_norm = std::abs(splinepy::utils::NormL2(rhs));
-    }
+    distance = difference.NormL2();
+    convergence_norm = rhs.NormL2();
 
+    // for now, we take same value for rel_tol
+    const double norm_goal = std::max(convergence_norm * tolerance, tolerance);
+    // get maxiteration
+    const int max_iter = max_iterations < 0 ? para_dim * 20 : max_iterations;
     // newton iterations
     for (int i{}; i < max_iter; ++i) {
-      // lhs
-      FillLhs(current_guess, difference, spline_gradient, lhs);
-
-      // GaussWithPivot may swap and modify enties of all the input
-      // -> can't use lhs and rhs afterwards, and we don't need them.
-      // -> solver_skip_mask and delta_guess is reordered to rewind swaps
-      splinepy::utils::GaussWithPivot(lhs, rhs, solver_skip_mask, delta_guess);
-      // Update
-      splinepy::utils::AddSecondToFirst(current_guess, delta_guess);
-      // Clip
-      splinepy::utils::Clip(search_bounds, current_guess, clipped);
-      // check distance
-      current_phys = spline_(current_guess);
-      splinepy::utils::FirstMinusSecondEqualsThird(current_phys,
-                                                   query,
-                                                   difference);
-      current_distance = splinepy::utils::NormL2(difference);
-      // assemble rhs, check norm
-      FillSplineGradientAndRhs(current_guess, difference, spline_gradient, rhs);
-      current_norm = splinepy::utils::NormL2(rhs);
-
-      // convergence check
-      if (std::abs(previous_norm - current_norm) < tolerance
-          || current_distance < tolerance) {
+      // norm and distance check for convergence
+      if (convergence_norm < norm_goal || distance < tolerance) {
         break;
       }
-      // set solver skip mask if clipping happened twice at the same place.
-      if (previous_clipped == clipped) {
-        solver_skip_mask = clipped;
-        // if skip mask is on for all entries, return now.
-        if (splinepy::utils::NonZeros(solver_skip_mask)
-            == SplineType::kParaDim) {
-          // current_guess should be clipped at this point.
-          break;
-        }
-      }
 
-      // we are here because it didn't converge. prepare next round
-      previous_norm = current_norm;
-      std::swap(previous_clipped, clipped);
+      // solve systems using gauss elimination with partial pivoting
+      // this will alter lhs in place, but shouldn't reorder rows inplace
+      system.Solve(rhs, delta_guess);
+
+      // currently we just clip at the bounds
+      // we need a more sophisticated update for stability
+      current_guess.Add(delta_guess);
+      current_guess.Clip(lower_bound, upper_bound, clipped);
+
+      // evaluate cost at current guess
+      GuessMinusQuery(current_guess, phys_query, current_phys, difference);
+      distance = difference.NormL2();
+
+      // assemble for next iteration
+      // this also count as rhs/lhs at current guess, which fills derivatives
+      // for return
+      FillSplineGradientAndRhs(current_guess, difference, spline_gradient, rhs);
+      spline_gradient.AAt(spline_gradient_AAt);
+      FillLhs(current_guess,
+              difference,
+              spline_gradient_AAt,
+              spline_hessian,
+              lhs);
+      convergence_norm = rhs.NormL2();
     }
-    // write return values - 7 args
-    distance = current_distance;     /* 1 */
-    convergence_norm = current_norm; /* 2 */
-    typename SplineType::Derivative_ derivative_query;
-    double der; /* to accommodate different kind of derivative types */
-    using DerivativeValueType = typename SplineType::Derivative_::value_type;
-    for (int i{}; i < SplineType::kParaDim; ++i) {
-      final_guess[i] = static_cast<double>(current_guess[i]); /* 3 */
-      for (int j{i}; j < SplineType::kParaDim; ++j) {
-        derivative_query.fill(DerivativeValueType{0});
-        ++derivative_query[i];
-        ++derivative_query[j];
-        const auto derivative = spline_(current_guess, derivative_query);
-        for (int k{}; k < SplineType::kDim; ++k) {
-          if constexpr (std::is_scalar<decltype(derivative)>::value) {
-            der = derivative;
-          } else {
-            der = static_cast<double>(derivative[k]);
-          }
-          // spline hessian
-          second_derivatives[(i * SplineType::kParaDim * SplineType::kDim)
-                             + (j * SplineType::kDim) + k] = der; /* 4 */
-          // symmetric part
-          if (i != j) {
-            second_derivatives[(j * SplineType::kParaDim * SplineType::kDim)
-                               + (i * SplineType::kDim) + k] = der;
-          }
 
-          // ones that don't need extra para_dim loop
-          if (i == 0 /* j starts with 0 */) {
-            first_derivatives[j * SplineType::kDim + k] =
-                spline_gradient[j][k]; /* 5 */
-            // ones that don't need extra extra para_dim loop
-            // => pure dim loop
-            if (j == 0) {
-              double cur_phys;
-              if constexpr (std::is_scalar_v<decltype(current_phys)>) {
-                nearest[k] = current_phys;
-              } else {
-                nearest[k] = static_cast<double>(current_phys[k]); /* 6 */
-              }
-              nearest_minus_query[k] = difference[k]; /* 7 */
-            }
-          }
-        }
+    // before returning, we just need to fill symmetric part of hessian
+    for (int i{}; i < spline_hessian.Shape()[0]; ++i) {
+      for (int j{i + 1}; j < spline_hessian.Shape()[1]; ++j) {
+        std::copy_n(&spline_hessian(i, j, 0), dim, &spline_hessian(j, i, 0));
       }
     }
   }
-
-protected:
-  SplineType const& spline_;
-  // kdtree related variables
-  GridPoints_ grid_points_;
-  PArrayI_ sampled_resolutions_;
-  bool kdtree_planted_ = false;
-  std::unique_ptr<Coordinates_> coordinates_;
-  std::unique_ptr<Cloud_> coordinates_cloud_;
-  std::unique_ptr<Tree_> kdtree_;
 };
 
 } // namespace splinepy::proximity

--- a/include/splinepy/proximity/proximity.hpp
+++ b/include/splinepy/proximity/proximity.hpp
@@ -43,7 +43,7 @@ protected:
   const splinepy::splines::SplinepyBase& spline_;
 
   // kdtree related variables
-  splinepy::utils::CStyleArrayPointerGridPoints grid_points_;
+  splinepy::utils::GridPoints grid_points_;
   RealArray_ sampled_spline_;
   std::unique_ptr<Cloud_> cloud_;
   std::unique_ptr<Tree_> kdtree_;

--- a/include/splinepy/splines/bezier.hpp
+++ b/include/splinepy/splines/bezier.hpp
@@ -48,7 +48,7 @@ public:
   using Coordinates_ = typename std::vector<Coordinate_>;
   using Derivative_ = typename std::array<std::size_t, para_dim>;
   using Dimension_ = std::size_t;
-  using Proximity_ = splinepy::proximity::Proximity<Bezier<para_dim, dim>>;
+  using Proximity_ = splinepy::proximity::Proximity;
 
   /// @brief Creates Base for Bezier
   /// @param degrees

--- a/include/splinepy/splines/bezier.inl
+++ b/include/splinepy/splines/bezier.inl
@@ -176,9 +176,7 @@ template<std::size_t para_dim, std::size_t dim>
 void Bezier<para_dim, dim>::SplinepyPlantNewKdTreeForProximity(
     const int* resolutions,
     const int& nthreads) {
-  splinepy::splines::helpers::ScalarTypePlantNewKdTreeForProximity(*this,
-                                                                   resolutions,
-                                                                   nthreads);
+  GetProximity().PlantNewKdTree(resolutions, nthreads);
 }
 
 template<std::size_t para_dim, std::size_t dim>

--- a/include/splinepy/splines/bspline.hpp
+++ b/include/splinepy/splines/bspline.hpp
@@ -93,7 +93,7 @@ public:
   using BinomialRatios_ = typename Base_::ParameterSpace_::BinomialRatios_;
   using BinomialRatio_ = typename BinomialRatios_::value_type;
   // Advanced use
-  using Proximity_ = splinepy::proximity::Proximity<BSpline<para_dim, dim>>;
+  using Proximity_ = splinepy::proximity::Proximity;
 
   /** raw ptr based inithelper.
    *  degrees should have same size as parametric dimension
@@ -387,10 +387,7 @@ public:
 
   virtual void SplinepyPlantNewKdTreeForProximity(const int* resolutions,
                                                   const int& nthreads) {
-    splinepy::splines::helpers::ScalarTypePlantNewKdTreeForProximity(
-        *this,
-        resolutions,
-        nthreads);
+    GetProximity().PlantNewKdTree(resolutions, nthreads);
   }
 
   /// Verbose proximity query - make sure to plant a kdtree first.

--- a/include/splinepy/splines/helpers/extract.hpp
+++ b/include/splinepy/splines/helpers/extract.hpp
@@ -14,10 +14,10 @@ inline int ExtractBoundaryFromAxisAndExtrema(const int& axis,
   return (extreme > 0) ? 2 * axis + 1 : 2 * axis;
 }
 
-template<typename SplineType, typename IndexType>
+template<typename SplineType, typename VectorType>
 std::shared_ptr<splinepy::splines::SplinepyBase>
 ExtractControlMeshSliceFromIDs(const SplineType& spline,
-                               const std::vector<IndexType>& indices,
+                               const VectorType& indices,
                                const int& plane_normal_axis) {
   // Perform sanity check
   if constexpr (SplineType::kParaDim == 1) {
@@ -123,17 +123,16 @@ ExtractBoundaryMeshSlice(const SplineType& spline, const int& boundary_id) {
 
     // get ids on boundary
     const auto cmr =
-        splinepy::splines::helpers::template GetControlMeshResolutions<
-            std::size_t>(spline);
+        splinepy::splines::helpers::template GetControlMeshResolutions<int>(
+            spline);
     const int plane_normal_axis = static_cast<int>(boundary_id / 2);
     const int plane_id =
         ((boundary_id % 2) == 0) ? 0 : cmr[plane_normal_axis] - 1;
-    const auto ids_on_boundary = splinepy::utils::GridPoints<
-        std::size_t,
-        std::size_t,
-        SplineType::kParaDim>::GridPointIdsOnHyperPlane(cmr,
-                                                        plane_normal_axis,
-                                                        plane_id);
+    const auto ids_on_boundary = splinepy::utils::GridPoints::IdsOnHyperPlane(
+        cmr.data(),
+        static_cast<int>(cmr.size()),
+        plane_normal_axis,
+        plane_id);
     return ExtractControlMeshSliceFromIDs(spline,
                                           ids_on_boundary,
                                           plane_normal_axis);
@@ -158,12 +157,11 @@ ExtractControlMeshSlice(const SplineType& spline,
     const auto cmr =
         splinepy::splines::helpers::template GetControlMeshResolutions<
             std::size_t>(spline);
-    const auto ids_on_boundary = splinepy::utils::GridPoints<
-        std::size_t,
-        std::size_t,
-        SplineType::kParaDim>::GridPointIdsOnHyperPlane(cmr,
-                                                        plane_normal_axis,
-                                                        plane_id);
+    const auto ids_on_boundary = splinepy::utils::GridPoints::IdsOnHyperPlane(
+        cmr.data(),
+        static_cast<int>(cmr.size()),
+        plane_normal_axis,
+        plane_id);
     return ExtractControlMeshSliceFromIDs(spline,
                                           ids_on_boundary,
                                           plane_normal_axis);

--- a/include/splinepy/splines/helpers/scalar_type_wrapper.hpp
+++ b/include/splinepy/splines/helpers/scalar_type_wrapper.hpp
@@ -175,15 +175,6 @@ void ScalarTypeJacobian(const SplineType& spline,
   }
 }
 
-template<typename SplineType, typename ResolutionType, typename NThreadsType>
-void ScalarTypePlantNewKdTreeForProximity(SplineType& spline,
-                                          const ResolutionType* resolutions,
-                                          const NThreadsType& nthreads) {
-  std::array<int, SplineType::kParaDim> core_res;
-  std::copy_n(resolutions, SplineType::kParaDim, core_res.begin());
-  spline.GetProximity().PlantNewKdTree(core_res, nthreads);
-}
-
 /// single degree elevation.
 template<typename SplineType, typename QueryType>
 void ScalarTypeElevateDegree(SplineType& spline, const QueryType query) {

--- a/include/splinepy/splines/nurbs.hpp
+++ b/include/splinepy/splines/nurbs.hpp
@@ -83,7 +83,7 @@ public:
   using IndexValue_ = typename Index_::Value_;
   // Advanced use
   using HomogeneousBSpline_ = typename Base_::HomogeneousBSpline_;
-  using Proximity_ = splinepy::proximity::Proximity<Nurbs<para_dim, dim>>;
+  using Proximity_ = splinepy::proximity::Proximity;
 
   /// @brief raw ptr based inithelper.
   /// @param degrees should have same size as parametric dimension
@@ -413,10 +413,7 @@ public:
 
   virtual void SplinepyPlantNewKdTreeForProximity(const int* resolutions,
                                                   const int& nthreads) {
-    splinepy::splines::helpers::ScalarTypePlantNewKdTreeForProximity(
-        *this,
-        resolutions,
-        nthreads);
+    GetProximity().PlantNewKdTree(resolutions, nthreads);
   }
 
   /// Verbose proximity query - make sure to plant a kdtree first.

--- a/include/splinepy/splines/rational_bezier.hpp
+++ b/include/splinepy/splines/rational_bezier.hpp
@@ -54,8 +54,7 @@ public:
   using Derivative_ = typename std::array<std::size_t, para_dim>;
   using Dimension_ = std::size_t;
   // advanced use
-  using Proximity_ =
-      splinepy::proximity::Proximity<RationalBezier<para_dim, dim>>;
+  using Proximity_ = splinepy::proximity::Proximity;
 
   /// @brief Create base
   /// @param degrees

--- a/include/splinepy/splines/rational_bezier.inl
+++ b/include/splinepy/splines/rational_bezier.inl
@@ -255,9 +255,8 @@ template<std::size_t para_dim, std::size_t dim>
 void RationalBezier<para_dim, dim>::SplinepyPlantNewKdTreeForProximity(
     const int* resolutions,
     const int& nthreads) {
-  splinepy::splines::helpers::ScalarTypePlantNewKdTreeForProximity(*this,
-                                                                   resolutions,
-                                                                   nthreads);
+
+  GetProximity().PlantNewKdTree(resolutions, nthreads);
 }
 
 template<std::size_t para_dim, std::size_t dim>

--- a/include/splinepy/utils/arrays.hpp
+++ b/include/splinepy/utils/arrays.hpp
@@ -408,7 +408,8 @@ public:
 /// @param c
 template<typename IterableA, typename IterableB, typename IterableC>
 inline void Subtract(const IterableA& a, const IterableB& b, IterableC& c) {
-  assert(a.size() == b.size() == c.size());
+  assert(a.size() == b.size());
+  assert(b.size() == c.size());
 
   const auto len = c.size();
 
@@ -460,7 +461,8 @@ public:
     // array_ should be a square matrix
     assert(len == array_.Shape()[1]);
     // len should match the size of b and x
-    assert(len == b.size() == x.size());
+    assert(len == b.size());
+    assert(len == x.size());
 
     // partial pivoting and forward reduction
     // since we reorder indices only, we append *_r to reordered ids

--- a/include/splinepy/utils/arrays.hpp
+++ b/include/splinepy/utils/arrays.hpp
@@ -8,129 +8,531 @@
 
 namespace splinepy::utils {
 
-/// Elementwise subtraction
-template<typename T, typename InputArrayType, std::size_t dim>
-inline void FirstMinusSecondEqualsThird(const InputArrayType& first,
-                                        const T* second, /* c array */
-                                        std::array<T, dim>& third) {
-  // one exception for bezman's scalar splines
-  if constexpr (std::is_scalar<InputArrayType>::value) {
-    static_assert(dim == 1, "Minus with scalar is only for std::array<T, 1>");
-    third[0] = first - second[0];
-  } else {
-    for (size_t i{}; i < dim; ++i) {
-      // following line should raise error during compile time
-      // if T != NameType::Type_
-      third[i] = static_cast<T>(first[i]) - second[i];
-    }
-  }
-}
-
-/// Inplace version of Mean
-/// Mainly to support bezman::Point types
-template<typename ReturnArrayT, typename InputArrayT>
-inline void
-Mean(const InputArrayT& arr1, const InputArrayT& arr2, ReturnArrayT& out) {
-  using ReturnValueType = typename ReturnArrayT::value_type;
-  for (std::size_t i{}; i < out.size(); ++i) {
-    out[i] = ReturnValueType{(arr1[i] + arr2[i]) * .5};
-  }
-}
-
-/// Dot product - use SecondArrayType to support bezman's scalar splines
-template<typename T1, typename SecondArrayT, std::size_t dim>
-inline T1 Dot(const std::array<T1, dim>& arr1, const SecondArrayT& arr2) {
-  T1 dotted{}; /* default value should be 0. */
-
-  if constexpr (std::is_scalar<SecondArrayT>::value) {
-    static_assert(dim == 1, "Dot with scalar is only for std::array<T, 1>");
-    dotted = arr1[0] - arr2;
-  } else {
-    for (std::size_t i{0}; i < dim; ++i) {
-      dotted += arr1[i] * static_cast<T1>(arr2[i]);
-    }
-  }
-
-  return dotted;
-}
-
-/// AAt
-template<typename T, std::size_t dim1, std::size_t dim2>
-inline std::array<std::array<T, dim1>, dim1>
-AAt(const std::array<std::array<T, dim2>, dim1>& arr1) {
-  std::array<std::array<T, dim1>, dim1> out;
-
-  for (std::size_t i{}; i < dim1; ++i) {
-    for (std::size_t j{i}; j < dim1; ++j) {
-      out[i][j] = Dot(arr1[i], arr1[j]);
-      if (i != j)
-        out[j][i] = out[i][j]; // fill symmetric part
-    }
-  }
-
-  return out;
-}
-
-/// elementwise inplace addition
-template<typename T1, typename T2, std::size_t dim>
-inline void AddSecondToFirst(std::array<T1, dim>& arr1,
-                             const std::array<T2, dim>& arr2) {
-  for (std::size_t i{0}; i < dim; i++) {
-    arr1[i] += T1{arr2[i]};
-  }
-}
-
-/*!
- * Inplace operation for para coord clipping and saving clip info
- *
- * Parameters
- * -----------
- * @param[in] bounds
- * @param[out] para_coord
- * @param[out] clipped (-1) minimum clip; (0) no clip; (1) maximum clip
- */
-template<typename T1, typename T2, std::size_t para_dim>
-inline void Clip(const std::array<std::array<T1, para_dim>, 2>& bounds,
-                 std::array<T2, para_dim>& para_coord,
-                 std::array<int, para_dim>& clipped) {
-  for (std::size_t i{0}; i < para_dim; i++) {
-    // check max
-    if (static_cast<T1>(para_coord[i]) > bounds[1][i]) {
-      clipped[i] = 1;
-      para_coord[i] = T2{bounds[1][i]};
-      // check min
-    } else if (static_cast<T1>(para_coord[i]) < bounds[0][i]) {
-      clipped[i] = -1;
-      para_coord[i] = T2{bounds[0][i]};
-    } else {
-      clipped[i] = 0;
-    } // end if
-  }   // end for
-}
-
-/// L2 Norm
-template<typename T, std::size_t dim>
-inline double NormL2(std::array<T, dim>& arr) {
-  double returnval{};
-  for (std::size_t i{}; i < dim; ++i) {
-    returnval += arr[i] * arr[i];
-  }
-  return std::sqrt(returnval);
-}
-
-/// @brief reorder by copying.
-/// @tparam T
-/// @tparam IndexType
+/// @brief fully dynamic array
+/// @tparam DataType
 /// @tparam dim
-/// @param arr
-/// @param order
-template<typename T, typename IndexType, std::size_t dim>
-void CopyReorder(std::array<T, dim>& arr, std::array<IndexType, dim>& order) {
-  const auto copyarr = arr; // should copy.
-  for (std::size_t i{0}; i < dim; i++) {
-    arr[order[i]] = copyarr[i];
+template<typename DataType, int dim = 1, typename IndexType = int>
+class Array {
+  static_assert(dim > 0, "dim needs to be positive value bigger than zero.");
+  static_assert(std::is_integral_v<IndexType>,
+                "IndexType should be an integral type")
+
+      public : using ShapeType_ = std::array<IndexType, dim>;
+  using StridesType_ = std::array<IndexType, dim - 1>;
+  static constexpr const IndexType kDim = static_cast<IndexType>(dim);
+
+protected:
+  bool own_data_{false};
+  /// @brief beginning of the array pointer that this object manages
+  DataType* data_{nullptr};
+
+  /// @brief size of this Array
+  IndexType size_{};
+
+  /// @brief strides in case this is a higher dim. last entry should be the same
+  /// as size_
+  StridesType_ strides_;
+
+  /// @brief shape of the array
+  ShapeType_ shape_;
+
+  /// @brief helper to find id offset
+  /// @tparam ...Ts
+  /// @param index
+  /// @param counter
+  /// @param ...id
+  template<typename... Ts>
+  constexpr void ComputeRemainingOffset(IndexType& index,
+                                        IndexType& counter,
+                                        const IndexType& id0,
+                                        const Ts&... id) {
+    // last element should be just added
+    if constexpr (sizeof...(Ts) == 0) {
+      index += id0;
+      // intentionally skipping
+      // ++counter;
+      return;
+    }
+
+    // add strides * id
+    index += strides_[counter++] * id0;
+
+    // do the rest
+    ComputeRemainingOffset(index, counter, id...);
+  }
+
+public:
+  constexpr DataType* data() {
+    assert(data_);
+    return data_;
+  }
+
+  constexpr const DataType* data() const {
+    assert(data_);
+    return data_;
+  }
+
+  constexpr DataType* begin() {
+    assert(data_);
+    return data_;
+  }
+
+  constexpr DataType* end() {
+    assert(data_);
+    assert(size_ > 0);
+    return data_ + size_;
+  }
+
+  constexpr IndexType size() const { return size_; }
+
+  void DestroyData() {
+    if (own_data_ && data_) {
+      delete[] data_;
+    }
+
+    data_ = nullptr;
+    own_data_ = false;
+  }
+
+  void SetData(DataType* data_pointer) {
+    DestroyData();
+    data_ = data_pointer;
+  }
+
+  DataType* GetData() {
+    assert(data_);
+    return data_;
+  }
+
+  const DataType* GetData() const {
+    assert(data_);
+    return data_;
+  }
+
+  void Reallocate(const IndexType& size) {
+    DestroyData();
+    data_ = new DataType[size];
+    size_ = size; // preferred way is to actually set shape
+    // set shape if this is a 1d array
+    if constexpr (dim == 1) {
+      shape_[0] = size;
+    }
+    own_data_ = true;
+  }
+
+  template<typename... Ts>
+  void SetShape(const IndexType& shape0, Ts&&... shape) {
+    static_assert(sizeof...(Ts) == static_cast<std::size_t>(dim - 1),
+                  "shape should match the dim");
+
+    // early exit in case of dim 1
+    if constexpr (sizeof...(Ts) == 0) {
+      size_ = shape0;
+      shape_[0] = shape0;
+      return;
+    }
+
+    // (re)initialize shape_
+    shape_ = {shape0, shape...};
+
+    // (re)initialize  strides_
+    strides_ = {std::forward<IndexType>(shape)...};
+
+    // reverse iter and accumulate
+    IndexType sub_total{1};
+    constexpr typename StridesType_::reverse_iterator r_stride_iter =
+        strides_.rbegin();
+    for (; r_stride_iter != strides_.rend(); ++r_stride_iter) {
+      // accumulate
+      sub_total *= *r_stride_iter;
+      // assign
+      *r_stride_iter = sub_total;
+    }
+
+    // at this point, sub total has accumulated shape values except shape0
+    // set size
+    size_ = sub_total * shape0;
+  }
+
+  /// @brief default. use SetData() and SetShape<false>
+  Array() = default;
+
+  /// @brief basic array ctor
+  /// @tparam ...Ts
+  /// @param ...shape
+  template<typename... Ts>
+  Array(Ts&&... shape) {
+    SetShape(shape...);
+    Reallocate(size_);
+  }
+
+  /// @brief data wrapping array
+  /// @tparam ...Ts
+  /// @param data_pointer
+  /// @param ...shape
+  template<typename... Ts>
+  Array(DataType* data_pointer, Ts&&... shape) {
+    SetData(data_pointer);
+    SetShape(shape...);
+  }
+
+  /// @brief
+  ~Array() { DestroyData(); }
+
+  /// @brief Returns const shape object
+  /// @param index
+  /// @return
+  constexpr const ShapeType_& Shape() const { return shape_; }
+
+  /// @brief flat indexed array access
+  /// @param index
+  /// @return
+  constexpr DataType& operator[](const IndexType& index) {
+    assert(index > -1 && index < size_);
+
+    return data_[index];
+  }
+
+  /// @brief flat indexed array access
+  /// @param index
+  /// @return
+  constexpr const DataType& operator[](const IndexType& index) const {
+    assert(index > -1 && index < size_);
+
+    return data_[index];
+  }
+
+  /// @brief multi-indexed array access
+  /// @tparam ...Ts
+  /// @param id0
+  /// @param ...id
+  /// @return
+  template<typename... Ts>
+  constexpr DataType& operator()(const IndexType& id0, const Ts&... id) {
+    static_assert(sizeof...(Ts) == static_cast<std::size_t>(dim - 1),
+                  "number of index should match dim");
+
+    if constexpr (dim == 1) {
+      return operator[](id0);
+    }
+
+    IndexType final_id{id0 * strides_[0]}, i{1};
+    ComputeRemainingOffset(final_id, i, id...);
+
+    assert(final_id > -1 && final_id < size_);
+
+    return data_[final_id];
+  }
+
+  /// @brief multi-indexed array access
+  /// @tparam ...Ts
+  /// @param id0
+  /// @param ...id
+  /// @return
+  template<typename... Ts>
+  constexpr const DataType& operator()(const IndexType& id0,
+                                       const Ts&... id) const {
+    static_assert(sizeof...(Ts) == static_cast<std::size_t>(dim - 1),
+                  "number of index should match dim");
+
+    if constexpr (dim == 1) {
+      return operator[](id0);
+    }
+
+    IndexType final_id{id0 * strides_[0]}, i{1};
+    ComputeRemainingOffset(final_id, i, id...);
+
+    assert(final_id > -1 && final_id < size_);
+
+    return data_[final_id];
+  }
+
+  /// @brief this[:] = v
+  /// @param v
+  constexpr void Fill(const DataType& v) {
+    assert(data_);
+
+    std::fill_n(data_, size_, v);
+  }
+
+  /// @brief this[i] += a[i]
+  /// @tparam Iterable
+  /// @param a
+  template<typename Iterable>
+  constexpr void Add(const Iterable& a) {
+    assert(a.size() == size_);
+    assert(data_);
+
+    for (IndexType i{}; i < size_; ++i) {
+      data_[i] += a[i];
+    }
+  }
+
+  /// @brief this[i] -= a[i]
+  /// @tparam Iterable
+  /// @param a
+  template<typename Iterable>
+  constexpr void Subtract(const Iterable& a) {
+    assert(a.size() == size_);
+    assert(data_);
+
+    for (IndexType i{}; i < size_; ++i) {
+      data_[i] -= a[i];
+    }
+  }
+
+  /// @brief c = (this) dot (a).
+  /// @tparam Iterable
+  /// @param a
+  /// @return
+  template<typename Iterable>
+  constexpr DataType InnerProduct(const Iterable& a) const {
+    static_assert(dim == 1,
+                  "inner product is only applicable for dim=1 Array.");
+    assert(a.size() == size_);
+    assert(data_);
+
+    DataType dot{};
+    for (IndexType i{}; i < size_; ++i) {
+      dot += a[i] + data_[i];
+    }
+
+    return dot;
+  }
+
+  constexpr void AAt(Array& aa_t) const {
+    static_assert(dim == 2, "AAt is only applicable for dim=2 array.");
+
+    const auto& height = shape_[0];
+    const auto& width = shape_[1];
+
+    for (int i{}; i < height; ++i) {
+      // compute upper triangle
+      for (int j{i}; j < height; ++j) {
+
+        // element to fill
+        DataType& ij = aa_t(i, j);
+        // init
+        ij = 0.0;
+        // get beginning of i and j row
+        DataType* i_ptr = &operator()(i, 0);
+        DataType* j_ptr = &operator()(j, 0);
+
+        // inner product
+        for (int k{}; k < width; ++k) {
+          ij += i_ptr[k] * j_ptr[k];
+        }
+
+        // fill symmetric part - this will write diagonal twice. it's okay.
+        aa_t(j, i) = ij;
+      }
+    }
+  }
+
+  /// @brief given upper and lower bounds, clips data values inplace.
+  /// @tparam Iterable
+  /// @tparam IntegerType
+  /// @param lower_bound
+  /// @param upper_bound
+  /// @param clipped
+  template<typename Iterable, typename IntegerType>
+  constexpr void Clip(const Iterable& lower_bound,
+                      const Iterable& upper_bound,
+                      Array<IntegerType, dim, IndexType>& clipped) {
+    static_assert(std::is_integral_v<IntegerType>,
+                  "clipped array should be an integral type");
+    static_assert(std::is_signed_v<IntegerType>,
+                  "clipped array should be a signed type");
+
+    assert(lower_bound.size() == size_);
+    assert(upper_bound.size() == size_);
+
+    for (IndexType i{}; i < size_; ++i) {
+
+      // deref values to write
+      DataType& data = data_[i];
+      IntegerType& clip = clipped[i];
+
+      if (const DataType& ub = upper_bound[i]; data > ub) {
+        // upper bound check
+        clip = 1;
+        data = ub;
+      } else if (const DataType& lb = lower_bound[i]; data < lb) {
+        // lower bound check
+        clip = -1;
+        data = lb;
+      } else {
+        // within the bounds
+        clip = 0;
+      }
+    }
+  }
+
+  /// @brief L2 norm
+  /// @return
+  constexpr DataType NormL2() {
+    DataType norm{};
+    for (IndexType i{}; i < size_; ++i) {
+      norm += data_[i];
+    }
+    return std::sqrt(norm);
+  }
+
+  /// @brief returns number of non (exact) zero elements.
+  /// @return
+  constexpr IndexType NonZeros() const {
+    IndexType n{};
+    for (IndexType i{}; i < size_; ++i) {
+      if (n != static_cast<DataType>(0)) {
+        ++n;
+      }
+    }
+    return n;
+  }
+};
+
+/// @brief c[i] = a[i] - b[i]
+/// @tparam IterableA
+/// @tparam IterableB
+/// @tparam IterableC
+/// @param a
+/// @param b
+/// @param c
+template<typename IterableA, typename IterableB, typename IterableC>
+inline void Subtract(const IterableA& a, const IterableB& b, IterableC& c) {
+  assert(a.size() == b.size() == c.size());
+
+  const auto len = c.size();
+
+  for (decltype(len) i{}; i < len; ++i) {
+    c[i] = a[i] - b[i];
   }
 }
+
+template<typename DataType, typename IndexType>
+class Matrix {
+  using DataType_ = DataType;
+  using IndexType_ = IndexType;
+  using SignedIndexType = std::make_signed_t<IndexType>;
+  using DataArray_ = Array<DataType, 2, IndexType>;
+  using RowOrderArray_ = Array<IndexType, 1, IndexType>;
+
+protected:
+  /// @brief 2d base array of this matrix
+  DataArray_& array_;
+
+  /// @brief row permutation.
+  RowOrderArray_ row_order_;
+
+public:
+  Matrix(DataArray& array) : array_(array) {
+    const IndexType& height = array.Shape()[0];
+    // alloc n_rows
+    row_order_.Reallocate(height);
+    // arange n_rows
+    ResetRowOrder();
+  }
+
+  constexpr void ResetRowOrder() {
+    std::iota(row_order_.begin(), row_order_.end(), 0);
+  }
+
+  constexpr void SwapRow(const IndexType& i, const IndexType j) {
+    std::swap(row_order_[i], row_order_[j]);
+  }
+
+  constexpr const RowIndexArray_& RowOrder() const { return row_order_; }
+
+  template<typename IterableB, typename IterableX>
+  constexpr void Solve(const IterableB& b, const IterableX& x) {
+
+    // get length of the array/matrix
+    const IndexType& len = array_.Shape()[0];
+
+    // array_ should be a square matrix
+    assert(len == array_.Shape()[1]);
+    // len should match the size of b and x
+    assert(len == b.size() == x.size());
+
+    // partial pivoting and forward reduction
+    // since we reorder indices only, we append *_r to reordered ids
+    for (std::size_t i{0}; i < para_dim; i++) {
+      // sneak in x initialization here.
+      // it doesn't matter if this is i or i_r
+      x[i] = 0.;
+
+      // ignore clipped entries
+      // if (skipmask[i] != 0)
+      //  continue;
+
+      /* swap */
+      // go through the rows and compare magnitude and find max row at col i.
+      // we use reordered index here to retrieve rows, but keep the
+      // true index for everything else
+      const IndexType& i_r = row_order_[i];
+      IndexType max_row{i};
+      DataType current_max{std::abs(array_(i_r, i))};
+      // loop with true row index
+      for (IndexType j{i + 1}; j < len; ++j) {
+        // but look up reordered row's value
+        DataType maybe_max{std::abs(array_(row_order_[j], i))};
+
+        if (maybe_max > current_max) {
+          current_max = std::move(maybe_max);
+          max_row = j;
+        }
+      }
+      // swap if needed. max entry row goes to i-th row.
+      if (max_row != i) {
+        SwapRow(max_row, i);
+        // std::swap(skipmask[maxrow], skipmask[i]);
+      }
+      /* END swap */
+
+      // forward reduction
+      const DataType a_ii = array_(i_r, i);
+      for (IndexType j{i + 1}; j < len; ++j) {
+        // retrieved reordered j-th row
+        const IndexType& j_r = row_order_[j];
+        // reduction factor for this row
+        const DataType reduction_factor = array_(j_r, i) / a_ii;
+
+        // matrix reduction
+        // get the beginnings of i and j rows
+        DataType* a_i = &array_(i_r, 0);
+        DataType* a_j = &array_(j_r, 0);
+        // start with setting the i th column zero.
+        a_j[i] = 0.;
+        // this is column entry, so true indices
+        // reduce the rest of the column
+        for (IndexType k{i + 1}; k < len; ++k) {
+          a_j[k] -= a_i[k] * reduction_factor;
+        }
+
+        // row-vec reduction
+        b[j_r] -= b[i_r] * reduction_factor;
+      }
+      /* END forward reduction */
+    }
+
+    // back substitution
+    // Loop backwards
+    for (SignedIndexType i{len - 1}; i > static_cast<SignedIndexType>(-1);
+         --i) {
+      // ignore clipped entries
+      // if (skipmask[i] != 0)
+      // continue;
+
+      const IndexType& i_r = row_order_[i];
+      DataType* a_i = &array_(i_r, 0);
+      DataType sum{};
+      for (IndexType j{i + 1}; j < len; ++j) {
+        sum += a_i[j] * x[row_order_[j]];
+      }
+      x[i_r] = (b[i_r] - sum) / a_i[i];
+    }
+  }
+};
 
 /// @brief Gauss elimination with partial pivoting to find x from (A x = b)
 /// @tparam para_dim
@@ -215,16 +617,6 @@ GaussWithPivot(std::array<std::array<double, para_dim>, para_dim>& A,
   // reorder
   CopyReorder(x, indexmap);
   CopyReorder(skipmask, indexmap);
-}
-
-template<typename T, std::size_t dim>
-inline int NonZeros(std::array<T, dim>& arr) {
-  int nonzeros{};
-  for (const auto& a : arr) {
-    if (a != 0)
-      ++nonzeros;
-  }
-  return nonzeros;
 }
 
 } /* namespace splinepy::utils */

--- a/include/splinepy/utils/grid_points.hpp
+++ b/include/splinepy/utils/grid_points.hpp
@@ -176,6 +176,8 @@ private:
 /// Values are kept as int since they come as int from python
 class CStyleArrayPointerGridPoints {
 public:
+  std::vector<double> step_size_;
+
   CStyleArrayPointerGridPoints() = default;
   CStyleArrayPointerGridPoints(const int dim,
                                const double* bounds,
@@ -195,6 +197,8 @@ public:
     entries_.assign(dim, std::vector<double>{});
     resolutions_.clear();
     resolutions_.reserve(dim);
+    step_size_.clear();
+    step_size_.reserve(dim);
     for (int i{}; i < dim; ++i) {
       const int& res = resolutions[i];
       if (res < 2) {
@@ -208,7 +212,8 @@ public:
       std::vector<double>& entryvec = entries_[i];
       entryvec.reserve(res);
 
-      const double step_size = (bounds[dim + i] - bounds[i]) / (res - 1);
+      double& step_size = step_size_[i];
+      step_size = (bounds[dim + i] - bounds[i]) / (res - 1);
       for (int j{}; j < resolutions[i]; ++j) {
         entryvec.emplace_back(bounds[i] + step_size * j);
       }

--- a/include/splinepy/utils/grid_points.hpp
+++ b/include/splinepy/utils/grid_points.hpp
@@ -9,172 +9,8 @@
 
 namespace splinepy::utils {
 
-/// @brief Grid points class
-/// @tparam DataT
-/// @tparam IndexType
-/// @tparam dim
-template<typename DataT, typename IndexType, int dim>
+/// @brief GridPoints based dynamic grid point sampler
 class GridPoints {
-public:
-  /// @brief Step size, could be useful for setting searchbounds aggressively
-  std::array<DataT, dim> step_size_;
-
-  GridPoints() = default;
-  /// @brief Constructor
-  /// @param bounds
-  /// @param resolutions
-  GridPoints(const std::array<std::array<DataT, dim>, 2>& bounds,
-             const std::array<IndexType, dim>& resolutions)
-      : res_(resolutions),
-        bounds_(bounds) {
-    // linspace and prepare possible entries */
-    len_ = 1;
-    for (int i{0}; i < dim; i++) {
-      len_ *= resolutions[i];
-      std::vector<DataT>& entryvec = entries_[i];
-      entryvec.reserve(resolutions[i]);
-
-      step_size_[i] = (bounds[1][i] - bounds[0][i]) / (res_[i] - 1);
-      for (int j{0}; j < resolutions[i]; j++) {
-        entryvec.emplace_back(bounds[0][i] + step_size_[i] * j);
-      }
-    }
-    len_times_dim_ = len_ * dim;
-  }
-
-  /// @brief Get grid point from index
-  const std::array<DataT, dim> operator[](const IndexType id) {
-    return IndexToGridPoint<std::array<DataT, dim>>(id);
-  }
-
-  /// @brief Get grid point from index
-  /// @param id
-  /// @return Grid point
-  template<typename GridPointType>
-  GridPointType IndexToGridPoint(const IndexType& id) const {
-
-    using ValueType = typename GridPointType::value_type;
-
-    GridPointType gpoint{};
-
-    IndexType quot{id};
-    for (int i{0}; i < dim; i++) {
-      gpoint[i] = ValueType{entries_[i][quot % res_[i]]};
-      quot /= res_[i];
-    }
-
-    return gpoint;
-  }
-
-  /// subroutine variation
-  template<typename GridPointType>
-  void IndexToGridPoint(const IndexType& id, GridPointType& gpoint) const {
-
-    using ValueType = typename GridPointType::value_type;
-
-    IndexType quot{id};
-    for (int i{0}; i < dim; i++) {
-      gpoint[i] = ValueType{entries_[i][quot % res_[i]]};
-      quot /= res_[i];
-    }
-  }
-
-  /// Saved at the first call then returns
-  const std::vector<DataT>& GetAllGridPoints() {
-    // early exit if we have them
-    if (saved_grid_points_.size() == len_times_dim_) {
-      return saved_grid_points_;
-    }
-    // get all.
-    saved_grid_points_.clear();
-    saved_grid_points_.reserve(len_times_dim_);
-    for (IndexType i{}; i < len_; ++i) {
-      // third time is the charm
-      IndexType quot{i};
-      for (IndexType j{}; j < dim; ++j) {
-        const auto& r = res_[j];
-        saved_grid_points_.emplace_back(entries_[j][quot % r]);
-        quot /= r;
-      }
-    }
-
-    return saved_grid_points_;
-  }
-
-  /// @brief Get global IDs
-  /// @param grid_resolutions
-  /// @param plane_normal_axis
-  /// @param plane_id
-  static std::vector<IndexType>
-  GridPointIdsOnHyperPlane(const std::array<IndexType, dim>& grid_resolutions,
-                           const IndexType& plane_normal_axis,
-                           const IndexType& plane_id) {
-    // Determine size of return vector
-    IndexType n_points_on_boundary{1};
-    for (std::size_t i_pd{}; i_pd < dim; i_pd++) {
-      if (i_pd == plane_normal_axis)
-        continue;
-      n_points_on_boundary *= grid_resolutions[i_pd];
-    }
-
-    auto local_to_global_bd_id = [&](const IndexType& local_id) {
-      IndexType combined_offsets{1}, id{local_id}, global_id{};
-      for (std::size_t i_pdc{}; i_pdc < dim; ++i_pdc) {
-        const auto& res = grid_resolutions[i_pdc];
-        if (i_pdc == plane_normal_axis) {
-          global_id += combined_offsets * plane_id;
-        } else {
-          // Determine index in coordinate indexing system
-          const IndexType rasterized_index = id % res;
-          // Use the current id to update the global index
-          global_id += rasterized_index * combined_offsets;
-          // Update the copy of the index to search for next slice
-          id -= rasterized_index;
-          id /= res;
-        }
-        combined_offsets *= res;
-      }
-      return global_id;
-    };
-
-    // Fill return list
-    std::vector<IndexType> return_list{};
-    return_list.reserve(n_points_on_boundary);
-    for (std::size_t i{}; i < n_points_on_boundary; ++i) {
-      return_list.push_back(local_to_global_bd_id(i));
-    }
-    return return_list;
-  }
-
-  /// @brief Get IDs of grid points on the boundary
-  static std::vector<IndexType>
-  GridPointIdsOnBoundary(const std::array<IndexType, dim>& grid_resolutions,
-                         const IndexType& plane_normal_axis,
-                         const IndexType& extrema) {
-    const IndexType plane_id =
-        (extrema > 0) ? grid_resolutions[plane_normal_axis] - 1 : 0;
-    return GridPointIdsOnHyperPlane(grid_resolutions,
-                                    plane_normal_axis,
-                                    plane_id);
-  }
-
-  /// @brief Size
-  IndexType Size() const { return len_; }
-
-  /// @brief Length
-  IndexType Len() const { return len_; }
-
-private:
-  std::array<IndexType, dim> res_;
-  std::array<std::array<DataT, dim>, 2> bounds_;
-  IndexType len_;
-  IndexType len_times_dim_;
-  std::array<std::vector<DataT>, dim> entries_;
-  std::vector<DataT> saved_grid_points_;
-};
-
-/// @brief CStyleArrayPointer based dynamic grid point sampler
-class CStyleArrayPointerGridPoints {
 public:
   template<typename T>
   using Vector_ = splinepy::utils::DefaultInitializationVector<T>;
@@ -192,10 +28,8 @@ public:
   /// @brief Dimension
   int dim_;
 
-  CStyleArrayPointerGridPoints() = default;
-  CStyleArrayPointerGridPoints(const int dim,
-                               const double* bounds,
-                               const int* resolutions) {
+  GridPoints() = default;
+  GridPoints(const int dim, const double* bounds, const int* resolutions) {
     SetUp(dim, bounds, resolutions);
   }
 
@@ -214,7 +48,7 @@ public:
       const int& res = resolutions[i];
       if (res < 2) {
         splinepy::utils::PrintAndThrowError(
-            "Resolutions for CStyleArrayPointerGridPoints can't be less than "
+            "Resolutions for GridPoints can't be less than "
             "2.");
       }
       len_ *= res;
@@ -266,6 +100,50 @@ public:
       ++i;
       repeat *= entry_size;
     }
+  }
+
+  /// @brief Get global IDs
+  /// @param grid_resolutions
+  /// @param plane_normal_axis
+  /// @param plane_id
+  static Vector_<int> IdsOnHyperPlane(const int* grid_resolutions,
+                                      const int& dim,
+                                      const int& plane_normal_axis,
+                                      const int& plane_id) {
+    // Determine size of return vector
+    int n_points_on_plane{1};
+    for (int i_pd{}; i_pd < dim; i_pd++) {
+      if (i_pd == plane_normal_axis)
+        continue;
+      n_points_on_plane *= grid_resolutions[i_pd];
+    }
+
+    auto local_to_global_bd_id = [&](const int& local_id) {
+      int combined_offsets{1}, id{local_id}, global_id{};
+      for (int i_pdc{}; i_pdc < dim; ++i_pdc) {
+        const int& res = grid_resolutions[i_pdc];
+        if (i_pdc == plane_normal_axis) {
+          global_id += combined_offsets * plane_id;
+        } else {
+          // Determine index in coordinate indexing system
+          const int rasterized_index = id % res;
+          // Use the current id to update the global index
+          global_id += rasterized_index * combined_offsets;
+          // Update the copy of the index to search for next slice
+          id -= rasterized_index;
+          id /= res;
+        }
+        combined_offsets *= res;
+      }
+      return global_id;
+    };
+
+    // Fill return list
+    Vector_<int> return_list(n_points_on_plane);
+    for (int i{}; i < n_points_on_plane; ++i) {
+      return_list[i] = local_to_global_bd_id(i);
+    }
+    return return_list;
   }
 
   /// @brief Size

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -1351,9 +1351,9 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
     double* queries = queries_vector.data();
 
     // use grid point generator to fill queries
-    splinepy::utils::CStyleArrayPointerGridPoints gp_generator(para_dim,
-                                                               para_bounds,
-                                                               resolutions);
+    splinepy::utils::GridPoints gp_generator(para_dim,
+                                             para_bounds,
+                                             resolutions);
     gp_generator.Fill(queries);
 
     // create lambda for nthread exe
@@ -1377,8 +1377,7 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
     //   second, to sample
 
     // create a container to hold grid point helper.
-    splinepy::utils::DefaultInitializationVector<
-        splinepy::utils::CStyleArrayPointerGridPoints>
+    splinepy::utils::DefaultInitializationVector<splinepy::utils::GridPoints>
         grid_points(n_splines);
 
     // create grid_points

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -369,10 +369,10 @@ py::array_t<double> PySpline::Sample(py::array_t<int> resolutions,
   double* bounds_ptr = bounds.data();
   Core()->SplinepyParametricBounds(bounds_ptr);
   // prepare sampler
-  auto grid = splinepy::utils::CStyleArrayPointerGridPoints(
-      para_dim_,
-      bounds_ptr,
-      static_cast<int*>(resolutions.request().ptr));
+  auto grid =
+      splinepy::utils::GridPoints(para_dim_,
+                                  bounds_ptr,
+                                  static_cast<int*>(resolutions.request().ptr));
   // prepare output
   const int n_sampled = grid.Size();
   py::array_t<double> sampled(n_sampled * dim_);


### PR DESCRIPTION
# Overview
This PR contributes to the long term goal of removing para_dim/dim from template parameters.
Proximity was taking SplineType as a template parameter.
Then it uses kParaDim and kDim to create std::arrays, nested std::arrays, and kdtree.
A solution for std::arrays is to add an Array class - this results updates in utils/arrays.hpp
As for k-d tree, turns out,  dim is not a strict template parameter. So I've updated napf to accordingly.
This should also reduce some compile tile.

## TODO
- split .cpp file

## Note
- currently, `clipped` info is not used. It used to be part of solver's skip_mask.


## Addressed issues
*  Missing flexibility in Proximity


## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
