### PR TITLE
make CStyleArrayGridPoints GridPoints

### DIFF
--- a/include/splinepy/proximity/proximity.hpp
+++ b/include/splinepy/proximity/proximity.hpp
@@ -43,7 +43,7 @@ protected:
   const splinepy::splines::SplinepyBase& spline_;
 
   // kdtree related variables
-  splinepy::utils::CStyleArrayPointerGridPoints grid_points_;
+  splinepy::utils::GridPoints grid_points_;
   RealArray_ sampled_spline_;
   std::unique_ptr<Cloud_> cloud_;
   std::unique_ptr<Tree_> kdtree_;

--- a/include/splinepy/splines/helpers/extract.hpp
+++ b/include/splinepy/splines/helpers/extract.hpp
@@ -14,10 +14,10 @@ inline int ExtractBoundaryFromAxisAndExtrema(const int& axis,
   return (extreme > 0) ? 2 * axis + 1 : 2 * axis;
 }
 
-template<typename SplineType, typename IndexType>
+template<typename SplineType, typename VectorType>
 std::shared_ptr<splinepy::splines::SplinepyBase>
 ExtractControlMeshSliceFromIDs(const SplineType& spline,
-                               const std::vector<IndexType>& indices,
+                               const VectorType& indices,
                                const int& plane_normal_axis) {
   // Perform sanity check
   if constexpr (SplineType::kParaDim == 1) {
@@ -123,17 +123,16 @@ ExtractBoundaryMeshSlice(const SplineType& spline, const int& boundary_id) {
 
     // get ids on boundary
     const auto cmr =
-        splinepy::splines::helpers::template GetControlMeshResolutions<
-            std::size_t>(spline);
+        splinepy::splines::helpers::template GetControlMeshResolutions<int>(
+            spline);
     const int plane_normal_axis = static_cast<int>(boundary_id / 2);
     const int plane_id =
         ((boundary_id % 2) == 0) ? 0 : cmr[plane_normal_axis] - 1;
-    const auto ids_on_boundary = splinepy::utils::GridPoints<
-        std::size_t,
-        std::size_t,
-        SplineType::kParaDim>::GridPointIdsOnHyperPlane(cmr,
-                                                        plane_normal_axis,
-                                                        plane_id);
+    const auto ids_on_boundary = splinepy::utils::GridPoints::IdsOnHyperPlane(
+        cmr.data(),
+        static_cast<int>(cmr.size()),
+        plane_normal_axis,
+        plane_id);
     return ExtractControlMeshSliceFromIDs(spline,
                                           ids_on_boundary,
                                           plane_normal_axis);
@@ -158,12 +157,11 @@ ExtractControlMeshSlice(const SplineType& spline,
     const auto cmr =
         splinepy::splines::helpers::template GetControlMeshResolutions<
             std::size_t>(spline);
-    const auto ids_on_boundary = splinepy::utils::GridPoints<
-        std::size_t,
-        std::size_t,
-        SplineType::kParaDim>::GridPointIdsOnHyperPlane(cmr,
-                                                        plane_normal_axis,
-                                                        plane_id);
+    const auto ids_on_boundary = splinepy::utils::GridPoints::IdsOnHyperPlane(
+        cmr.data(),
+        static_cast<int>(cmr.size()),
+        plane_normal_axis,
+        plane_id);
     return ExtractControlMeshSliceFromIDs(spline,
                                           ids_on_boundary,
                                           plane_normal_axis);

--- a/include/splinepy/utils/grid_points.hpp
+++ b/include/splinepy/utils/grid_points.hpp
@@ -9,172 +9,8 @@
 
 namespace splinepy::utils {
 
-/// @brief Grid points class
-/// @tparam DataT
-/// @tparam IndexType
-/// @tparam dim
-template<typename DataT, typename IndexType, int dim>
+/// @brief GridPoints based dynamic grid point sampler
 class GridPoints {
-public:
-  /// @brief Step size, could be useful for setting searchbounds aggressively
-  std::array<DataT, dim> step_size_;
-
-  GridPoints() = default;
-  /// @brief Constructor
-  /// @param bounds
-  /// @param resolutions
-  GridPoints(const std::array<std::array<DataT, dim>, 2>& bounds,
-             const std::array<IndexType, dim>& resolutions)
-      : res_(resolutions),
-        bounds_(bounds) {
-    // linspace and prepare possible entries */
-    len_ = 1;
-    for (int i{0}; i < dim; i++) {
-      len_ *= resolutions[i];
-      std::vector<DataT>& entryvec = entries_[i];
-      entryvec.reserve(resolutions[i]);
-
-      step_size_[i] = (bounds[1][i] - bounds[0][i]) / (res_[i] - 1);
-      for (int j{0}; j < resolutions[i]; j++) {
-        entryvec.emplace_back(bounds[0][i] + step_size_[i] * j);
-      }
-    }
-    len_times_dim_ = len_ * dim;
-  }
-
-  /// @brief Get grid point from index
-  const std::array<DataT, dim> operator[](const IndexType id) {
-    return IndexToGridPoint<std::array<DataT, dim>>(id);
-  }
-
-  /// @brief Get grid point from index
-  /// @param id
-  /// @return Grid point
-  template<typename GridPointType>
-  GridPointType IndexToGridPoint(const IndexType& id) const {
-
-    using ValueType = typename GridPointType::value_type;
-
-    GridPointType gpoint{};
-
-    IndexType quot{id};
-    for (int i{0}; i < dim; i++) {
-      gpoint[i] = ValueType{entries_[i][quot % res_[i]]};
-      quot /= res_[i];
-    }
-
-    return gpoint;
-  }
-
-  /// subroutine variation
-  template<typename GridPointType>
-  void IndexToGridPoint(const IndexType& id, GridPointType& gpoint) const {
-
-    using ValueType = typename GridPointType::value_type;
-
-    IndexType quot{id};
-    for (int i{0}; i < dim; i++) {
-      gpoint[i] = ValueType{entries_[i][quot % res_[i]]};
-      quot /= res_[i];
-    }
-  }
-
-  /// Saved at the first call then returns
-  const std::vector<DataT>& GetAllGridPoints() {
-    // early exit if we have them
-    if (saved_grid_points_.size() == len_times_dim_) {
-      return saved_grid_points_;
-    }
-    // get all.
-    saved_grid_points_.clear();
-    saved_grid_points_.reserve(len_times_dim_);
-    for (IndexType i{}; i < len_; ++i) {
-      // third time is the charm
-      IndexType quot{i};
-      for (IndexType j{}; j < dim; ++j) {
-        const auto& r = res_[j];
-        saved_grid_points_.emplace_back(entries_[j][quot % r]);
-        quot /= r;
-      }
-    }
-
-    return saved_grid_points_;
-  }
-
-  /// @brief Get global IDs
-  /// @param grid_resolutions
-  /// @param plane_normal_axis
-  /// @param plane_id
-  static std::vector<IndexType>
-  GridPointIdsOnHyperPlane(const std::array<IndexType, dim>& grid_resolutions,
-                           const IndexType& plane_normal_axis,
-                           const IndexType& plane_id) {
-    // Determine size of return vector
-    IndexType n_points_on_boundary{1};
-    for (std::size_t i_pd{}; i_pd < dim; i_pd++) {
-      if (i_pd == plane_normal_axis)
-        continue;
-      n_points_on_boundary *= grid_resolutions[i_pd];
-    }
-
-    auto local_to_global_bd_id = [&](const IndexType& local_id) {
-      IndexType combined_offsets{1}, id{local_id}, global_id{};
-      for (std::size_t i_pdc{}; i_pdc < dim; ++i_pdc) {
-        const auto& res = grid_resolutions[i_pdc];
-        if (i_pdc == plane_normal_axis) {
-          global_id += combined_offsets * plane_id;
-        } else {
-          // Determine index in coordinate indexing system
-          const IndexType rasterized_index = id % res;
-          // Use the current id to update the global index
-          global_id += rasterized_index * combined_offsets;
-          // Update the copy of the index to search for next slice
-          id -= rasterized_index;
-          id /= res;
-        }
-        combined_offsets *= res;
-      }
-      return global_id;
-    };
-
-    // Fill return list
-    std::vector<IndexType> return_list{};
-    return_list.reserve(n_points_on_boundary);
-    for (std::size_t i{}; i < n_points_on_boundary; ++i) {
-      return_list.push_back(local_to_global_bd_id(i));
-    }
-    return return_list;
-  }
-
-  /// @brief Get IDs of grid points on the boundary
-  static std::vector<IndexType>
-  GridPointIdsOnBoundary(const std::array<IndexType, dim>& grid_resolutions,
-                         const IndexType& plane_normal_axis,
-                         const IndexType& extrema) {
-    const IndexType plane_id =
-        (extrema > 0) ? grid_resolutions[plane_normal_axis] - 1 : 0;
-    return GridPointIdsOnHyperPlane(grid_resolutions,
-                                    plane_normal_axis,
-                                    plane_id);
-  }
-
-  /// @brief Size
-  IndexType Size() const { return len_; }
-
-  /// @brief Length
-  IndexType Len() const { return len_; }
-
-private:
-  std::array<IndexType, dim> res_;
-  std::array<std::array<DataT, dim>, 2> bounds_;
-  IndexType len_;
-  IndexType len_times_dim_;
-  std::array<std::vector<DataT>, dim> entries_;
-  std::vector<DataT> saved_grid_points_;
-};
-
-/// @brief CStyleArrayPointer based dynamic grid point sampler
-class CStyleArrayPointerGridPoints {
 public:
   template<typename T>
   using Vector_ = splinepy::utils::DefaultInitializationVector<T>;
@@ -192,10 +28,8 @@ public:
   /// @brief Dimension
   int dim_;
 
-  CStyleArrayPointerGridPoints() = default;
-  CStyleArrayPointerGridPoints(const int dim,
-                               const double* bounds,
-                               const int* resolutions) {
+  GridPoints() = default;
+  GridPoints(const int dim, const double* bounds, const int* resolutions) {
     SetUp(dim, bounds, resolutions);
   }
 
@@ -214,7 +48,7 @@ public:
       const int& res = resolutions[i];
       if (res < 2) {
         splinepy::utils::PrintAndThrowError(
-            "Resolutions for CStyleArrayPointerGridPoints can't be less than "
+            "Resolutions for GridPoints can't be less than "
             "2.");
       }
       len_ *= res;
@@ -266,6 +100,50 @@ public:
       ++i;
       repeat *= entry_size;
     }
+  }
+
+  /// @brief Get global IDs
+  /// @param grid_resolutions
+  /// @param plane_normal_axis
+  /// @param plane_id
+  static Vector_<int> IdsOnHyperPlane(const int* grid_resolutions,
+                                      const int& dim,
+                                      const int& plane_normal_axis,
+                                      const int& plane_id) {
+    // Determine size of return vector
+    int n_points_on_plane{1};
+    for (int i_pd{}; i_pd < dim; i_pd++) {
+      if (i_pd == plane_normal_axis)
+        continue;
+      n_points_on_plane *= grid_resolutions[i_pd];
+    }
+
+    auto local_to_global_bd_id = [&](const int& local_id) {
+      int combined_offsets{1}, id{local_id}, global_id{};
+      for (int i_pdc{}; i_pdc < dim; ++i_pdc) {
+        const int& res = grid_resolutions[i_pdc];
+        if (i_pdc == plane_normal_axis) {
+          global_id += combined_offsets * plane_id;
+        } else {
+          // Determine index in coordinate indexing system
+          const int rasterized_index = id % res;
+          // Use the current id to update the global index
+          global_id += rasterized_index * combined_offsets;
+          // Update the copy of the index to search for next slice
+          id -= rasterized_index;
+          id /= res;
+        }
+        combined_offsets *= res;
+      }
+      return global_id;
+    };
+
+    // Fill return list
+    Vector_<int> return_list(n_points_on_plane);
+    for (int i{}; i < n_points_on_plane; ++i) {
+      return_list[i] = local_to_global_bd_id(i);
+    }
+    return return_list;
   }
 
   /// @brief Size

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -1351,9 +1351,9 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
     double* queries = queries_vector.data();
 
     // use grid point generator to fill queries
-    splinepy::utils::CStyleArrayPointerGridPoints gp_generator(para_dim,
-                                                               para_bounds,
-                                                               resolutions);
+    splinepy::utils::GridPoints gp_generator(para_dim,
+                                             para_bounds,
+                                             resolutions);
     gp_generator.Fill(queries);
 
     // create lambda for nthread exe
@@ -1377,8 +1377,7 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
     //   second, to sample
 
     // create a container to hold grid point helper.
-    splinepy::utils::DefaultInitializationVector<
-        splinepy::utils::CStyleArrayPointerGridPoints>
+    splinepy::utils::DefaultInitializationVector<splinepy::utils::GridPoints>
         grid_points(n_splines);
 
     // create grid_points

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -369,10 +369,10 @@ py::array_t<double> PySpline::Sample(py::array_t<int> resolutions,
   double* bounds_ptr = bounds.data();
   Core()->SplinepyParametricBounds(bounds_ptr);
   // prepare sampler
-  auto grid = splinepy::utils::CStyleArrayPointerGridPoints(
-      para_dim_,
-      bounds_ptr,
-      static_cast<int*>(resolutions.request().ptr));
+  auto grid =
+      splinepy::utils::GridPoints(para_dim_,
+                                  bounds_ptr,
+                                  static_cast<int*>(resolutions.request().ptr));
   // prepare output
   const int n_sampled = grid.Size();
   py::array_t<double> sampled(n_sampled * dim_);


### PR DESCRIPTION
# Overview
This PR removes `GridPoints` - It was only used to extract hyperplane ids.  CStyleArrayGridPoints is renamed to GridPoints. 

## Addressed issues
*  dim as template parameter

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
