### PR TITLE
Bug fix ci docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         pip install -r ./docs/requirements.txt
         python docs/source/handle_markdown.py
-        sphinx-build -W -b html docs/source docs/build -j auto
+        sphinx-build -b html docs/source docs/build -j auto
 
     - name: deploy docs only if it is pushed to main
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         pip install -r ./docs/requirements.txt
         python docs/source/handle_markdown.py
-        sphinx-build -b html docs/source docs/build -j auto
+        sphinx-build -W -b html docs/source docs/build -j auto
 
     - name: deploy docs only if it is pushed to main
       uses: peaceiris/actions-gh-pages@v3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ html_theme_options = {
             "icon": "fa-solid fa-box",
         },
     ],
-    "navigation_with_keys": True,
+    "navigation_with_keys": False,
 }
 # html_favicon = "_static/favicon.ico"
 html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,9 @@ html_theme_options = {
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
 
+tml_theme_options = {
+    "navigation_with_keys": True,
+}
 
 autodoc_default_options = {
     "autosummary": True,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ html_theme_options = {
             "icon": "fa-solid fa-box",
         },
     ],
+    "navigation_with_keys": True,
 }
 # html_favicon = "_static/favicon.ico"
 html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,10 +65,6 @@ html_theme_options = {
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
 
-tml_theme_options = {
-    "navigation_with_keys": True,
-}
-
 autodoc_default_options = {
     "autosummary": True,
 }


### PR DESCRIPTION
# Overview

Sphinx writes a warning that in the next release the default value for `navigation_with_keys` will change to `False`. Because in the docs/ .. pipeline the flag for `Warning, treated as an error` is set to `True` (-W): (`sphinx-build -W -b html docs/source docs/build -j auto`)  the pipeline fails.

## Addressed issues
#281 

## Showcase
A short / one-liner example to highlight the (new) feature
```
import splinepy

new, feature = splinepy.tataratat()
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
