### PR TITLE
New_NThreadExe

### DIFF
--- a/include/splinepy/proximity/proximity.hpp
+++ b/include/splinepy/proximity/proximity.hpp
@@ -79,7 +79,7 @@ public:
     sampled_spline_.Reallocate(n_queries * dim);
 
     // lambda function to allow n-thread execution
-    auto sample_coordinates = [&](int begin, int end) {
+    auto sample_coordinates = [&](int begin, int end, int) {
       RealArray_ query(para_dim);
       double* query_data = query.data();
 

--- a/include/splinepy/proximity/proximity.hpp
+++ b/include/splinepy/proximity/proximity.hpp
@@ -79,7 +79,7 @@ public:
     sampled_spline_.Reallocate(n_queries * dim);
 
     // lambda function to allow n-thread execution
-    auto sample_coordinates = [&](int begin, int end, int) {
+    auto sample_coordinates = [&](const int begin, const int end, int) {
       RealArray_ query(para_dim);
       double* query_data = query.data();
 

--- a/include/splinepy/utils/nthreads.hpp
+++ b/include/splinepy/utils/nthreads.hpp
@@ -3,57 +3,52 @@
 #include <cstdlib>
 #include <thread>
 
-namespace splinepy::utils 
-{
-  /// N-Thread execution. Queries will be split into chunks and each thread
-  /// will execute those.
-  template<typename Func, typename IndexType>
-  void NThreadExecution(
-      const Func& f,
-      const IndexType& total,
-      IndexType nthread /* copy */) 
-  {
-    // For any negative value, std::thread::hardware_concurrency() will be taken
-    // If you are not satisfied with returned value, use positive value.
-    // For more info:
-    // https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency
-    // Minimal value that comes out of it will be 0.
-    
-    if (nthread < 0) 
-    {
-      nthread = std::thread::hardware_concurrency();
-    }
+namespace splinepy::utils {
+/// N-Thread execution. Queries will be split into chunks and each thread
+/// will execute those.
+template<typename Func, typename IndexType>
+void NThreadExecution(const Func& f,
+                      const IndexType& total,
+                      IndexType nthread /* copy */) {
+  // For any negative value, std::thread::hardware_concurrency() will be taken
+  // If you are not satisfied with returned value, use positive value.
+  // For more info:
+  // https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency
+  // Minimal value that comes out of it will be 0.
 
-    // 0 or 1, don't create a thread.
-    if (nthread <= 1) 
-    {
-      f(0, total, 0);
-      return;
-    }
+  if (nthread < 0) {
+    nthread = std::thread::hardware_concurrency();
+  }
 
-    // we don't want nthread to exceed total
-    nthread = std::min(total, nthread);
+  // 0 or 1, don't create a thread.
+  if (nthread <= 1) {
+    f(0, total, 0);
+    return;
+  }
 
-    // reserve thread pool
-    std::vector<std::thread> thread_pool;
-    thread_pool.reserve(nthread);
-    
-    // get chunk size and prepare threads
-    // make sure it rounds up
-    const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
-      
-    for (int i{}; i < (nthread - 1); i++) 
-    {
-      thread_pool.emplace_back(std::thread{f, i*chunk_size, (i+1)*chunk_size, i});
-    }
-  
-    // last one
-    thread_pool.emplace_back(std::thread{f, (nthread - 1) * chunk_size, total, nthread-1});
+  // we don't want nthread to exceed total
+  nthread = std::min(total, nthread);
 
-    for (auto& t : thread_pool) 
-    {
-      t.join();
-    }
+  // reserve thread pool
+  std::vector<std::thread> thread_pool;
+  thread_pool.reserve(nthread);
+
+  // get chunk size and prepare threads
+  // make sure it rounds up
+  const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
+
+  for (int i{}; i < (nthread - 1); i++) {
+    thread_pool.emplace_back(
+        std::thread{f, i * chunk_size, (i + 1) * chunk_size, i});
+  }
+
+  // last one
+  thread_pool.emplace_back(
+      std::thread{f, (nthread - 1) * chunk_size, total, nthread - 1});
+
+  for (auto& t : thread_pool) {
+    t.join();
   }
 }
+} // namespace splinepy::utils
 /* namespace splinepy::utils */

--- a/include/splinepy/utils/nthreads.hpp
+++ b/include/splinepy/utils/nthreads.hpp
@@ -3,80 +3,89 @@
 #include <cstdlib>
 #include <thread>
 
-namespace splinepy::utils {
+namespace splinepy::utils 
+{
+  enum class NThreadQueryType : int {
+    // split queries into chunks that can allows contiguous visit
+    Chunk = 0,
+    // useful if you want to visit queries with nthread steps,
+    // similar to python's `queries[start::nthread]`.
+    // practical difference is that it passes (i_thread, total) to the function f,
+    // instead of (chunk_begin, chunk_end)
+    Step = 1
+  };
 
-enum class NThreadQueryType : int {
-  // split queries into chunks that can allows contiguous visit
-  Chunk = 0,
-  // useful if you want to visit queries with nthread steps,
-  // similar to python's `queries[start::nthread]`.
-  // practical difference is that it passes (i_thread, total) to the function f,
-  // instead of (chunk_begin, chunk_end)
-  Step = 1
-};
+  template<typename Func, typename IndexType>
+  void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool);
 
-template<typename Func, typename IndexType>
-void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool);
+  /// N-Thread execution. Queries will be split into chunks and each thread
+  /// will execute those.
+  template<typename Func, typename IndexType>
+  void NThreadExecution(
+      const Func& f,
+      const IndexType& total,
+      IndexType nthread /* copy */,
+      const NThreadQueryType query_type = NThreadQueryType::Chunk) 
+  {
+    // For any negative value, std::thread::hardware_concurrency() will be taken
+    // If you are not satisfied with returned value, use positive value.
+    // For more info:
+    // https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency
+    // Minimal value that comes out of it will be 0.
+    
+    if (nthread < 0) 
+    {
+      nthread = std::thread::hardware_concurrency();
+    }
 
-/// N-Thread execution. Queries will be split into chunks and each thread
-/// will execute those.
-template<typename Func, typename IndexType>
-void NThreadExecution(
-    const Func& f,
-    const IndexType& total,
-    IndexType nthread /* copy */,
-    const NThreadQueryType query_type = NThreadQueryType::Chunk) {
-  // For any negative value, std::thread::hardware_concurrency() will be taken
-  // If you are not satisfied with returned value, use positive value.
-  // For more info:
-  //   https://en.cppreference.com/w/cpp/thread/thread/hardware_concurrency
-  // Minimal value that comes out of it will be 0.
-  if (nthread < 0) {
-    nthread = std::thread::hardware_concurrency();
-  }
+    // 0 or 1, don't create a thread.
+    if (nthread <= 1) 
+    {
+      f(0, total);
+      return;
+    }
 
-  // 0 or 1, don't create a thread.
-  if (nthread <= 1) {
-    f(0, total);
-    return;
-  }
+    // we don't want nthread to exceed total
+    nthread = std::min(total, nthread);
 
-  // we don't want nthread to exceed total
-  nthread = std::min(total, nthread);
-
-  // reserve thread pool
-  std::vector<std::thread> thread_pool;
-  thread_pool.reserve(nthread);
-  
-    if (query_type == NThreadQueryType::Chunk) {
+    // reserve thread pool
+    std::vector<std::thread> thread_pool;
+    thread_pool.reserve(nthread);
+    
+    if (query_type == NThreadQueryType::Chunk) 
+    {
     // get chunk size and prepare threads
     // make sure it rounds up
-    const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
-    
-    for (int i{}; i < (nthread - 1); ++i) {
-      threaden(f, i*chunk_size, (i+1)*chunk_size, thread_pool);
-    }
- 
-    // last one
-    threaden(f, (nthread - 1) * chunk_size, total);
+      const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
+      
+      for (int i{}; i < (nthread - 1); ++i) 
+      {
+        threaden(f, i*chunk_size, (i+1)*chunk_size, thread_pool);
+      }
   
-  } else if (query_type == NThreadQueryType::Step) {
-    for (int i{}; i < nthread; ++i) {
-      // strictly, (most of the time) we don't need total for lambda funcs
-      // keep it for conformity
-      threaden(f, i, total, thread_pool);
+      // last one
+      threaden(f, (nthread - 1) * chunk_size, total);
+    } 
+    else if (query_type == NThreadQueryType::Step) 
+    {
+      for (int i{}; i < nthread; ++i) 
+      {
+        // strictly, (most of the time) we don't need total for lambda funcs
+        // keep it for conformity
+        threaden(f, i, total, thread_pool);
+      }
+    }
+
+    for (auto& t : thread_pool) 
+    {
+      t.join();
     }
   }
 
-  for (auto& t : thread_pool) {
-    t.join();
-  }
-}
-
-template<typename Func, typename IndexType>
-void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool)
-{ 
-  thread_pool.emplace_back(std::thread{f, begin, end});
-} 
+  template<typename Func, typename IndexType>
+  void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool)
+  { 
+    thread_pool.emplace_back(std::thread{f, begin, end});
+  } 
 }
 /* namespace splinepy::utils */

--- a/include/splinepy/utils/nthreads.hpp
+++ b/include/splinepy/utils/nthreads.hpp
@@ -42,7 +42,7 @@ namespace splinepy::utils
     // make sure it rounds up
     const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
       
-    for (int i{}; i < (nthread - 1); ++i) 
+    for (int i{}; i < (nthread - 1); i++) 
     {
       thread_pool.emplace_back(std::thread{f, i*chunk_size, (i+1)*chunk_size, i});
     }

--- a/include/splinepy/utils/nthreads.hpp
+++ b/include/splinepy/utils/nthreads.hpp
@@ -5,27 +5,13 @@
 
 namespace splinepy::utils 
 {
-  enum class NThreadQueryType : int {
-    // split queries into chunks that can allows contiguous visit
-    Chunk = 0,
-    // useful if you want to visit queries with nthread steps,
-    // similar to python's `queries[start::nthread]`.
-    // practical difference is that it passes (i_thread, total) to the function f,
-    // instead of (chunk_begin, chunk_end)
-    Step = 1
-  };
-
-  template<typename Func, typename IndexType>
-  void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool);
-
   /// N-Thread execution. Queries will be split into chunks and each thread
   /// will execute those.
   template<typename Func, typename IndexType>
   void NThreadExecution(
       const Func& f,
       const IndexType& total,
-      IndexType nthread /* copy */,
-      const NThreadQueryType query_type = NThreadQueryType::Chunk) 
+      IndexType nthread /* copy */) 
   {
     // For any negative value, std::thread::hardware_concurrency() will be taken
     // If you are not satisfied with returned value, use positive value.
@@ -41,7 +27,7 @@ namespace splinepy::utils
     // 0 or 1, don't create a thread.
     if (nthread <= 1) 
     {
-      f(0, total);
+      f(0, total, 0);
       return;
     }
 
@@ -52,40 +38,22 @@ namespace splinepy::utils
     std::vector<std::thread> thread_pool;
     thread_pool.reserve(nthread);
     
-    if (query_type == NThreadQueryType::Chunk) 
-    {
     // get chunk size and prepare threads
     // make sure it rounds up
-      const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
+    const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
       
-      for (int i{}; i < (nthread - 1); ++i) 
-      {
-        threaden(f, i*chunk_size, (i+1)*chunk_size, thread_pool);
-      }
-  
-      // last one
-      threaden(f, (nthread - 1) * chunk_size, total);
-    } 
-    else if (query_type == NThreadQueryType::Step) 
+    for (int i{}; i < (nthread - 1); ++i) 
     {
-      for (int i{}; i < nthread; ++i) 
-      {
-        // strictly, (most of the time) we don't need total for lambda funcs
-        // keep it for conformity
-        threaden(f, i, total, thread_pool);
-      }
+      thread_pool.emplace_back(std::thread{f, i*chunk_size, (i+1)*chunk_size, i});
     }
+  
+    // last one
+    thread_pool.emplace_back(std::thread{f, (nthread - 1) * chunk_size, total, nthread-1});
 
     for (auto& t : thread_pool) 
     {
       t.join();
     }
   }
-
-  template<typename Func, typename IndexType>
-  void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::thread>& thread_pool)
-  { 
-    thread_pool.emplace_back(std::thread{f, begin, end});
-  } 
 }
 /* namespace splinepy::utils */

--- a/include/splinepy/utils/nthreads.hpp
+++ b/include/splinepy/utils/nthreads.hpp
@@ -54,9 +54,7 @@ void NThreadExecution(
     const IndexType chunk_size = std::div((total + nthread - 1), nthread).quot;
     
     for (int i{}; i < (nthread - 1); ++i) {
-      IndexType begin = i*chunk_size;
-      IndexType end = (i+1)*chunk_size;
-      threaden(f, begin, end, thread_pool);
+      threaden(f, i*chunk_size, (i+1)*chunk_size, thread_pool);
     }
  
     // last one
@@ -80,4 +78,5 @@ void threaden(const Func& f, IndexType begin, IndexType end, std::vector<std::th
 { 
   thread_pool.emplace_back(std::thread{f, begin, end});
 } 
+}
 /* namespace splinepy::utils */

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -144,7 +144,6 @@ void RaiseMismatch(const CoreSplineVector& splist,
 
   // lambda for nthread comparison
   auto check_mismatch_step = [&](int, int, const int i_thread) {
-    
     // alloc vectors in case we need to compare
     IntVector spline_degree(ref_para_dim), spline_cmr(ref_para_dim);
     int total_ = static_cast<int>(splist.size());
@@ -267,7 +266,6 @@ void RaiseMismatch(const CoreSplineVector& splist0,
 
   // lambda for nthread comparison
   auto check_mismatch_step = [&](int, int, const int i_thread) {
-    
     // alloc some tmp vector if needed
     IntVector int_vec0, int_vec1;
     const int total_ = static_cast<int>(splist0.size());
@@ -1128,7 +1126,7 @@ py::array_t<double> PyMultipatch::SubPatchCenters() {
                                       n_default_threads_);
   }
 
-  auto calc_sub_patch_centers_step = [&](int, int , const int i_thread) {
+  auto calc_sub_patch_centers_step = [&](int, int, const int i_thread) {
     // each thread needs one query
     DoubleVector queries_vector; /* unused if same_parametric_bounds=true*/
     double* queries;
@@ -1297,9 +1295,7 @@ py::array_t<double> PyMultipatch::Evaluate(py::array_t<double> queries,
   };
 
   // exe
-  splinepy::utils::NThreadExecution(evaluate_step,
-                                    n_total,
-                                    nthreads);
+  splinepy::utils::NThreadExecution(evaluate_step, n_total, nthreads);
 
   return evaluated;
 }
@@ -1403,9 +1399,7 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
     };
 
     // exe - this one is step
-    splinepy::utils::NThreadExecution(sample_step,
-                                      n_total,
-                                      nthreads);
+    splinepy::utils::NThreadExecution(sample_step, n_total, nthreads);
   }
 
   return sampled;

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -20,7 +20,7 @@ std::vector<PySpline::CoreSpline_> ToCoreSplineVector(py::list pysplines,
   const int n_splines = static_cast<int>(pysplines.size());
   std::vector<PySpline::CoreSpline_> core_splines(n_splines);
 
-  auto to_core = [&](int begin, int end, int) {
+  auto to_core = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       core_splines[i] =
           pysplines[i].template cast<std::shared_ptr<PySpline>>()->Core();
@@ -40,7 +40,7 @@ ToCoreSplineVector(py::list pysplines,
   const int n_splines = static_cast<int>(pysplines.size());
   std::vector<PySpline::CoreSpline_> core_splines(n_splines);
 
-  auto to_core = [&](int begin, int end, int) {
+  auto to_core = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       // get accessor
       auto spline = pysplines[i];
@@ -270,7 +270,7 @@ void RaiseMismatch(const CoreSplineVector& splist0,
     
     // alloc some tmp vector if needed
     IntVector int_vec0, int_vec1;
-    const int total = static_cast<int>(splist0.size());
+    const int total_ = static_cast<int>(splist0.size());
 
     for (int i{i_thread}; i < total_; i += nthreads) {
       // get spline to check
@@ -709,7 +709,7 @@ py::tuple GetBoundaryOrientations(const py::list& spline_list,
       static_cast<bool*>(bool_orientations.request().ptr);
 
   // Provide lambda for multithread execution
-  auto get_orientation = [&](int start, int end, int) {
+  auto get_orientation = [&](const int start, const int end, int) {
     for (int i{start}; i < end; ++i) {
       GetBoundaryOrientation(cpp_spline_list[base_id_ptr[i]],
                              base_face_id_ptr[i],
@@ -763,12 +763,9 @@ py::list ExtractAllBoundarySplines(const py::list& spline_list,
     // start : process-ID
     // end : unused hence no referencing
 
-    // Auxiliary variables
-    //const int start_index = start * chunk_size;
-    //const int end_index = (start + 1) * chunk_size;
     auto& boundaries_local = lists_to_concatenate[start];
     // Start extraction (remaining order)
-    for (int i{start_index}; i < end_index; i++) {
+    for (int i{start}; i < end; i++) {
       for (int j{}; j < n_faces; j++) {
         if (interface_ptr[i * n_faces + j] < 0) {
           boundaries_local.append(
@@ -1059,7 +1056,7 @@ std::shared_ptr<PyMultipatch> PyMultipatch::SubMultipatch() {
   CoreSplineVector out_boundaries(n_boundaries);
 
   // prepare lambda
-  auto boundary_extract = [&](int begin, int end, int) {
+  auto boundary_extract = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       // start of the offset
       const int offset = i * n_boundary;
@@ -1117,7 +1114,7 @@ py::array_t<double> PyMultipatch::SubPatchCenters() {
     para_bounds_ptr = para_bounds.data();
     const int stride = n_queries * para_dim;
 
-    auto calc_para_bounds = [&](int begin, int end, int) {
+    auto calc_para_bounds = [&](const int begin, const int end, int) {
       for (int i{begin}; i < end; ++i) {
         splinepy::splines::helpers::ScalarTypeBoundaryCenters(
             *core_patches_[i],
@@ -1373,7 +1370,7 @@ py::array_t<double> PyMultipatch::Sample(const int resolution,
         grid_points(n_splines);
 
     // create grid_points
-    auto create_grid_points = [&](int begin, int end, int) {
+    auto create_grid_points = [&](const int begin, const int end, int) {
       DoubleVector para_bounds_vector(2 * para_dim);
       double* para_bounds = para_bounds_vector.data();
 
@@ -1436,7 +1433,7 @@ void PyMultipatch::AddFields(py::list& fields,
   std::vector<std::shared_ptr<PyMultipatch>> field_ptrs(n_new_fields);
 
   // Multi-threading where each threads deals with a field at a time
-  auto field_to_multipatch = [&](int begin, int end, int) {
+  auto field_to_multipatch = [&](const int begin, const int end, int) {
     // Chunks over field ids
     for (int i{begin}; i < end; ++i) {
       // create multipatch

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -353,14 +353,14 @@ py::array_t<double> PySpline::Evaluate(py::array_t<double> queries,
 
   // prepare vectorized evaluate queries
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
-  auto evaluate = [&](int begin, int end) {
+  auto evaluate = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyEvaluate(&queries_ptr[i * para_dim_],
                                &evaluated_ptr[i * dim_]);
     }
   };
 
-  splinepy::utils::ecution(evaluate, n_queries, nthreads);
+  splinepy::utils::NThreadExecution(evaluate, n_queries, nthreads);
 
   evaluated.resize({n_queries, dim_});
   return evaluated;
@@ -415,7 +415,7 @@ py::array_t<double> PySpline::Jacobian(const py::array_t<double> queries,
   // prepare lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   const int stride = para_dim_ * dim_;
-  auto derive = [&](int begin, int end) {
+  auto derive = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyJacobian(&queries_ptr[i * para_dim_],
                                &jacobians_ptr[i * stride]);

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -360,7 +360,7 @@ py::array_t<double> PySpline::Evaluate(py::array_t<double> queries,
     }
   };
 
-  splinepy::utils::NThreadExecution(evaluate, n_queries, nthreads);
+  splinepy::utils::ecution(evaluate, n_queries, nthreads);
 
   evaluated.resize({n_queries, dim_});
   return evaluated;
@@ -385,7 +385,7 @@ py::array_t<double> PySpline::Sample(py::array_t<int> resolutions,
   double* sampled_ptr = static_cast<double*>(sampled.request().ptr);
 
   // wrap evaluate
-  auto sample = [&](int begin, int end) {
+  auto sample = [&](int begin, int end, int) {
     std::vector<double> query(para_dim_);
     double* query_ptr = query.data();
     for (int i{begin}; i < end; ++i) {
@@ -467,7 +467,7 @@ py::array_t<double> PySpline::Derivative(py::array_t<double> queries,
   // prepare lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
-  auto derive = [&](int begin, int end) {
+  auto derive = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyDerivative(
           &queries_ptr[i * para_dim_],
@@ -494,7 +494,7 @@ py::array_t<int> PySpline::Support(py::array_t<double> queries,
   // prepare_lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* supports_ptr = static_cast<int*>(supports.request().ptr);
-  auto support = [&](int begin, int end) {
+  auto support = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepySupport(&queries_ptr[i * para_dim_],
                               &supports_ptr[i * n_support]);
@@ -518,7 +518,7 @@ py::array_t<double> PySpline::Basis(py::array_t<double> queries,
   // prepare_lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   double* bases_ptr = static_cast<double*>(bases.request().ptr);
-  auto basis = [&](int begin, int end) {
+  auto basis = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasis(&queries_ptr[i * para_dim_],
                             &bases_ptr[i * n_support]);
@@ -544,7 +544,7 @@ py::tuple PySpline::BasisAndSupport(py::array_t<double> queries,
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   double* basis_ptr = static_cast<double*>(basis.request().ptr);
   int* support_ptr = static_cast<int*>(support.request().ptr);
-  auto basis_support = [&](int begin, int end) {
+  auto basis_support = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisAndSupport(&queries_ptr[i * para_dim_],
                                       &basis_ptr[i * n_support],
@@ -599,7 +599,7 @@ py::array_t<double> PySpline::BasisDerivative(py::array_t<double> queries,
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
   double* basis_der_ptr = static_cast<double*>(basis_der.request().ptr);
-  auto basis_derivative = [&](int begin, int end) {
+  auto basis_derivative = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisDerivative(
           &queries_ptr[i * para_dim_],
@@ -654,7 +654,7 @@ py::tuple PySpline::BasisDerivativeAndSupport(py::array_t<double> queries,
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
   double* basis_der_ptr = static_cast<double*>(basis_der.request().ptr);
   int* support_ptr = static_cast<int*>(support.request().ptr);
-  auto basis_der_support = [&](int begin, int end) {
+  auto basis_der_support = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisDerivativeAndSupport(
           &queries_ptr[i * para_dim_],
@@ -707,7 +707,7 @@ PySpline::Proximities(py::array_t<double> queries,
       static_cast<double*>(first_derivatives.request().ptr);
   double* second_derivatives_ptr =
       static_cast<double*>(second_derivatives.request().ptr);
-  auto proximities = [&](int begin, int end) {
+  auto proximities = [&](int begin, int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyVerboseProximity(&queries_ptr[i * dim_],
                                        tolerance,

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -385,7 +385,7 @@ py::array_t<double> PySpline::Sample(py::array_t<int> resolutions,
   double* sampled_ptr = static_cast<double*>(sampled.request().ptr);
 
   // wrap evaluate
-  auto sample = [&](int begin, int end, int) {
+  auto sample = [&](const int begin, const int end, int) {
     std::vector<double> query(para_dim_);
     double* query_ptr = query.data();
     for (int i{begin}; i < end; ++i) {
@@ -467,7 +467,7 @@ py::array_t<double> PySpline::Derivative(py::array_t<double> queries,
   // prepare lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
-  auto derive = [&](int begin, int end, int) {
+  auto derive = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyDerivative(
           &queries_ptr[i * para_dim_],
@@ -494,7 +494,7 @@ py::array_t<int> PySpline::Support(py::array_t<double> queries,
   // prepare_lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* supports_ptr = static_cast<int*>(supports.request().ptr);
-  auto support = [&](int begin, int end, int) {
+  auto support = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepySupport(&queries_ptr[i * para_dim_],
                               &supports_ptr[i * n_support]);
@@ -518,7 +518,7 @@ py::array_t<double> PySpline::Basis(py::array_t<double> queries,
   // prepare_lambda for nthread exe
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   double* bases_ptr = static_cast<double*>(bases.request().ptr);
-  auto basis = [&](int begin, int end, int) {
+  auto basis = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasis(&queries_ptr[i * para_dim_],
                             &bases_ptr[i * n_support]);
@@ -544,7 +544,7 @@ py::tuple PySpline::BasisAndSupport(py::array_t<double> queries,
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   double* basis_ptr = static_cast<double*>(basis.request().ptr);
   int* support_ptr = static_cast<int*>(support.request().ptr);
-  auto basis_support = [&](int begin, int end, int) {
+  auto basis_support = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisAndSupport(&queries_ptr[i * para_dim_],
                                       &basis_ptr[i * n_support],
@@ -599,7 +599,7 @@ py::array_t<double> PySpline::BasisDerivative(py::array_t<double> queries,
   double* queries_ptr = static_cast<double*>(queries.request().ptr);
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
   double* basis_der_ptr = static_cast<double*>(basis_der.request().ptr);
-  auto basis_derivative = [&](int begin, int end, int) {
+  auto basis_derivative = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisDerivative(
           &queries_ptr[i * para_dim_],
@@ -654,7 +654,7 @@ py::tuple PySpline::BasisDerivativeAndSupport(py::array_t<double> queries,
   int* orders_ptr = static_cast<int*>(orders.request().ptr);
   double* basis_der_ptr = static_cast<double*>(basis_der.request().ptr);
   int* support_ptr = static_cast<int*>(support.request().ptr);
-  auto basis_der_support = [&](int begin, int end, int) {
+  auto basis_der_support = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyBasisDerivativeAndSupport(
           &queries_ptr[i * para_dim_],
@@ -707,7 +707,7 @@ PySpline::Proximities(py::array_t<double> queries,
       static_cast<double*>(first_derivatives.request().ptr);
   double* second_derivatives_ptr =
       static_cast<double*>(second_derivatives.request().ptr);
-  auto proximities = [&](int begin, int end, int) {
+  auto proximities = [&](const int begin, const int end, int) {
     for (int i{begin}; i < end; ++i) {
       Core()->SplinepyVerboseProximity(&queries_ptr[i * dim_],
                                        tolerance,


### PR DESCRIPTION
# Overview
The "nthreads.hpp"-file of splinepy has been changed and the inherent files have been adapted as well. Goal was to eliminate the distinction between "Steps" and "Chunks" inside the "nthreads.hpp"-file.
Reference to this topic is this [issue](https://github.com/tataratat/splinepy/discussions/251#discussion-5636315).

## Addressed issues
*  reduced the lamda signature of NThreadExecution to 3 parameters
*  deleted the distinction between Chunks and Steps
*  adapted all the function calls

## Showcase

```
void NThreadExecution(const Func& f, const IndexType& total, IndexType nthread)  {
    // ...
    // f hands over 3 parameters now (instead of 2)
    f(begin, end, thread_index);
    // ...}
```
