### PR TITLE
Feature: leading underscore to module imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 splinepy welcomes and appreciates discussions, issues and pull requests!
 
 ## Quick start
-Once the repo is forked, one possible starting point would be creating a new python environments, for example, using [conda](https://docs.conda.io/en/latest/miniconda.html) with `python=3.9`
+Once the repo is forked, one possible starting point would be creating a new python environments, for example, using [conda](https://docs.conda.io/en/latest/miniconda.html) with `python=3.10`
 ```bash
-conda create -n splinepyenv python=3.9
+conda create -n splinepyenv python=3.10
 conda activate splinepyenv
 git clone git@github.com:<path-to-your-fork>
 cd splinepy  # or <forkname>
@@ -19,6 +19,7 @@ pip install -e. --config-settings=cmake.args=-DSPLINEPY_MORE=OFF --config-settin
 - no complex comphrehensions: preferably fits in a line, 2 lines max if it is totally necessary
 - use first letter abbreviations in element loops:  `for kv in knot_vectors`
 - use `i`, `j`, `k`, `l` for pure index: `for i, kv in enumerate(knot_vectors)`
+- module local import with a leading underscore: `from splinepy import settings as _settings`
 
 ## C++ style / implementation preferences
 For c++, we've prepared a `.clang-format`, with that you can just run `clang-format`. We closely follow naming scheme suggested by [google stype guide](https://google.github.io/styleguide/cppguide.html#Naming), with a clear exception of file naming.

--- a/splinepy/_base.py
+++ b/splinepy/_base.py
@@ -15,5 +15,7 @@ class SplinepyBase:
         super().__init_subclass__(*args, **kwargs)
         cls._logi = _log.prepend_log("<" + cls.__qualname__ + ">", _log.info)
         cls._logd = _log.prepend_log("<" + cls.__qualname__ + ">", _log.debug)
-        cls._logw = _log.prepend_log("<" + cls.__qualname__ + ">", _log.warning)
+        cls._logw = _log.prepend_log(
+            "<" + cls.__qualname__ + ">", _log.warning
+        )
         return super().__new__(cls)

--- a/splinepy/_base.py
+++ b/splinepy/_base.py
@@ -2,7 +2,7 @@
 
 Base type of splinepy
 """
-from splinepy.utils import log
+from splinepy.utils import log as _log
 
 
 class SplinepyBase:
@@ -13,7 +13,7 @@ class SplinepyBase:
         Add logger shortcut.
         """
         super().__init_subclass__(*args, **kwargs)
-        cls._logi = log.prepend_log("<" + cls.__qualname__ + ">", log.info)
-        cls._logd = log.prepend_log("<" + cls.__qualname__ + ">", log.debug)
-        cls._logw = log.prepend_log("<" + cls.__qualname__ + ">", log.warning)
+        cls._logi = _log.prepend_log("<" + cls.__qualname__ + ">", _log.info)
+        cls._logd = _log.prepend_log("<" + cls.__qualname__ + ">", _log.debug)
+        cls._logw = _log.prepend_log("<" + cls.__qualname__ + ">", _log.warning)
         return super().__new__(cls)

--- a/splinepy/bezier.py
+++ b/splinepy/bezier.py
@@ -1,9 +1,11 @@
-import numpy as np
+import numpy as _np
 
-from splinepy import settings, spline, splinepy_core
+from splinepy import settings as _settings
+from splinepy import spline as _spline
+from splinepy import splinepy_core as _splinepy_core
 
 
-class BezierBase(spline.Spline):
+class BezierBase(_spline.Spline):
     r"""Bezier Base. Contains extra operations that are only
     available for bezier families.
 
@@ -68,10 +70,10 @@ class BezierBase(spline.Spline):
             )
 
         # multiply - dimension compatibility is checked in cpp side
-        multiplied = splinepy_core.multiply(self, factor)
+        multiplied = _splinepy_core.multiply(self, factor)
 
         # return corresponding type
-        return settings.NAME_TO_TYPE[multiplied.name](spline=multiplied)
+        return _settings.NAME_TO_TYPE[multiplied.name](spline=multiplied)
 
     def __add__(self, summand):
         """
@@ -92,7 +94,7 @@ class BezierBase(spline.Spline):
           New spline that describes sum
         """
         # same type check, same para dim check, same dim check done in cpp
-        added = splinepy_core.add(self, summand)
+        added = _splinepy_core.add(self, summand)
 
         return type(self)(spline=added)
 
@@ -147,22 +149,22 @@ class BezierBase(spline.Spline):
           internal control points
         """
         # dimension compatibility checked in cpp
-        composed = splinepy_core.compose(self, inner_function)
+        composed = _splinepy_core.compose(self, inner_function)
 
         if compute_sensitivities:
-            composed_sensivities = splinepy_core.compose_sensitivities(
+            composed_sensivities = _splinepy_core.compose_sensitivities(
                 self, inner_function
             )
 
             return (
-                settings.NAME_TO_TYPE[composed.name](spline=composed),
+                _settings.NAME_TO_TYPE[composed.name](spline=composed),
                 [
-                    settings.NAME_TO_TYPE[cc.name](spline=cc)
+                    _settings.NAME_TO_TYPE[cc.name](spline=cc)
                     for cc in composed_sensivities
                 ],
             )
         else:
-            return settings.NAME_TO_TYPE[composed.name](spline=composed)
+            return _settings.NAME_TO_TYPE[composed.name](spline=composed)
 
     def composition_derivative(self, inner, inner_derivative):
         r"""
@@ -196,11 +198,11 @@ class BezierBase(spline.Spline):
         composition_der: BezierBase
         """
         # compatibility check is done in cpp
-        composition_der = splinepy_core.composition_derivative(
+        composition_der = _splinepy_core.composition_derivative(
             self, inner, inner_derivative
         )
 
-        return settings.NAME_TO_TYPE[composition_der.name](
+        return _settings.NAME_TO_TYPE[composition_der.name](
             spline=composition_der
         )
 
@@ -221,7 +223,7 @@ class BezierBase(spline.Spline):
         """
         if max(locations) > 1 or min(locations) < 0:
             raise ValueError("Invalid split location. Should be in (0, 1).")
-        split = splinepy_core.split(self, para_dim, locations)
+        split = _splinepy_core.split(self, para_dim, locations)
 
         return [type(self)(spline=s) for s in split]
 
@@ -240,7 +242,7 @@ class BezierBase(spline.Spline):
         if dim >= self.dim:
             raise ValueError(f"Can't extract ({dim}) dim from {self.whatami}.")
 
-        return type(self)(spline=splinepy_core.extract_dim(self, dim))
+        return type(self)(spline=_splinepy_core.extract_dim(self, dim))
 
 
 class Bezier(BezierBase):
@@ -340,20 +342,20 @@ class Bezier(BezierBase):
 
     @property
     def rationalbezier(self):
-        return settings.NAME_TO_TYPE["RationalBezier"](
-            **self.todict(), weights=np.ones((self.cps.shape[0], 1))
+        return _settings.NAME_TO_TYPE["RationalBezier"](
+            **self.todict(), weights=_np.ones((self.cps.shape[0], 1))
         )
 
     @property
     def bspline(self):
-        return settings.NAME_TO_TYPE["BSpline"](
-            spline=splinepy_core.same_spline_with_knot_vectors(self)
+        return _settings.NAME_TO_TYPE["BSpline"](
+            spline=_splinepy_core.same_spline_with_knot_vectors(self)
         )
 
     @property
     def nurbs(self):
-        return settings.NAME_TO_TYPE["NURBS"](
-            spline=splinepy_core.same_spline_with_knot_vectors(
+        return _settings.NAME_TO_TYPE["NURBS"](
+            spline=_splinepy_core.same_spline_with_knot_vectors(
                 self.rationalbezier
             )
         )

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -164,8 +164,7 @@ class BSplineBase(_spline.Spline):
         """
         if beziers:
             indices, data = _splinepy_core.bezier_extraction_matrix(
-                [kv.numpy() for kv in self.knot_vectors],
-                self.degrees,
+                self,
                 _settings.TOLERANCE,
             )
 
@@ -292,12 +291,8 @@ class BSplineBase(_spline.Spline):
         -------
         extracted Beziers : list
         """
-        # Extract bezier patches and create PyRationalBezier objects
-        patches = _splinepy_core.extract_bezier_patches(self.copy())
-
-        # use core spline based init and name to type conversion to find
-        # correct types
-        return [_settings.NAME_TO_TYPE[p.name](spline=p) for p in patches]
+        # this core call makes copy of self and extracts bezier patches.
+        return _splinepy_core.extract_bezier_patches(self)
 
 
 class BSpline(BSplineBase):

--- a/splinepy/bspline.py
+++ b/splinepy/bspline.py
@@ -1,17 +1,20 @@
-import numpy as np
+import numpy as _np
 
 try:
-    import scipy
+    import scipy as _scipy
 
     has_scipy = True
 except ImportError:
     has_scipy = False
 
 
-from splinepy import settings, spline, splinepy_core, utils
+from splinepy import settings as _settings
+from splinepy import spline as _spline
+from splinepy import splinepy_core as _splinepy_core
+from splinepy import utils as _utils
 
 
-class BSplineBase(spline.Spline):
+class BSplineBase(_spline.Spline):
     r"""BSpline base. Contains extra operations that are only available for
     bspline families, i.e., :class:`.BSpline` and :class:`.NURBS`.
 
@@ -106,8 +109,8 @@ class BSplineBase(spline.Spline):
                 "(Too small)"
             )
 
-        inserted = splinepy_core.insert_knots(
-            self, parametric_dimension, utils.data.enforce_contiguous(knots)
+        inserted = _splinepy_core.insert_knots(
+            self, parametric_dimension, _utils.data.enforce_contiguous(knots)
         )
 
         self._logd(f"Inserted {len(knots)} knot(s).")
@@ -160,9 +163,10 @@ class BSplineBase(spline.Spline):
           insertion for more details
         """
         if beziers:
-            indices, data = splinepy_core.bezier_extraction_matrix(
-                self,
-                settings.TOLERANCE,
+            indices, data = _splinepy_core.bezier_extraction_matrix(
+                [kv.numpy() for kv in self.knot_vectors],
+                self.degrees,
+                _settings.TOLERANCE,
             )
 
             # Indices represents the relevant ctps whereas data is a list of
@@ -171,11 +175,11 @@ class BSplineBase(spline.Spline):
             matrices = []
             for m_data in data:
                 if has_scipy:
-                    matrix = scipy.sparse.csr_matrix(
+                    matrix = _scipy.sparse.csr_matrix(
                         m_data[0], shape=m_data[1]
                     )
                 else:
-                    matrix = np.zeros(m_data[1])
+                    matrix = _np.zeros(m_data[1])
                     matrix[m_data[0][1][0], m_data[0][1][1]] = m_data[0][0]
                 matrices.append(matrix)
             #  2. Create global matrix
@@ -187,17 +191,17 @@ class BSplineBase(spline.Spline):
             matrices = [matrix[ids, :] for ids in indices]
             return matrices
 
-        data = splinepy_core.global_knot_insertion_matrix(
+        data = _splinepy_core.global_knot_insertion_matrix(
             self.knot_vectors,
             self.degrees,
             parametric_dimension,
-            utils.data.enforce_contiguous(knots, dtype="float64"),
-            settings.TOLERANCE,
+            _utils.data.enforce_contiguous(knots, dtype="float64"),
+            _settings.TOLERANCE,
         )
         if has_scipy:
-            matrix = scipy.sparse.csr_matrix(data[0], shape=data[1])
+            matrix = _scipy.sparse.csr_matrix(data[0], shape=data[1])
         else:
-            matrix = np.zeros(data[1])
+            matrix = _np.zeros(data[1])
             matrix[data[0][1][0], data[0][1][1]] = data[0][0]
 
         return matrix
@@ -238,11 +242,11 @@ class BSplineBase(spline.Spline):
                 "(Too small)"
             )
 
-        removed = splinepy_core.remove_knots(
+        removed = _splinepy_core.remove_knots(
             self,
             parametric_dimension,
-            utils.data.enforce_contiguous(knots),
-            tolerance=spline._default_if_none(tolerance, settings.TOLERANCE),
+            _utils.data.enforce_contiguous(knots),
+            tolerance=_spline._default_if_none(tolerance, _settings.TOLERANCE),
         )
 
         if any(removed):
@@ -265,14 +269,14 @@ class BSplineBase(spline.Spline):
         -------
         None
         """
-        if not splinepy_core.has_core(self):
+        if not _splinepy_core.has_core(self):
             raise ValueError(
                 "spline is not fully initialized."
                 "Please, first initialize spline before normalize_knot_vectors."
             )
 
         for kv in self.knot_vectors:
-            if isinstance(kv, splinepy_core.KnotVector):
+            if isinstance(kv, _splinepy_core.KnotVector):
                 kv.scale(0, 1)
 
     def extract_bezier_patches(self):
@@ -288,8 +292,12 @@ class BSplineBase(spline.Spline):
         -------
         extracted Beziers : list
         """
-        # this core call makes copy of self and extracts bezier patches.
-        return splinepy_core.extract_bezier_patches(self)
+        # Extract bezier patches and create PyRationalBezier objects
+        patches = _splinepy_core.extract_bezier_patches(self.copy())
+
+        # use core spline based init and name to type conversion to find
+        # correct types
+        return [_settings.NAME_TO_TYPE[p.name](spline=p) for p in patches]
 
 
 class BSpline(BSplineBase):
@@ -433,12 +441,12 @@ class BSpline(BSplineBase):
         if knot_vector is None:
             knot_vector = []
 
-        query_points = utils.data.enforce_contiguous(
+        query_points = _utils.data.enforce_contiguous(
             query_points, dtype="float64"
         )
 
         fitted = cls(
-            **splinepy_core.interpolate_curve(
+            **_splinepy_core.interpolate_curve(
                 points=query_points,
                 degree=degree,
                 centripetal=centripetal,
@@ -489,11 +497,11 @@ class BSpline(BSplineBase):
         if knot_vector is None:
             knot_vector = []
 
-        query_points = utils.data.enforce_contiguous(
+        query_points = _utils.data.enforce_contiguous(
             query_points, dtype="float64"
         )
 
-        results = splinepy_core.approximate_curve(
+        results = _splinepy_core.approximate_curve(
             points=query_points,
             degree=degree,
             n_control_points=num_control_points,
@@ -544,12 +552,12 @@ class BSpline(BSplineBase):
         --------
         fitted: BSpline
         """
-        query_points = utils.data.enforce_contiguous(
+        query_points = _utils.data.enforce_contiguous(
             query_points, dtype="float64"
         )
 
         fitted = cls(
-            **splinepy_core.interpolate_surface(
+            **_splinepy_core.interpolate_surface(
                 points=query_points,
                 size_u=size_u,
                 size_v=size_v,
@@ -622,12 +630,12 @@ class BSpline(BSplineBase):
             or larger than the number of control points in each dimension."""
             )
 
-        query_points = utils.data.enforce_contiguous(
+        query_points = _utils.data.enforce_contiguous(
             query_points, dtype="float64"
         )
 
         fitted = cls(
-            **splinepy_core.approximate_surface(
+            **_splinepy_core.approximate_surface(
                 points=query_points,
                 num_points_u=num_points_u,
                 num_points_v=num_points_v,
@@ -667,9 +675,9 @@ class BSpline(BSplineBase):
         --------
         same_nurbs: NURBS
         """
-        same_nurbs = settings.NAME_TO_TYPE["NURBS"](
+        same_nurbs = _settings.NAME_TO_TYPE["NURBS"](
             **self.todict(),
-            weights=np.ones(self.control_points.shape[0], dtype=np.float64),
+            weights=_np.ones(self.control_points.shape[0], dtype=_np.float64),
         )
 
         return same_nurbs

--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -1,4 +1,4 @@
-import numpy as np
+import numpy as _np
 
 
 def valid_queries(spline, queries):
@@ -28,10 +28,10 @@ def valid_queries(spline, queries):
         )
 
     # Check minimum value
-    min_query = np.min(queries, axis=0)
-    if np.any(bounds[0, :] > min_query):
-        error_dim = np.where(bounds[1, :] > min_query)[0][0]
-        error_query = np.argmin(queries, axis=0)[error_dim]
+    min_query = _np.min(queries, axis=0)
+    if _np.any(bounds[0, :] > min_query):
+        error_dim = _np.where(bounds[1, :] > min_query)[0][0]
+        error_query = _np.argmin(queries, axis=0)[error_dim]
         raise ValueError(
             f"Query request out of bounds in parametric dimension "
             f"{error_dim}. Detected query {queries[error_query,:]} at "
@@ -40,10 +40,10 @@ def valid_queries(spline, queries):
         )
 
     # Check maximum value
-    max_query = np.max(queries, axis=0)
-    if np.any(bounds[1, :] < max_query):
-        error_dim = np.where(bounds[1, :] < max_query)[0][0]
-        error_query = np.argmax(queries, axis=0)[error_dim]
+    max_query = _np.max(queries, axis=0)
+    if _np.any(bounds[1, :] < max_query):
+        error_dim = _np.where(bounds[1, :] < max_query)[0][0]
+        error_query = _np.argmax(queries, axis=0)[error_dim]
         raise ValueError(
             f"Query request out of bounds in parametric dimension "
             f"{error_dim}. Detected query {queries[error_query,:]} at "

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -448,7 +448,10 @@ def arc(
     if degree:
         start_angle = _np.radians(start_angle)
         angle = _np.radians(angle)
-    start_point = [radius * _np.cos(start_angle), radius * _np.sin(start_angle)]
+    start_point = [
+        radius * _np.cos(start_angle),
+        radius * _np.sin(start_angle),
+    ]
     point_spline = _settings.NAME_TO_TYPE["RationalBezier"](
         degrees=[0], control_points=[start_point], weights=[1.0]
     )

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -1,5 +1,12 @@
 import numpy as _np
-from gustaf import Edges, Faces, Vertices, Volumes as _Edges, _Faces, _Vertices, _Volumes
+from gustaf import (
+    Volumes as _Edges,
+)
+from gustaf import (
+    _Faces,
+    _Vertices,
+    _Volumes,
+)
 from gustaf.utils import connec as _connec
 from gustaf.utils.arr import enforce_len as _enforce_len
 
@@ -517,7 +524,7 @@ class Extractor:
     """
 
     def __init__(self, spl):
-        from splinepy import Multipatch, Spline as _Multipatch, _Spline
+        from splinepy import Multipatch, _Spline
 
         if not isinstance(spl, (_Spline, Multipatch)):
             raise ValueError("Extractor expects a Spline or Multipatch type")

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -1,12 +1,8 @@
 import numpy as _np
-from gustaf import (
-    Volumes as _Edges,
-)
-from gustaf import (
-    _Faces,
-    _Vertices,
-    _Volumes,
-)
+from gustaf import Edges as _Edges
+from gustaf import Faces as _Faces
+from gustaf import Vertices as _Vertices
+from gustaf import Volumes as _Volumes
 from gustaf.utils import connec as _connec
 from gustaf.utils.arr import enforce_len as _enforce_len
 
@@ -524,9 +520,10 @@ class Extractor:
     """
 
     def __init__(self, spl):
-        from splinepy import Multipatch, _Spline
+        from splinepy import Multipatch as _Multipatch
+        from splinepy import Spline as _Spline
 
-        if not isinstance(spl, (_Spline, Multipatch)):
+        if not isinstance(spl, (_Spline, _Multipatch)):
             raise ValueError("Extractor expects a Spline or Multipatch type")
         self._spline = spl
 

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -1,10 +1,10 @@
-import numpy as np
-from gustaf import Edges, Faces, Vertices, Volumes
-from gustaf.utils import connec
-from gustaf.utils.arr import enforce_len
+import numpy as _np
+from gustaf import Edges, Faces, Vertices, Volumes as _Edges, _Faces, _Vertices, _Volumes
+from gustaf.utils import connec as _connec
+from gustaf.utils.arr import enforce_len as _enforce_len
 
-from splinepy import settings
-from splinepy.utils.data import cartesian_product
+from splinepy import settings as _settings
+from splinepy.utils.data import cartesian_product as _cartesian_product
 
 
 def edges(
@@ -27,7 +27,7 @@ def edges(
     --------
     edges: Edges
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     # Check resolution input
     if not isinstance(resolution, int):
@@ -35,23 +35,23 @@ def edges(
 
     if spline.para_dim == 1:
         vertices = spline.sample(resolution)
-        e = connec.range_to_edges(
+        e = _connec.range_to_edges(
             (0, resolution),
             closed=False,
         )
-        if isinstance(spline, Multipatch):
-            e = np.vstack(
+        if isinstance(spline, _Multipatch):
+            e = _np.vstack(
                 [e + i * resolution for i in range(len(spline.patches))]
             )
-        return Edges(
+        return _Edges(
             vertices=vertices,
             edges=e,
         )
 
     else:
         # recursion for Multipatch splines
-        if isinstance(spline, Multipatch):
-            return Edges.concat(
+        if isinstance(spline, _Multipatch):
+            return _Edges.concat(
                 [
                     edges(spline=s, resolution=resolution, all_knots=all_knots)
                     for s in spline.patches
@@ -68,7 +68,7 @@ def edges(
         for i in range(spline.para_dim):
             split_knots = relevant_knots.copy()
             split_knots.pop(i)
-            n_knot_lines = np.prod([len(s) for s in split_knots], dtype=int)
+            n_knot_lines = _np.prod([len(s) for s in split_knots], dtype=int)
             # Create query points
             # Sampling along a line can be done using cartesian product,
             # however, to preserve the correct order we need to permute the
@@ -80,22 +80,22 @@ def edges(
             reorder_mask = (
                 [*range(1, i + 1)] + [0] + [*range(1 + i, spline.para_dim)]
             )
-            extract_knot_queries = cartesian_product(
-                [np.linspace(*spline.parametric_bounds[:, i], resolution)]
+            extract_knot_queries = _cartesian_product(
+                [_np.linspace(*spline.parametric_bounds[:, i], resolution)]
                 + split_knots,
                 reverse=True,
             )[:, reorder_mask]
 
             # Retrieve connectivity to be repeated
-            single_line_connectivity = connec.range_to_edges(
+            single_line_connectivity = _connec.range_to_edges(
                 (0, resolution),
                 closed=False,
             )
 
             temp_edges.append(
-                Edges(
+                _Edges(
                     vertices=spline.evaluate(extract_knot_queries),
-                    edges=np.vstack(
+                    edges=_np.vstack(
                         [
                             single_line_connectivity + resolution * j
                             for j in range(n_knot_lines)
@@ -104,7 +104,7 @@ def edges(
                 )
             )
 
-        return Edges.concat(temp_edges)
+        return _Edges.concat(temp_edges)
 
 
 def faces(
@@ -130,41 +130,41 @@ def faces(
     --------
     faces: faces
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     if spline.para_dim == 2:
-        if isinstance(spline, Multipatch):
+        if isinstance(spline, _Multipatch):
             n_faces = (resolution - 1) ** spline.para_dim
             vertices = resolution**spline.para_dim
-            f_loc = connec.make_quad_faces(
-                enforce_len(resolution, spline.para_dim)
+            f_loc = _connec.make_quad_faces(
+                _enforce_len(resolution, spline.para_dim)
             )
-            face_connectivity = np.empty((n_faces * len(spline.patches), 4))
+            face_connectivity = _np.empty((n_faces * len(spline.patches), 4))
             # Create Connectivity for Multipatches
             for i in range(len(spline.patches)):
                 face_connectivity[i * n_faces : (i + 1) * n_faces] = f_loc + (
                     i * vertices
                 )
         else:
-            face_connectivity = connec.make_quad_faces(
-                enforce_len(resolution, spline.para_dim)
+            face_connectivity = _connec.make_quad_faces(
+                _enforce_len(resolution, spline.para_dim)
             )
-        faces = Faces(
+        faces = _Faces(
             vertices=spline.sample(resolution),
             faces=face_connectivity,
         )
 
     elif spline.para_dim == 3:
         # Extract boundaries and sample from boundaries
-        if isinstance(spline, Multipatch):
+        if isinstance(spline, _Multipatch):
             boundaries = spline.boundary_multipatch()
         else:
-            boundaries = Multipatch(splines=spline.extract.boundaries())
+            boundaries = _Multipatch(splines=spline.extract.boundaries())
 
         n_faces = (resolution - 1) ** 2
         vertices = resolution**2
-        f_loc = connec.make_quad_faces(enforce_len(resolution, 2))
-        face_connectivity = np.empty((n_faces * len(boundaries.patches), 4))
+        f_loc = _connec.make_quad_faces(_enforce_len(resolution, 2))
+        face_connectivity = _np.empty((n_faces * len(boundaries.patches), 4))
 
         # Create Connectivity for Multipatches
         for i in range(len(boundaries.patches)):
@@ -173,7 +173,7 @@ def faces(
             )
 
         # make faces and merge vertices before returning
-        faces = Faces(
+        faces = _Faces(
             vertices=boundaries.sample(resolution), faces=face_connectivity
         )
 
@@ -202,7 +202,7 @@ def volumes(spline, resolution, watertight=False):
     --------
     volumes: Volumes
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     if spline.para_dim != 3 or spline.dim != 3:
         raise ValueError(
@@ -210,16 +210,16 @@ def volumes(spline, resolution, watertight=False):
             "para_dim: 3 dim: 3 splines."
         )
 
-    if isinstance(spline, Multipatch):
+    if isinstance(spline, _Multipatch):
         if not isinstance(resolution, int):
             raise ValueError(
                 "Resolution for sampling must be integer type for Multipatch "
                 "objects"
             )
-        p_connect = connec.make_hexa_volumes(enforce_len(resolution, 3))
+        p_connect = _connec.make_hexa_volumes(_enforce_len(resolution, 3))
         n_elements_per_patch = p_connect.shape[0]
         n_vertices_per_patch = resolution**spline.para_dim
-        connectivity = np.empty(
+        connectivity = _np.empty(
             (n_elements_per_patch * len(spline.patches), p_connect.shape[1])
         )
 
@@ -231,10 +231,10 @@ def volumes(spline, resolution, watertight=False):
             )
             connectivity[ids] = p_connect + i * n_vertices_per_patch
     else:
-        connectivity = connec.make_hexa_volumes(enforce_len(resolution, 3))
+        connectivity = _connec.make_hexa_volumes(_enforce_len(resolution, 3))
 
     # Create volumes
-    volumes = Volumes(
+    volumes = _Volumes(
         vertices=spline.sample(resolution),
         volumes=connectivity,
     )
@@ -257,7 +257,7 @@ def control_points(spline):
     --------
     cps_as_Vertices: Vertices
     """
-    return Vertices(spline.control_points)
+    return _Vertices(spline.control_points)
 
 
 def control_edges(spline):
@@ -271,18 +271,18 @@ def control_edges(spline):
     --------
     edges: Edges
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     if spline.para_dim != 1:
         raise ValueError("Invalid spline type!")
 
-    if isinstance(spline, Multipatch):
+    if isinstance(spline, _Multipatch):
         # @todo avoid loop and transfer range_to_edges to cpp
-        return Edges.concat([control_edges(s) for s in spline.patches])
+        return _Edges.concat([control_edges(s) for s in spline.patches])
     else:
-        return Edges(
+        return _Edges(
             vertices=spline.control_points,
-            edges=connec.range_to_edges(
+            edges=_connec.range_to_edges(
                 len(spline.control_points), closed=False
             ),
         )
@@ -299,18 +299,18 @@ def control_faces(spline):
     --------
     faces: Faces
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     if spline.para_dim != 2:
         raise ValueError("Invalid spline type!")
 
-    if isinstance(spline, Multipatch):
+    if isinstance(spline, _Multipatch):
         # @todo avoid loop and transfer range_to_edges to cpp
-        return Faces.concat([control_faces(s) for s in spline.patches])
+        return _Faces.concat([control_faces(s) for s in spline.patches])
     else:
-        return Faces(
+        return _Faces(
             vertices=spline.control_points,
-            faces=connec.make_quad_faces(spline.control_mesh_resolutions),
+            faces=_connec.make_quad_faces(spline.control_mesh_resolutions),
         )
 
 
@@ -325,18 +325,18 @@ def control_volumes(spline):
     --------
     volumes: Volumes
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     if spline.para_dim != 3:
         raise ValueError("Invalid spline type!")
 
-    if isinstance(spline, Multipatch):
+    if isinstance(spline, _Multipatch):
         # @todo avoid loop and transfer range_to_edges to cpp
-        return Volumes.concat([control_volumes(s) for s in spline.patches])
+        return _Volumes.concat([control_volumes(s) for s in spline.patches])
     else:
-        return Volumes(
+        return _Volumes(
             vertices=spline.control_points,
-            volumes=connec.make_hexa_volumes(spline.control_mesh_resolutions),
+            volumes=_connec.make_hexa_volumes(spline.control_mesh_resolutions),
         )
 
 
@@ -379,10 +379,10 @@ def spline(spline, para_dim, split_plane):
     -------
     spline
     """
-    from splinepy.spline import Spline
+    from splinepy.spline import Spline as _Spline
 
     # Check type
-    if not isinstance(spline, Spline):
+    if not isinstance(spline, _Spline):
         raise TypeError("Unknown spline representation passed to sub spline")
 
     # Check arguments for sanity
@@ -424,15 +424,15 @@ def spline(spline, para_dim, split_plane):
     # Start extraction
     cps_res = spline_copy.control_mesh_resolutions
     # start and end id. indices correspond to [first dim][first appearance]
-    start_id = np.where(
+    start_id = _np.where(
         abs(spline_copy.knot_vectors[para_dim].numpy() - split_plane[0])
-        < settings.TOLERANCE
+        < _settings.TOLERANCE
     )[0][0]
-    end_id = np.where(
+    end_id = _np.where(
         abs(spline_copy.knot_vectors[para_dim].numpy() - split_plane[-1])
-        < settings.TOLERANCE
+        < _settings.TOLERANCE
     )[0][0]
-    para_dim_ids = np.arange(np.prod(cps_res))
+    para_dim_ids = _np.arange(_np.prod(cps_res))
     for i_pd in range(para_dim):
         para_dim_ids -= para_dim_ids % cps_res[i_pd]
         para_dim_ids = para_dim_ids // cps_res[i_pd]
@@ -460,7 +460,7 @@ def spline(spline, para_dim, split_plane):
                 (end_id + spline_copy.degrees[para_dim] - 1)
             ]
 
-            spline_info["knot_vectors"][para_dim] = np.concatenate(
+            spline_info["knot_vectors"][para_dim] = _np.concatenate(
                 ([start_knot], knots_in_between, [end_knot])
             )
 
@@ -493,17 +493,17 @@ def boundaries(spline, boundary_ids=None):
     boundary_spline: type(self)
         boundary spline, which has one less para_dim
     """
-    from splinepy import Multipatch
-    from splinepy import splinepy_core as core
+    from splinepy import Multipatch as _Multipatch
+    from splinepy import splinepy_core as _core
 
     # Pass to respective c++ implementation
-    if isinstance(spline, Multipatch):
+    if isinstance(spline, _Multipatch):
         return spline.boundary_multipatch()
     else:
         bids = [] if boundary_ids is None else list(boundary_ids)
         return [
             type(spline)(spline=c)
-            for c in core.extract_boundaries(spline, bids)
+            for c in _core.extract_boundaries(spline, bids)
         ]
 
 
@@ -517,9 +517,9 @@ class Extractor:
     """
 
     def __init__(self, spl):
-        from splinepy import Multipatch, Spline
+        from splinepy import Multipatch, Spline as _Multipatch, _Spline
 
-        if not isinstance(spl, (Spline, Multipatch)):
+        if not isinstance(spl, (_Spline, Multipatch)):
             raise ValueError("Extractor expects a Spline or Multipatch type")
         self._spline = spl
 

--- a/splinepy/helpme/ffd.py
+++ b/splinepy/helpme/ffd.py
@@ -2,12 +2,12 @@
 
 Freeform Deformation!
 """
-import gustaf as gus
+import gustaf as _gus
 
-from splinepy import settings
-from splinepy._base import SplinepyBase
-from splinepy.helpme.create import from_bounds
-from splinepy.spline import Spline
+from splinepy import settings as _settings
+from splinepy._base import SplinepyBase as _SplinepyBase
+from splinepy.helpme.create import from_bounds as _from_bounds
+from splinepy.spline import Spline as _Spline
 
 
 def _rescaled_vertices(vertices, scale, offset):
@@ -18,7 +18,7 @@ def _spline_para_dim_and_mesh_dim_matches(spline, mesh):
     return spline.para_dim == mesh.vertices.shape[1]
 
 
-class FFD(SplinepyBase):
+class FFD(_SplinepyBase):
     """
     Free-form deformation is a method used to deform an object by a
     deformation function. In our case the object is given via a mesh, the
@@ -64,7 +64,7 @@ class FFD(SplinepyBase):
 
         # use setters for attr
         if padding is None:
-            self.padding = settings.TOLERANCE
+            self.padding = _settings.TOLERANCE
         if mesh is not None:
             self.mesh = mesh
         if spline is not None:
@@ -121,7 +121,7 @@ class FFD(SplinepyBase):
             return None
 
         # type check
-        if not isinstance(mesh, gus.Vertices):
+        if not isinstance(mesh, _gus.Vertices):
             raise TypeError("mesh should be an instance of gus.Vertices")
 
         # warn and erase existing spline if dimension doesn't match
@@ -143,7 +143,7 @@ class FFD(SplinepyBase):
             par_dim = mesh.vertices.shape[1]
             # try to expand bounds same ratio as
             bounds = mesh.bounds().copy()
-            self.spline = from_bounds([[0] * par_dim, [1] * par_dim], bounds)
+            self.spline = _from_bounds([[0] * par_dim, [1] * par_dim], bounds)
             self._logd("created default spline")
 
         self._logd("Setting mesh.")
@@ -208,7 +208,7 @@ class FFD(SplinepyBase):
             self._spline = None
             return None
 
-        if not isinstance(spline, Spline):
+        if not isinstance(spline, _Spline):
             raise TypeError(
                 "spline should be an instance of splinepy.Spline class"
             )
@@ -252,7 +252,7 @@ class FFD(SplinepyBase):
         if padding < 0:
             raise ValueError("Padding should be a positive number.")
 
-        if padding < settings.TOLERANCE:
+        if padding < _settings.TOLERANCE:
             raise ValueError(
                 "Padding is too small - "
                 "should be bigger than the tolerance ({settings.TOLERANCE})."
@@ -307,7 +307,7 @@ class FFD(SplinepyBase):
         if return_gustaf or return_showable:
             return things_to_show
 
-        return gus.show(
+        return _gus.show(
             ["Original Mesh", things_to_show["original_mesh"]],
             [
                 "Spline and Mesh",
@@ -335,7 +335,7 @@ class FFD(SplinepyBase):
         # let's show faces at most, since volumes can take awhile
         mesh = self._mesh
         if mesh.kind == "volume":
-            mesh = gus.Faces(
+            mesh = _gus.Faces(
                 mesh.const_vertices,
                 mesh.faces()[mesh.single_faces()],
                 copy=False,

--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -1,6 +1,6 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.utils.data import cartesian_product
+from splinepy.utils.data import cartesian_product as _cartesian_product
 
 
 def volume(spline, orders=None):
@@ -26,10 +26,10 @@ def volume(spline, orders=None):
     volume : float
       Integral of dim-dimensional object
     """
-    from splinepy.spline import Spline
+    from splinepy.spline import Spline as _Spline
 
-    # Check input type
-    if not isinstance(spline, Spline):
+    # Check i_nput type
+    if not isinstance(spline, _Spline):
         raise NotImplementedError("Extrude only works for splines")
 
     # Determine integration points
@@ -53,9 +53,9 @@ def volume(spline, orders=None):
             )
 
         # Gauss-Legendre is exact for polynomials 2*n-1
-        quad_orders = np.ceil((expected_degree + 1) * 0.5).astype("int")
+        quad_orders = _np.ceil((expected_degree + 1) * 0.5).astype("int")
     else:
-        quad_orders = np.ascontiguousarray(orders, dtype=int).flatten()
+        quad_orders = _np.ascontiguousarray(orders, dtype=int).flatten()
         if quad_orders.size != spline.para_dim:
             raise ValueError(
                 "Integration order must be array of size para_dim"
@@ -63,25 +63,25 @@ def volume(spline, orders=None):
 
     for order in quad_orders:
         # Get legendre quadratuer points
-        pos, ws = np.polynomial.legendre.leggauss(order)
+        pos, ws = _np.polynomial.legendre.leggauss(order)
         # from (-1,1) to (0,1)
         positions.append(pos * 0.5 + 0.5)
         weights.append(ws * 0.5)
 
     # summarize integration points
-    positions = cartesian_product(positions)
-    weights = cartesian_product(weights).prod(axis=1)
+    positions = _cartesian_product(positions)
+    weights = _cartesian_product(weights).prod(axis=1)
 
     # Calculate Volume
     if spline.has_knot_vectors:
-        volume = np.sum(
+        volume = _np.sum(
             [
-                np.sum(np.linalg.det(b.jacobian(positions)) * weights)
+                _np.sum(_np.linalg.det(b.jacobian(positions)) * weights)
                 for b in spline.extract.beziers()
             ]
         )
     else:
-        volume = np.sum(np.linalg.det(spline.jacobian(positions)) * weights)
+        volume = _np.sum(_np.linalg.det(spline.jacobian(positions)) * weights)
     return volume
 
 

--- a/splinepy/helpme/multi_index.py
+++ b/splinepy/helpme/multi_index.py
@@ -1,7 +1,7 @@
 """
 Helps you find control point ids.
 """
-import numpy as np
+import numpy as _np
 
 
 class MultiIndex:
@@ -21,14 +21,14 @@ class MultiIndex:
         ----------
         grid_resolutions: array-like
         """
-        if not isinstance(grid_resolutions, (tuple, list, np.ndarray)):
+        if not isinstance(grid_resolutions, (tuple, list, _np.ndarray)):
             raise TypeError(
                 "grid_resolutions must be array-like type, not"
                 f"{type(grid_resolutions)}"
             )
 
         # create raveled indices
-        raveled = np.arange(np.prod(grid_resolutions), dtype="int32")
+        raveled = _np.arange(_np.prod(grid_resolutions), dtype="int32")
 
         # to allow general __getitem__ like query, turn them into
         # grid's shape

--- a/splinepy/helpme/permute.py
+++ b/splinepy/helpme/permute.py
@@ -1,6 +1,6 @@
-import numpy as np
+import numpy as _np
 
-from splinepy import utils
+from splinepy import utils as _utils
 
 
 def parametric_axes(spline, permutation_list, inplace=True):
@@ -34,7 +34,7 @@ def parametric_axes(spline, permutation_list, inplace=True):
     if not set(range(spline.para_dim)) == set(permutation_list):
         raise ValueError("Permutation list invalid")
 
-    utils.log.debug("Permuting parametric axes...")
+    _utils.log.debug("Permuting parametric axes...")
 
     # Update knot_vectors where applicable
     if "knot_vectors" in spline.required_properties:
@@ -56,32 +56,32 @@ def parametric_axes(spline, permutation_list, inplace=True):
 
     # Map global to local index
     # i_glob = i + n_i * j  + n_i * n_j * k ...
-    local_indices = np.empty([n_ctps, spline.para_dim], dtype=int)
-    global_indices = np.arange(n_ctps, dtype=int)
+    local_indices = _np.empty([n_ctps, spline.para_dim], dtype=int)
+    global_indices = _np.arange(n_ctps, dtype=int)
     for i_p in range(spline.para_dim):
         local_indices[:, i_p] = global_indices % ctps_dims[i_p]
         global_indices -= local_indices[:, i_p]
-        global_indices = np.floor_divide(global_indices, ctps_dims[i_p])
+        global_indices = _np.floor_divide(global_indices, ctps_dims[i_p])
 
     # Reorder indices
     local_indices[:] = local_indices[:, permutation_list]
 
     # Rearange global to local
-    global_indices = np.matmul(
-        local_indices, np.cumprod([1] + new_ctps_dims)[0:-1]
+    global_indices = _np.matmul(
+        local_indices, _np.cumprod([1] + new_ctps_dims)[0:-1]
     )
     # Get inverse mapping
-    global_indices = np.argsort(global_indices)
+    global_indices = _np.argsort(global_indices)
     if "weights" in spline.required_properties:
         dict_spline["weights"] = spline.weights[global_indices]
     dict_spline["control_points"] = spline.control_points[global_indices, :]
 
     if inplace:
-        utils.log.debug("  applying permutation inplace")
+        _utils.log.debug("  applying permutation inplace")
         spline._new_core(**dict_spline)
 
         return None
 
     else:
-        utils.log.debug("  returning permuted spline")
+        _utils.log.debug("  returning permuted spline")
         return type(spline)(**dict_spline)

--- a/splinepy/helpme/visualize.py
+++ b/splinepy/helpme/visualize.py
@@ -1,87 +1,87 @@
-import gustaf as gus
-import numpy as np
-from gustaf import Vertices
-from gustaf.helpers import options
-from gustaf.utils.arr import enforce_len
+import gustaf as _gus
+import numpy as _np
+from gustaf import Vertices as _Vertices
+from gustaf.helpers import options as _options
+from gustaf.utils.arr import enforce_len as _enforce_len
 
-from splinepy import settings
-from splinepy.utils import log
+from splinepy import settings as _settings
+from splinepy.utils import log as _log
 
 _vedo_spline_common_options = (
-    options.Option("vedo", "knots", "Show spline's knots.", (bool,)),
-    options.Option("vedo", "knot_c", "Knot color.", (str, tuple, list, int)),
-    options.Option(
+    _options.Option("vedo", "knots", "Show spline's knots.", (bool,)),
+    _options.Option("vedo", "knot_c", "Knot color.", (str, tuple, list, int)),
+    _options.Option(
         "vedo",
         "knot_lw",
         "Line width of knots. Number of pixels. "
         "Applicable to para_dim > 1.",
         (int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "knot_alpha",
         "Transparency of knots in range [0, 1]. Applicable to para_dim > 1",
         (float, int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_points",
         "Show spline's control points."
         "Options propagates to control mesh, unless it is specified.",
         (bool,),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_point_r",
         "Control point radius",
         (float, int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_point_c",
         "Color of control_points in {rgb, RGB, str of (hex, name), int}",
         (str, tuple, list, int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_point_alpha",
         "Transparency of control points in range [0, 1].",
         (float, int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_point_ids",
         "Show ids of control_points.",
         (bool,),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_mesh",
         "Show spline's control mesh.",
         (bool,),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_mesh_c",
         "Color of control_mesh in {rgb, RGB, str of (hex, name), int}",
         (str, tuple, list, int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "control_mesh_lw",
         "Line width of control mesh. Number of pixels",
         (int),
     ),
-    options.Option(
+    _options.Option(
         "vedo",
         "resolutions",
         "Sampling resolution for spline.",
-        (int, list, tuple, np.ndarray),
+        (int, list, tuple, _np.ndarray),
     ),
 )
 
 
-class SplineShowOption(options.ShowOption):
+class SplineShowOption(_options.ShowOption):
     """
     Show options for splines.
     """
@@ -90,20 +90,20 @@ class SplineShowOption(options.ShowOption):
 
     # if we start to support more backends, most of this options should become
     # some sort of spline common.
-    _valid_options = options.make_valid_options(
-        *options.vedo_common_options,
+    _valid_options = _options.make_valid_options(
+        *_options.vedo_common_options,
         *_vedo_spline_common_options,
-        options.Option(
+        _options.Option(
             "vedo",
             "fitting_queries",
             "Shows fitting queries if they are locally saved in splines.",
             (bool,),
         ),
-        options.Option(
+        _options.Option(
             "vedo",
             "arrow_data_on",
             "Specify parametric coordinates to place arrow_data.",
-            (list, tuple, np.ndarray),
+            (list, tuple, _np.ndarray),
         ),
     )
 
@@ -123,11 +123,11 @@ class SplineShowOption(options.ShowOption):
                 f"Given helpee is {type(helpee)}.",
             )
         self._options = {}
-        self._backend = gus.settings.VISUALIZATION_BACKEND
+        self._backend = _gus.settings.VISUALIZATION_BACKEND
         self._options[self._backend] = {}
 
 
-class MultipatchShowOption(options.ShowOption):
+class MultipatchShowOption(_options.ShowOption):
     """
     Show options for Multipatches.
     """
@@ -136,8 +136,8 @@ class MultipatchShowOption(options.ShowOption):
 
     # if we start to support more backends, most of this options should become
     # some sort of spline common.
-    _valid_options = options.make_valid_options(
-        *options.vedo_common_options,
+    _valid_options = _options.make_valid_options(
+        *_options.vedo_common_options,
         *_vedo_spline_common_options,
     )
 
@@ -157,7 +157,7 @@ class MultipatchShowOption(options.ShowOption):
                 f"Given helpee is {type(helpee)}.",
             )
         self._options = {}
-        self._backend = gus.settings.VISUALIZATION_BACKEND
+        self._backend = _gus.settings.VISUALIZATION_BACKEND
         self._options[self._backend] = {}
 
 
@@ -173,18 +173,18 @@ def _sample_knots_1d(spline):
 
     def sample_uks(s):
         """samples unique knots from single patch spline"""
-        return s.evaluate(np.asanyarray(s.unique_knots[0]).reshape(-1, 1))
+        return s.evaluate(_np.asanyarray(s.unique_knots[0]).reshape(-1, 1))
 
     # sample unique knots in physical space and create vertices
     # for multi-patch, we will call this function for its patches
     if spline.name.startswith("Multi"):
-        evaluated_knots = np.vstack([sample_uks(p) for p in spline.patches])
+        evaluated_knots = _np.vstack([sample_uks(p) for p in spline.patches])
     else:
         evaluated_knots = sample_uks(spline)
 
     # create vertices - for multipatch, we could remove duplicating vertices
     # it gets annoying
-    knots = Vertices(evaluated_knots)
+    knots = _Vertices(evaluated_knots)
 
     # apply show options to show this vertices as 'x'
     knots.show_options["labels"] = ["x"] * len(knots.vertices)
@@ -379,8 +379,8 @@ def _sample_arrow_data(spline, adata_name, sampled_spline, res):
                 )
             # tolerance padding. may still cause issues in splinepy.
             # in that case, we will have to scale queries.
-            lb_diff = queries.min(axis=0) - bounds[0] + settings.TOLERANCE
-            ub_diff = queries.max(axis=0) - bounds[1] - settings.TOLERANCE
+            lb_diff = queries.min(axis=0) - bounds[0] + _settings.TOLERANCE
+            ub_diff = queries.max(axis=0) - bounds[1] - _settings.TOLERANCE
             if any(lb_diff < 0) or any(ub_diff > 0):
                 raise ValueError(
                     f"Given locations for ({adata_name}) are outside the "
@@ -391,7 +391,7 @@ def _sample_arrow_data(spline, adata_name, sampled_spline, res):
         adata = spline.spline_data.as_arrow(adata_name, on=on)
 
         # create vertices that can be shown as arrows
-        loc_vertices = Vertices(spline.evaluate(queries), copy=False)
+        loc_vertices = _Vertices(spline.evaluate(queries), copy=False)
         loc_vertices.vertex_data[adata_name] = adata
 
         # transfer options
@@ -421,7 +421,7 @@ def _create_control_point_ids(spline):
     """
     # a bit redundant, but nicely separable
     cp_ids = spline.extract.control_points()
-    cp_ids.show_options["labels"] = np.arange(len(cp_ids.vertices))
+    cp_ids.show_options["labels"] = _np.arange(len(cp_ids.vertices))
     cp_ids.show_options["label_options"] = {"font": "VTK"}
 
     return cp_ids
@@ -450,7 +450,7 @@ def _create_fitting_queries(spline):
     Create fitting queries. This will raise if spline is not BSpline or
     fitting queries does not exist.
     """
-    fqs = Vertices(spline._fitting_queries)
+    fqs = _Vertices(spline._fitting_queries)
     fqs.show_options["c"] = "blue"
     fqs.show_options["r"] = 10
     return fqs
@@ -495,7 +495,7 @@ def _vedo_showable(spline):
         spline,
         spline.show_options.get("arrow_data", None),
         sampled_spline,
-        enforce_len(res, spline.para_dim),
+        _enforce_len(res, spline.para_dim),
     )
     if arrow_data is not None:
         sampled_gus["arrow_data"] = arrow_data
@@ -575,7 +575,7 @@ def show(spline, **kwargs):
             try:
                 spline.show_options[key] = value
             except BaseException:
-                log.debug(
+                _log.debug(
                     f"Skipping invalid option {key} for "
                     f"{spline.show_options._helps}."
                 )
@@ -602,10 +602,10 @@ def show(spline, **kwargs):
     if para_space:
         things_to_show.pop("parametric_spline")
 
-        return gus.show(
+        return _gus.show(
             ["Parametric Space", p_spline],
             ["Physical Space", *things_to_show.values()],
             **kwargs,
         )
 
-    return gus.show(things_to_show, **kwargs)
+    return _gus.show(things_to_show, **kwargs)

--- a/splinepy/io/cats.py
+++ b/splinepy/io/cats.py
@@ -10,7 +10,7 @@ import numpy as _np
 
 from splinepy.io import ioutils as _ioutils
 from splinepy.utils.log import debug as _debug
-from splinepy.utils.log import warning as _warning 
+from splinepy.utils.log import warning as _warning
 
 # List of spline keywords (bundled here in case they change - many unused)
 CATS_XML_KEY_WORDS = {

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -10,6 +10,7 @@ from splinepy.utils.data import enforce_contiguous as _enforce_contiguous
 from splinepy.utils.log import debug as _debug
 from splinepy.utils.log import warning as _warning
 
+
 def _spline_to_ET(
     root,
     multipatch,
@@ -230,7 +231,7 @@ def export(
     """
     from splinepy import Multipatch as _Multipatch
     from splinepy.settings import NTHREADS as _NTHREADS
-    from splinepy.settings import TOLERANCE as _TOLERANCE 
+    from splinepy.settings import TOLERANCE as _TOLERANCE
     from splinepy.spline import Spline as _Spline
     from splinepy.splinepy_core import orientations as _orientations
 
@@ -264,7 +265,9 @@ def export(
     multipatch_element = _ET.SubElement(
         xml_data, "MultiPatch", id=str(0), parDim=str(multipatch.para_dim)
     )
-    patch_range = _ET.SubElement(multipatch_element, "patches", type="id_range")
+    patch_range = _ET.SubElement(
+        multipatch_element, "patches", type="id_range"
+    )
     patch_range.text = (
         f"{index_offset} " f"{len(multipatch.patches) - 1 + index_offset}"
     )
@@ -570,7 +573,9 @@ def load(fname, load_options=True):
             if patch_element is None:
                 _debug("Unsupported format")
             if patch_element.attrib.get("type") != "id_range":
-                _debug(f"Invalid patch type {patch_element.attrib.get('type')}")
+                _debug(
+                    f"Invalid patch type {patch_element.attrib.get('type')}"
+                )
             patch_range = _matrix_from_node(patch_element).astype(_np.int64)
             offset = patch_range[0]
             n_splines = patch_range[1] - patch_range[0] + 1

--- a/splinepy/io/iges.py
+++ b/splinepy/io/iges.py
@@ -1,8 +1,7 @@
 """
 iges io.
 """
-from splinepy import splinepy_core
-from splinepy.utils import log
+from splinepy import splinepy_core as _splinepy_core
 
 
 def load(fname):
@@ -18,7 +17,7 @@ def load(fname):
     splines: list
       Spline Type defined in NAME_TO_TYPE
     """
-    return splinepy_core.read_iges(fname)
+    return _splinepy_core.read_iges(fname)
 
 
 def export(fname, splines):
@@ -35,31 +34,4 @@ def export(fname, splines):
     --------
     None
     """
-    try:
-        return splinepy_core.export_iges(fname, splines)
-
-    except RuntimeError:
-        # create empty valid spline array
-        valid_splines = []
-        # check if any spline contains volume elements
-        for ispl, spline in enumerate(splines):
-            if spline.para_dim > 2:
-                log.warning(
-                    f"Skipping volumetric {type(spline)} at splines[{ispl}]"
-                    "which cannot be handled by the .iges file format \n"
-                    "To include this spline, use a boundary representation "
-                    "instead, by calling e.g. spline.extract.boundaries()"
-                )
-            elif spline.dim > 3:
-                log.warning(
-                    f"Skipping high dim {type(spline)} at splines[{ispl}]"
-                    "which cannot be handled by the .iges file format."
-                    "iges supports up to dim=3."
-                )
-            else:
-                valid_splines.append(spline)
-
-        if len(valid_splines) == 0:
-            raise ValueError("No valid splines found in the given input")
-
-        return splinepy_core.export_iges(fname, valid_splines)
+    return _splinepy_core.export_iges(fname, splines)

--- a/splinepy/io/ioutils.py
+++ b/splinepy/io/ioutils.py
@@ -2,7 +2,7 @@
 io utils.
 """
 
-import os
+import os as _os
 
 
 def make_meaningful(line, comment="#"):
@@ -87,14 +87,14 @@ def abs_fname(fname):
     abs_fname: str
       Maybe same to fname, maybe not.
     """
-    if os.path.isabs(fname):
+    if _os.path.isabs(fname):
         pass
 
     elif "~" in fname:
-        fname = os.path.expanduser(fname)
+        fname = _os.path.expanduser(fname)
 
     else:
-        fname = os.path.abspath(fname)
+        fname = _os.path.abspath(fname)
 
     return fname
 
@@ -115,13 +115,13 @@ def expand_tabs(fname, overwrite=True, tab_expand=2):
     -------
     None
     """
-    import os.path as op
+    import os.path as _op
 
     # Safe guard in case an absolute path is handed to the function
     if overwrite:
         out_name = fname
     else:
-        dir, file = op.split(fname)
+        dir, file = _op.split(fname)
         out_name = dir + "copy_" + file
 
     with open(fname) as inputFile:
@@ -144,8 +144,8 @@ def dict_to_spline(spline_dictionary):
     spline_lits : list
       List of splines in called format (NAME_TO_TYPE)
     """
-    from splinepy.settings import NAME_TO_TYPE
-    from splinepy.spline import Spline
+    from splinepy.settings import NAME_TO_TYPE as _NAME_TO_TYPE
+    from splinepy.spline import Spline as _Spline
 
-    spline_list = [Spline(**spd) for spd in spline_dictionary]
-    return [NAME_TO_TYPE[spl.name](spline=spl) for spl in spline_list]
+    spline_list = [_Spline(**spd) for spd in spline_dictionary]
+    return [_NAME_TO_TYPE[spl.name](spline=spl) for spl in spline_list]

--- a/splinepy/io/irit.py
+++ b/splinepy/io/irit.py
@@ -1,11 +1,11 @@
 """
 irit io.
 """
-import re
+import re as _re
 
-import numpy as np
+import numpy as _np
 
-from splinepy.io import ioutils
+from splinepy.io import ioutils as _ioutils
 
 # Keywords that indicate new spline (irit is case insensitive, all lower case)
 SPLINE_KEY_WORD_REGEX = r"\s+(bspline|bezier)\s+"
@@ -33,7 +33,7 @@ def load(fname, expand_tabs=True, strip_comments=False):
     """
     # Expand taps to spaces
     if expand_tabs:
-        ioutils.expand_tabs(fname)
+        _ioutils.expand_tabs(fname)
 
     # Delete lines not containing brackets in the beginning
     def extract_relevant_text(lines):
@@ -42,7 +42,7 @@ def load(fname, expand_tabs=True, strip_comments=False):
                 [
                     line.lower().strip()
                     for line in lines
-                    if re.match(r".*[\[\]].*", line) is not None
+                    if _re.match(r".*[\[\]].*", line) is not None
                 ]
             )
         else:
@@ -55,7 +55,7 @@ def load(fname, expand_tabs=True, strip_comments=False):
 
         # At this point we ignore all non-spline related data and do a keyword
         # based search for relevant information
-        spline_strings = re.split(SPLINE_KEY_WORD_REGEX, relevant_text)
+        spline_strings = _re.split(SPLINE_KEY_WORD_REGEX, relevant_text)
 
         # Init list
         spline_list = []
@@ -66,10 +66,10 @@ def load(fname, expand_tabs=True, strip_comments=False):
             spline = {}
 
             # Extract data from data
-            extracted_data = re.split(r"\]\s*\]", data)[0] + "]"
+            extracted_data = _re.split(r"\]\s*\]", data)[0] + "]"
 
             # Split dimensions and degrees from data
-            dim_and_deg = re.split(r"(e\d|p\d)", extracted_data)
+            dim_and_deg = _re.split(r"(e\d|p\d)", extracted_data)
 
             # must contain ctps/degs rational/poly dimension control points
             if len(dim_and_deg) != 3:
@@ -87,35 +87,35 @@ def load(fname, expand_tabs=True, strip_comments=False):
 
             # Extract degrees (and control point dimensions)
             deg_info = [
-                int(s) for s in re.split(r"\s+", dim_and_deg[0]) if len(s) > 0
+                int(s) for s in _re.split(r"\s+", dim_and_deg[0]) if len(s) > 0
             ]
 
             # IRIT uses orders instead of degrees
             if type == "bezier":
-                orders = np.array(deg_info)
-                n_ctps = np.prod(orders)
+                orders = _np.array(deg_info)
+                n_ctps = _np.prod(orders)
             else:
-                n_ctps = np.prod(deg_info[: (len(deg_info) // 2)])
-                orders = np.array(deg_info[(len(deg_info) // 2) :])
+                n_ctps = _np.prod(deg_info[: (len(deg_info) // 2)])
+                orders = _np.array(deg_info[(len(deg_info) // 2) :])
             spline["degrees"] = orders - 1
 
             # Paradim is specified from degrees
             para_dim = orders.size
 
             # Extract control point and kv information
-            ctps_and_kvs = re.findall(r"\[(.*?)\]", dim_and_deg[2])
+            ctps_and_kvs = _re.findall(r"\[(.*?)\]", dim_and_deg[2])
             ctps = " ".join(
-                [s for s in ctps_and_kvs if re.search(r"\s*kv.*", s) is None]
+                [s for s in ctps_and_kvs if _re.search(r"\s*kv.*", s) is None]
             )
 
             if is_rational:
-                ctps = np.fromstring(str(ctps), dtype=float, sep=" ").reshape(
+                ctps = _np.fromstring(str(ctps), dtype=float, sep=" ").reshape(
                     -1, dim + 1
                 )
                 spline["weights"] = ctps[:, 0]
                 spline["control_points"] = ctps[:, 1:] / ctps[:, 0:1]
             else:
-                spline["control_points"] = np.fromstring(
+                spline["control_points"] = _np.fromstring(
                     str(ctps), dtype=float, sep=" "
                 ).reshape(-1, dim)
 
@@ -138,7 +138,7 @@ def load(fname, expand_tabs=True, strip_comments=False):
                 knot_v_strings = [
                     s.split("kv")[1]
                     for s in ctps_and_kvs
-                    if re.search(r"\s*kv.*", s) is not None
+                    if _re.search(r"\s*kv.*", s) is not None
                 ]
                 if len(knot_v_strings) != para_dim:
                     raise ValueError(
@@ -152,14 +152,14 @@ def load(fname, expand_tabs=True, strip_comments=False):
                         + str(len(knot_v_strings))
                     )
                 spline["knot_vectors"] = [
-                    np.fromstring(kv, dtype=float, sep=" ")
+                    _np.fromstring(kv, dtype=float, sep=" ")
                     for kv in knot_v_strings
                 ]
 
             # Append dictionary to list
             spline_list.append(spline)
 
-        return ioutils.dict_to_spline(spline_list)
+        return _ioutils.dict_to_spline(spline_list)
 
 
 def export(fname, splines):
@@ -175,14 +175,14 @@ def export(fname, splines):
     --------
     None
     """
-    from splinepy.bezier import BezierBase
-    from splinepy.bspline import BSplineBase
-    from splinepy.multipatch import Multipatch
-    from splinepy.spline import Spline
+    from splinepy.bezier import BezierBase as _BezierBase
+    from splinepy.bspline import BSplineBase as _BSplineBase
+    from splinepy.multipatch import Multipatch as _Multipatch
+    from splinepy.spline import Spline as _Spline
 
-    if isinstance(splines, Multipatch):
+    if isinstance(splines, _Multipatch):
         splines = splines.patches
-    elif isinstance(splines, Spline):
+    elif isinstance(splines, _Spline):
         splines = [splines]
 
     # Start Export
@@ -198,10 +198,10 @@ def export(fname, splines):
             # Paradim key
             f.write(PARA_DIM_KEYS.get(str(spline.para_dim), "MULTIVAR"))
             # Type identifier
-            if isinstance(spline, BezierBase):
+            if isinstance(spline, _BezierBase):
                 f.write(" BEZIER ")
             # Write orders or/and control point mesh resolutions
-            if isinstance(spline, BSplineBase):
+            if isinstance(spline, _BSplineBase):
                 f.write(" BSPLINE ")
                 f.write(
                     " ".join(
@@ -222,7 +222,7 @@ def export(fname, splines):
                 f.write(" E" + str(spline.dim) + "\n")
 
             # Write knot vectors where required
-            if isinstance(spline, BSplineBase):
+            if isinstance(spline, _BSplineBase):
                 for kv in spline.knot_vectors:
                     f.write(
                         "    [KV " + " ".join([str(k) for k in kv]) + "]\n"
@@ -230,7 +230,7 @@ def export(fname, splines):
 
             # Determine weighted control points
             if spline.is_rational:
-                control_points = np.hstack(
+                control_points = _np.hstack(
                     (
                         spline.weights.reshape(-1, 1),
                         spline.weights.reshape(-1, 1) * spline.control_points,

--- a/splinepy/io/json.py
+++ b/splinepy/io/json.py
@@ -2,13 +2,13 @@
 Export splines in custom json format
 """
 
-import base64
-import json
+import base64 as _base64
+import json as _json
 
-import numpy as np
+import numpy as _np
 
-from splinepy import settings
-from splinepy.utils.log import debug
+from splinepy import settings as _settings
+from splinepy.utils.log import debug as _debug
 
 
 def load(fname):
@@ -24,11 +24,11 @@ def load(fname):
     spline_list: list
     """
     # Make Required Properties locally accessible
-    from splinepy.spline import RequiredProperties
+    from splinepy.spline import RequiredProperties as _RequiredProperties
 
     # Import data from file into dict format
     with open(fname) as f:
-        jsonbz = json.load(f)
+        jsonbz = _json.load(f)
 
     spline_list = []
     base64encoding = jsonbz["Base64Encoding"]
@@ -36,26 +36,26 @@ def load(fname):
     for jbz in jsonbz["SplineList"]:
         # Convert Base64 str into np array
         if base64encoding:
-            jbz["control_points"] = np.frombuffer(
-                base64.b64decode(jbz["control_points"].encode("ascii")),
-                dtype=np.float64,
+            jbz["control_points"] = _np.frombuffer(
+                _base64.b64decode(jbz["control_points"].encode("ascii")),
+                dtype=_np.float64,
             ).reshape((-1, jbz["dim"]))
             if jbz.get("weights") is not None:
-                jbz["weights"] = np.frombuffer(
-                    base64.b64decode(jbz["weights"].encode("ascii")),
-                    dtype=np.float64,
+                jbz["weights"] = _np.frombuffer(
+                    _base64.b64decode(jbz["weights"].encode("ascii")),
+                    dtype=_np.float64,
                 ).reshape((-1, 1))
 
         # Declare Type and get required properties
-        req_props = RequiredProperties.of(jbz["SplineType"])
+        req_props = _RequiredProperties.of(jbz["SplineType"])
         data_dict = {}
         for prop in req_props:
             data_dict[prop] = jbz[prop]
         spline_list.append(
-            settings.NAME_TO_TYPE[jbz["SplineType"]](**data_dict)
+            _settings.NAME_TO_TYPE[jbz["SplineType"]](**data_dict)
         )
 
-    debug("Imported " + str(len(spline_list)) + " splines from file.")
+    _debug("Imported " + str(len(spline_list)) + " splines from file.")
 
     return spline_list
 
@@ -100,11 +100,11 @@ def export(fname, spline_list, list_name=None, base64encoding=False):
     }
 
     # Append all splines to a dictionary
-    from splinepy.spline import Spline
+    from splinepy.spline import Spline as _Spline
 
     spline_dictonary_list = []
     for i_spline in spline_list:
-        if not issubclass(type(i_spline), Spline):
+        if not issubclass(type(i_spline), _Spline):
             raise ValueError("Unsupported type in list")
 
         # Create Dictionary
@@ -116,17 +116,17 @@ def export(fname, spline_list, list_name=None, base64encoding=False):
         spline_dictonary_list.append(i_spline_dict)
 
         if base64encoding:
-            i_spline_dict["control_points"] = base64.b64encode(
-                np.array(i_spline_dict["control_points"])
+            i_spline_dict["control_points"] = _base64.b64encode(
+                _np.array(i_spline_dict["control_points"])
             ).decode("utf-8")
             if "weights" in i_spline.required_properties:
-                i_spline_dict["weights"] = base64.b64encode(
-                    np.array(i_spline_dict["weights"])
+                i_spline_dict["weights"] = _base64.b64encode(
+                    _np.array(i_spline_dict["weights"])
                 ).decode("utf-8")
 
     output_dict["SplineList"] = spline_dictonary_list
 
     with open(fname, "w") as file_pointer:
-        file_pointer.write(json.dumps(output_dict, indent=4))
+        file_pointer.write(_json.dumps(output_dict, indent=4))
 
     return output_dict

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -3,16 +3,14 @@
 Currently hardcoded for 2D-single-patch-splines.
 """
 
-import gustaf as gus
-import numpy as np
+import gustaf as _gus
+import numpy as _np
 
-# single function imports
-from splinepy.io.ioutils import (
-    dict_to_spline,
-    form_lines,
-    make_meaningful,
-    next_line,
-)
+from splinepy.io.ioutils import dict_to_spline as _dict_to_spline
+from splinepy.io.ioutils import form_lines as _form_lines
+from splinepy.io.ioutils import make_meaningful as _make_meaningful
+from splinepy.io.ioutils import next_line as _next_line
+
 
 # keywords : possible assert value
 _mfem_meaningful_keywords = {
@@ -45,9 +43,9 @@ def load(fname):
     nurbs: dict
       dict ready to be used for init.
     """
-    from copy import deepcopy
+    from copy import deepcopy as _deepcopy
 
-    mk = deepcopy(_mfem_meaningful_keywords)
+    mk = _deepcopy(_mfem_meaningful_keywords)
     # they follow a strict order or keywords, so just gather those in order
     # Ordering is a hotkey because control points comes right after
     hotkeys = [
@@ -59,7 +57,7 @@ def load(fname):
     collect = False
     with open(fname) as f:
         for single_line in f:
-            line = make_meaningful(single_line)
+            line = _make_meaningful(single_line)
             if not line:
                 continue
 
@@ -69,7 +67,7 @@ def load(fname):
 
             elif len(keyword_hit) == 1 and keyword_hit[0] in hotkeys:
                 collect = True
-                current_key = deepcopy(keyword_hit[0])
+                current_key = _deepcopy(keyword_hit[0])
                 continue
 
             elif len(keyword_hit) == 1 and keyword_hit[0] not in hotkeys:
@@ -117,11 +115,11 @@ def load(fname):
     mfem_dict_spline = {
         "degrees": degrees,
         "knot_vectors": knot_vectors,
-        "control_points": np.ascontiguousarray(control_points),
-        "weights": np.ascontiguousarray(weights),
+        "control_points": _np.ascontiguousarray(control_points),
+        "weights": _np.ascontiguousarray(weights),
     }
 
-    spline = dict_to_spline([mfem_dict_spline])[0]
+    spline = _dict_to_spline([mfem_dict_spline])[0]
 
     _, reorder = dof_mapping(spline)
 
@@ -150,7 +148,7 @@ def read_solution(
 
     with open(fname) as f:
         hotkey = "Ordering"
-        line = next_line(f)
+        line = _next_line(f)
         solution = []
         collect = False
         while line is not None:
@@ -159,18 +157,18 @@ def read_solution(
             elif hotkey in line:
                 collect = True
 
-            line = next_line(f)
+            line = _next_line(f)
 
     if len(reference_nurbs.control_points) != len(solution):
         raise ValueError("Solution length does not match reference nurbs")
 
     mfem_dict_spline = reference_nurbs.todict()
 
-    spline = dict_to_spline([mfem_dict_spline])[0]
+    spline = _dict_to_spline([mfem_dict_spline])[0]
 
     _, reorder = dof_mapping(spline)
 
-    spline.cps = np.ascontiguousarray(solution)[reorder]
+    spline.cps = _np.ascontiguousarray(solution)[reorder]
     spline.ws[:] = spline.ws[reorder]
 
     return spline
@@ -203,7 +201,7 @@ def _mfem_dof_map_2d(spline):
     to_m.extend(edges)
     to_m.extend(internal)
 
-    return to_m, np.argsort(to_m).tolist()
+    return to_m, _np.argsort(to_m).tolist()
 
 
 def _mfem_dof_map_3d(spline):
@@ -256,7 +254,7 @@ def _mfem_dof_map_3d(spline):
     to_m.extend(faces)
     to_m.extend(internal)
 
-    return to_m, np.argsort(to_m).tolist()
+    return to_m, _np.argsort(to_m).tolist()
 
 
 def dof_mapping(spline):
@@ -302,13 +300,13 @@ def export_cartesian(
     -------
     None
     """
-    from splinepy import Multipatch
+    from splinepy import Multipatch as _Multipatch
 
     # Check first spline
-    if not isinstance(spline_list, (list, Multipatch)):
+    if not isinstance(spline_list, (list, _Multipatch)):
         raise ValueError("export_cartesian expects list for export.")
     if isinstance(spline_list, list):
-        spline_list = Multipatch(splines=spline_list)
+        spline_list = _Multipatch(splines=spline_list)
 
     # Set Tolerance
     if tolerance is None:
@@ -332,7 +330,7 @@ def export_cartesian(
 
         def _corner_vertex_ids(spline):
             cmr = spline.control_mesh_resolutions
-            return np.array(
+            return _np.array(
                 [
                     0,
                     cmr[0] - 1,
@@ -343,9 +341,9 @@ def export_cartesian(
             )
 
         # Face enumeration is different from splinepy's
-        sub_element_vertices = np.array([[0, 1], [1, 2], [3, 2], [0, 3]])
+        sub_element_vertices = _np.array([[0, 1], [1, 2], [3, 2], [0, 3]])
         # splinepy's face 3 corresponds to mfem's face 0
-        splinepy_face_id_2_mfem_face_id = np.array([3, 1, 0, 2])
+        splinepy_face_id_2_mfem_face_id = _np.array([3, 1, 0, 2])
 
     elif para_dim == 3:
         geometry_type = 5
@@ -355,7 +353,7 @@ def export_cartesian(
 
         def _corner_vertex_ids(spline):
             cmr = spline.control_mesh_resolutions
-            return np.array(
+            return _np.array(
                 [
                     0,
                     cmr[0] - 1,
@@ -369,7 +367,7 @@ def export_cartesian(
                 dtype="int32",
             )
 
-        sub_element_vertices = np.array(
+        sub_element_vertices = _np.array(
             [
                 [0, 1, 2, 3],
                 [1, 2, 6, 5],
@@ -379,10 +377,10 @@ def export_cartesian(
                 [4, 5, 6, 7],
             ]
         )
-        splinepy_face_id_2_mfem_face_id = np.array([3, 1, 4, 2, 0, 5])
+        splinepy_face_id_2_mfem_face_id = _np.array([3, 1, 4, 2, 0, 5])
 
     # Create a list of all corner vertices ordered by spline patch number
-    corner_vertices = np.vstack(
+    corner_vertices = _np.vstack(
         [
             spline.cps[_corner_vertex_ids(spline), :]
             for spline in spline_list.patches
@@ -392,15 +390,15 @@ def export_cartesian(
     # Retrieve information using bezman
     connectivity = spline_list.interfaces
 
-    (_, _, inverse_numeration, _) = gus.utils.arr.close_rows(
+    (_, _, inverse_numeration, _) = _gus.utils.arr.close_rows(
         corner_vertices, tolerance, return_intersection=False
     )
     vertex_ids = inverse_numeration.reshape(-1, n_vertex_per_element)
     # Get boundaries from interfaces
-    boundary_elements, boundary_faces = np.where(connectivity < 0)
+    boundary_elements, boundary_faces = _np.where(connectivity < 0)
     boundary_ids = -connectivity[boundary_elements, boundary_faces]
     # Convert from splinepy enumeration to mfem enumeration
-    boundaries = np.take_along_axis(
+    boundaries = _np.take_along_axis(
         vertex_ids[boundary_elements, :],
         sub_element_vertices[splinepy_face_id_2_mfem_face_id[boundary_faces]],
         axis=1,
@@ -442,7 +440,7 @@ def export_cartesian(
         f.write(f"\n\nedges\n{0}\n")
 
         # Write Number Of vertices
-        f.write(f"\nvertices\n{int(np.max(vertex_ids)+1)}\n\n")
+        f.write(f"\nvertices\n{int(_np.max(vertex_ids)+1)}\n\n")
 
         # Export Splines
         f.write("patches\n\n")
@@ -528,7 +526,7 @@ def export(fname, nurbs, precision=10):
     else:
         nurbs = nurbs.nurbs  # turns it into nurbs
 
-    intro_sec = form_lines(
+    intro_sec = _form_lines(
         "MFEM NURBS mesh v1.0",
         "",
         "#",
@@ -543,21 +541,21 @@ def export(fname, nurbs, precision=10):
         "",
     )
 
-    dimension_sec = form_lines(
+    dimension_sec = _form_lines(
         "dimension",
         str(nurbs.para_dim),
         "",
     )
 
     if nurbs.para_dim == 2:
-        elements_sec = form_lines(
+        elements_sec = _form_lines(
             "elements",
             "1",
             "1 3 0 1 2 3",
             "",
         )
 
-        boundary_sec = form_lines(
+        boundary_sec = _form_lines(
             "boundary",
             "4",
             "1 1 0 1",
@@ -567,7 +565,7 @@ def export(fname, nurbs, precision=10):
             "",
         )
 
-        edges_sec = form_lines(
+        edges_sec = _form_lines(
             "edges",
             "4",
             "0 0 1",
@@ -577,7 +575,7 @@ def export(fname, nurbs, precision=10):
             "",
         )
 
-        vertices_sec = form_lines(
+        vertices_sec = _form_lines(
             "vertices",
             "4",
             "",
@@ -603,13 +601,13 @@ def export(fname, nurbs, precision=10):
 
         # This is reusable
         def kv_sec(spline):
-            kvs = form_lines(
+            kvs = _form_lines(
                 "knotvectors",
                 str(len(spline.knot_vectors)),
             )
             kvs2 = ""
             for i in range(spline.para_dim):
-                kvs2 += form_lines(
+                kvs2 += _form_lines(
                     str(spline.degrees[i])
                     + " "
                     + str(cnr[i])
@@ -631,7 +629,7 @@ def export(fname, nurbs, precision=10):
     # disregard inverse
     reorder_ids, _ = dof_mapping(nurbs)
 
-    with np.printoptions(
+    with _np.printoptions(
         formatter={"float_kind": lambda x: f"{x:.{precision}f}"}
     ):
         # weights - string operation
@@ -650,7 +648,7 @@ def export(fname, nurbs, precision=10):
         cps_sec = cps_sec.replace("\n", "")  # remove \n
         cps_sec = cps_sec.replace("]", "\n")  # replace ] with \n
 
-    fe_space_sec = form_lines(
+    fe_space_sec = _form_lines(
         "FiniteElementSpace",
         "FiniteElementCollection: NURBS" + str(nurbs.degrees[0]),
         "VDim: " + str(nurbs.dim),

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -11,7 +11,6 @@ from splinepy.io.ioutils import form_lines as _form_lines
 from splinepy.io.ioutils import make_meaningful as _make_meaningful
 from splinepy.io.ioutils import next_line as _next_line
 
-
 # keywords : possible assert value
 _mfem_meaningful_keywords = {
     "MFEM NURBS mesh v1.0": "intro",

--- a/splinepy/io/npz.py
+++ b/splinepy/io/npz.py
@@ -8,9 +8,10 @@ keys in raw files are:
   - whatami : (1,) np.ndarray, str
 """
 
-import numpy as np
+import numpy as _np
 
-from splinepy import io, splinepy_core
+from splinepy import io as _io
+from splinepy import splinepy_core as _splinepy_core
 
 
 def load(
@@ -27,7 +28,7 @@ def load(
     --------
     list_spline: list of NURBS / BSpline / Bezier / Rational Bezier
     """
-    loaded = np.load(fname)
+    loaded = _np.load(fname)
 
     # Initialize an empty list to store the splines
     list_of_spline_dicts = []
@@ -55,7 +56,7 @@ def load(
         # Append dictionary of spline to the list
         list_of_spline_dicts.append(dict_spline)
 
-    return io.ioutils.dict_to_spline(list_of_spline_dicts)
+    return _io.ioutils.dict_to_spline(list_of_spline_dicts)
 
 
 def export(fname, list_of_splines):
@@ -74,7 +75,7 @@ def export(fname, list_of_splines):
 
     # Checking for proper type of input
     if not isinstance(list_of_splines, list):
-        if isinstance(list_of_splines, splinepy_core.PySpline):
+        if isinstance(list_of_splines, _splinepy_core.PySpline):
             list_of_splines = [list_of_splines]
         else:
             raise TypeError("Only a list of splines or a spline can be saved.")
@@ -106,7 +107,7 @@ def export(fname, list_of_splines):
                 ] = spline.knot_vectors[j]
 
     # Save the dictionary as `.npz`
-    np.savez(
+    _np.savez(
         fname,
         **property_dicts,
     )

--- a/splinepy/io/vtk.py
+++ b/splinepy/io/vtk.py
@@ -4,7 +4,7 @@ This one samples and exports a vtk compatible geometries.
 Requires sample resolutions.
 Doesn't load.
 """
-from splinepy import splinepy_core
+from splinepy import splinepy_core as _splinepy_core
 
 
 def export(fname, splines, resolutions_per_spline):
@@ -22,4 +22,4 @@ def export(fname, splines, resolutions_per_spline):
     --------
     None
     """
-    return splinepy_core.export_vtk(fname, splines, resolutions_per_spline)
+    return _splinepy_core.export_vtk(fname, splines, resolutions_per_spline)

--- a/splinepy/load.py
+++ b/splinepy/load.py
@@ -3,12 +3,13 @@
 Single function file containing `load_splines`.
 """
 
-import os
+import os as _os
 
-from splinepy import io
-from splinepy.io.ioutils import abs_fname, dict_to_spline
-from splinepy.nurbs import NURBS
-from splinepy.splinepy_core import read_iges
+from splinepy import io as _io
+from splinepy.io.ioutils import abs_fname as _abs_fname
+from splinepy.io.ioutils import dict_to_spline as _dict_to_spline
+from splinepy.nurbs import NURBS as _NURBS
+from splinepy.splinepy_core import read_iges as _read_iges
 
 
 def load_splines(fname, as_dict=False):
@@ -32,26 +33,26 @@ def load_splines(fname, as_dict=False):
     splines: list of BSpline/NURBS or dict
     """
     fname = str(fname)
-    fname = abs_fname(fname)
+    fname = _abs_fname(fname)
 
-    ext = os.path.splitext(fname)[1]
+    ext = _os.path.splitext(fname)[1]
 
     if ext in {".iges", ".igs"}:
-        loaded_splines = read_iges(fname)
+        loaded_splines = _read_iges(fname)
 
     elif ext == ".itd":
-        loaded_splines = io.load.irit(fname)
+        loaded_splines = _io.load.irit(fname)
 
     elif ext == ".npz":
         # it should only have one spline, but
         # put it in a list to keep output format consistent
-        loaded_splines = [io.npz.load(fname)]
+        loaded_splines = [_io.npz.load(fname)]
 
     elif ext == ".mesh":
-        loaded_splines = [io.mfem.load(fname)]
+        loaded_splines = [_io.mfem.load(fname)]
 
     elif ext == ".json":
-        json_load_raw = io.json.load(fname)
+        json_load_raw = _io.json.load(fname)
         # json load returns splines organized by their types in dict
         # pretty neat. but for now, let's keep the format consistent
         loaded_splines = []
@@ -70,7 +71,7 @@ def load_splines(fname, as_dict=False):
         return loaded_splines
 
     # turn dicts into real splines
-    splines = dict_to_spline(loaded_splines)
+    splines = _dict_to_spline(loaded_splines)
 
     return splines
 
@@ -90,12 +91,12 @@ def load_solution(fname, reference_spline):
     solution_spline: Spline
     """
     fname = str(fname)
-    fname = abs_fname(fname)
+    fname = _abs_fname(fname)
 
-    ext = os.path.splitext(fname)[1]
+    ext = _os.path.splitext(fname)[1]
 
     if ext == ".gf":
-        return NURBS(**io.mfem.read_solution(fname, reference_spline))
+        return _NURBS(**_io.mfem.read_solution(fname, reference_spline))
 
     else:
         raise NotImplementedError("We can only import < .gf >  solution files")

--- a/splinepy/microstructure/microstructure.py
+++ b/splinepy/microstructure/microstructure.py
@@ -1,14 +1,14 @@
-import gustaf as gus
-import numpy as np
+import gustaf as _gus
+import numpy as _np
 
-from splinepy._base import SplinepyBase
-from splinepy.bspline import BSpline
-from splinepy.multipatch import Multipatch
-from splinepy.splinepy_core import PySpline
-from splinepy.utils.data import cartesian_product
+from splinepy._base import SplinepyBase as _SplinepyBase
+from splinepy.bspline import BSpline as _BSpline
+from splinepy.multipatch import Multipatch as _Multipatch
+from splinepy.splinepy_core import PySpline as _PySpline
+from splinepy.utils.data import cartesian_product as _cartesian_product
 
 
-class Microstructure(SplinepyBase):
+class Microstructure(_SplinepyBase):
     """Helper class to facilitatae the construction of microstructures."""
 
     def __init__(
@@ -77,7 +77,7 @@ class Microstructure(SplinepyBase):
         None
         """
 
-        if not isinstance(deformation_function, PySpline):
+        if not isinstance(deformation_function, _PySpline):
             raise ValueError(
                 "Deformation function must be splinepy-Spline."
                 " e.g. splinepy.NURBS"
@@ -154,7 +154,7 @@ class Microstructure(SplinepyBase):
         None
         """
         # place single tiles into a list to provide common interface
-        if isinstance(microtile, (PySpline, list)):
+        if isinstance(microtile, (_PySpline, list)):
             microtile = self._make_microtilable(microtile)
         # Assign Microtile object to member variable
         self._microtile = microtile
@@ -285,10 +285,10 @@ class Microstructure(SplinepyBase):
                     self.tiling[i_pd] = n_current_spans
                 else:
                     # Determine new knots
-                    n_k_span = np.zeros(n_current_spans, dtype=int)
-                    span_measure = np.diff(ukv)
+                    n_k_span = _np.zeros(n_current_spans, dtype=int)
+                    span_measure = _np.diff(ukv)
                     for _ in range(tt - n_current_spans):
-                        add_knot = np.argmax(span_measure)
+                        add_knot = _np.argmax(span_measure)
                         n_k_span[add_knot] += 1
                         span_measure[add_knot] *= n_k_span[add_knot] / (
                             n_k_span[add_knot] + 1
@@ -297,7 +297,7 @@ class Microstructure(SplinepyBase):
                     new_knots = []
                     for i, nks in enumerate(n_k_span):
                         new_knots.extend(
-                            np.linspace(ukv[i], ukv[i + 1], nks + 2)[1:-1]
+                            _np.linspace(ukv[i], ukv[i + 1], nks + 2)[1:-1]
                         )
                     additional_knots.append(new_knots)
 
@@ -370,10 +370,10 @@ class Microstructure(SplinepyBase):
         # Second step (if MS is parametrized)
         if is_parametrized:
             para_bounds = self.deformation_function.parametric_bounds.T
-            def_fun_para_space = BSpline(
+            def_fun_para_space = _BSpline(
                 degrees=[1] * self.deformation_function.para_dim,
                 knot_vectors=para_bounds.repeat(2, 1),
-                control_points=cartesian_product(para_bounds),
+                control_points=_cartesian_product(para_bounds),
             )
             for i_pd in range(deformation_function_copy.para_dim):
                 if len(deformation_function_copy.unique_knots[i_pd][1:-1]) > 0:
@@ -502,8 +502,8 @@ class Microstructure(SplinepyBase):
         )
 
         # Use element_resolutions to get global indices of patches
-        local_indices = cartesian_product(
-            [np.arange(er) for er in element_resolutions]
+        local_indices = _cartesian_product(
+            [_np.arange(er) for er in element_resolutions]
         )
 
         # Determine the number of geometric derivatives with respect to the
@@ -556,11 +556,11 @@ class Microstructure(SplinepyBase):
                 # To avoid unnecessary constructions (if a parameter
                 # sensitivity evaluates to zero), perform only those that are
                 # in the support of a specific design variable
-                support = np.where(
-                    np.any(np.any(tile_sensitivities != 0.0, axis=0), axis=0)
+                support = _np.where(
+                    _np.any(_np.any(tile_sensitivities != 0.0, axis=0), axis=0)
                 )[0]
-                anti_support = np.where(
-                    np.any(np.all(tile_sensitivities == 0.0, axis=0), axis=0)
+                anti_support = _np.where(
+                    _np.any(_np.all(tile_sensitivities == 0.0, axis=0), axis=0)
                 )[0]
                 tile_sens_on_support = tile_sensitivities[:, :, support]
             else:
@@ -626,7 +626,7 @@ class Microstructure(SplinepyBase):
                     # derivatives of the composed spline with respect to a
                     # component of a control point within the bezier patch
                     # of the deformation function.
-                    cps = np.hstack([p.cps for p in patch_info])
+                    cps = _np.hstack([p.cps for p in patch_info])
                     # We use the matrices to map the contributions of the
                     # bezier ctps to the deformation functions
                     mapped_cps = cps @ knot_insertion_matrices[i_patch]
@@ -634,7 +634,7 @@ class Microstructure(SplinepyBase):
                     # Last step: create beziers to be added to the derivative
                     # fields
                     for j_cc in range(n_macro_sensitivities):
-                        control_points = np.zeros(
+                        control_points = _np.zeros(
                             (cps.shape[0], self._deformation_function.dim)
                         )
                         ii_ctps, jj_dim = divmod(
@@ -650,7 +650,7 @@ class Microstructure(SplinepyBase):
                         )
 
         # Use a multipatch object to bundle all information
-        self._microstructure = Multipatch(splines=spline_list_ms)
+        self._microstructure = _Multipatch(splines=spline_list_ms)
 
         # Add fields if requested
         if macro_sensitivities or parameter_sensitivities:
@@ -689,7 +689,7 @@ class Microstructure(SplinepyBase):
         deformation_function = self.deformation_function
 
         # Show in vedo
-        return gus.show(
+        return _gus.show(
             ["Deformation Function", deformation_function],
             ["Microtile", microtile[0]],
             ["Composed Microstructure", microstructure],
@@ -763,7 +763,7 @@ class Microstructure(SplinepyBase):
         result = self._parametrization_function(
             self._microtile.evaluation_points
         )
-        if not isinstance(result, np.ndarray):
+        if not isinstance(result, _np.ndarray):
             raise ValueError(
                 "Function outline of parametrization function must be "
                 "`f(np.ndarray)->np.ndarray`"
@@ -776,7 +776,7 @@ class Microstructure(SplinepyBase):
         result = self.parameter_sensitivity_function(
             self._microtile.evaluation_points
         )
-        if (not isinstance(result, np.ndarray)) or (not result.ndim == 3):
+        if (not isinstance(result, _np.ndarray)) or (not result.ndim == 3):
             raise ValueError(
                 "Function outline of parameter sensitivity function must "
                 "be `f(np.ndarray)->np.ndarray`, with dimension 3 and shape:"
@@ -798,7 +798,7 @@ class Microstructure(SplinepyBase):
         return _UserTile(microtile)
 
 
-class _UserTile(SplinepyBase):
+class _UserTile(_SplinepyBase):
     def __init__(self, microtile):
         """
         On the fly created class of a user tile
@@ -813,7 +813,7 @@ class _UserTile(SplinepyBase):
             microtile = [microtile]
 
         for m in microtile:
-            if not isinstance(m, PySpline):
+            if not isinstance(m, _PySpline):
                 raise ValueError(
                     "Microtiles must be (list of) "
                     "splinepy-Splines. e.g. splinepy.NURBS"

--- a/splinepy/microstructure/tiles/armadillo.py
+++ b/splinepy/microstructure/tiles/armadillo.py
@@ -1,13 +1,13 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class Armadillo(TileBase):
+class Armadillo(_TileBase):
     def __init__(self):
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5, 0.5],
             ]
@@ -57,8 +57,8 @@ class Armadillo(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -71,7 +71,7 @@ class Armadillo(TileBase):
                 "Derivatives are not implemented for this tile yet"
             )
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -86,7 +86,7 @@ class Armadillo(TileBase):
 
         if closure == "x_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -131,7 +131,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -176,7 +176,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -221,7 +221,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -266,7 +266,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -311,7 +311,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_zero,
@@ -356,7 +356,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -401,7 +401,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -446,7 +446,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -491,7 +491,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -536,7 +536,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -581,7 +581,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -626,7 +626,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -671,7 +671,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -716,7 +716,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -761,7 +761,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_one_half - v_half_contact_length,
@@ -806,7 +806,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -851,7 +851,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -898,7 +898,7 @@ class Armadillo(TileBase):
 
         elif closure == "x_max":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -943,7 +943,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -988,7 +988,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -1033,7 +1033,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -1078,7 +1078,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -1123,7 +1123,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_zero,
@@ -1168,7 +1168,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -1213,7 +1213,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -1258,7 +1258,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -1303,7 +1303,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -1348,7 +1348,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -1393,7 +1393,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -1438,7 +1438,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -1483,7 +1483,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -1528,7 +1528,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -1573,7 +1573,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_one_half - v_half_contact_length,
@@ -1618,7 +1618,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -1663,7 +1663,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -1710,7 +1710,7 @@ class Armadillo(TileBase):
 
         elif closure == "y_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -1755,7 +1755,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -1800,7 +1800,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -1845,7 +1845,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -1890,7 +1890,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -1935,7 +1935,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_zero,
@@ -1980,7 +1980,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_one,
@@ -2025,7 +2025,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -2070,7 +2070,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -2115,7 +2115,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -2160,7 +2160,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -2205,7 +2205,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -2250,7 +2250,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -2295,7 +2295,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -2340,7 +2340,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -2385,7 +2385,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_one_half - v_half_contact_length,
@@ -2430,7 +2430,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -2475,7 +2475,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -2523,7 +2523,7 @@ class Armadillo(TileBase):
         elif closure == "y_max":
             # set points:
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -2568,7 +2568,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -2613,7 +2613,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -2658,7 +2658,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -2703,7 +2703,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -2748,7 +2748,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_zero,
@@ -2793,7 +2793,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -2838,7 +2838,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -2883,7 +2883,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -2928,7 +2928,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -2973,7 +2973,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_one,
@@ -3018,7 +3018,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_one,
@@ -3063,7 +3063,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -3108,7 +3108,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -3153,7 +3153,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -3198,7 +3198,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_one_half - v_half_contact_length,
@@ -3243,7 +3243,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -3288,7 +3288,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -3335,7 +3335,7 @@ class Armadillo(TileBase):
 
         elif closure == "z_max":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -3380,7 +3380,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -3425,7 +3425,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -3470,7 +3470,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -3515,7 +3515,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -3560,7 +3560,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_zero,
@@ -3605,7 +3605,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -3650,7 +3650,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -3695,7 +3695,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -3740,7 +3740,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -3785,7 +3785,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -3830,7 +3830,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -3875,7 +3875,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -3920,7 +3920,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one,
@@ -3965,7 +3965,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one,
@@ -4010,7 +4010,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_zero,
@@ -4055,7 +4055,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -4100,7 +4100,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -4148,7 +4148,7 @@ class Armadillo(TileBase):
         elif closure == "z_min":
             # set points:
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -4193,7 +4193,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_right = np.array(
+            connection_front_right = _np.array(
                 [
                     [
                         v_wall_thickness + v_one_half,
@@ -4238,7 +4238,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            front = np.array(
+            front = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -4283,7 +4283,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_left = np.array(
+            connection_back_left = _np.array(
                 [
                     [
                         -v_wall_thickness + v_one_half,
@@ -4328,7 +4328,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [
                         v_zero,
@@ -4373,7 +4373,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_left = np.array(
+            connection_front_left = _np.array(
                 [
                     [
                         v_zero,
@@ -4418,7 +4418,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            back = np.array(
+            back = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -4463,7 +4463,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_right = np.array(
+            connection_back_right = _np.array(
                 [
                     [
                         v_inner_half_contact_length + v_one_half,
@@ -4508,7 +4508,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [
                         v_one,
@@ -4553,7 +4553,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [
                         v_one_half + v_inner_half_contact_length,
@@ -4598,7 +4598,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_bottom = np.array(
+            connection_front_bottom = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -4643,7 +4643,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_front_top = np.array(
+            connection_front_top = _np.array(
                 [
                     [
                         v_half_contact_length + v_one_half,
@@ -4688,7 +4688,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_bottom = np.array(
+            connection_back_bottom = _np.array(
                 [
                     [
                         v_one,
@@ -4733,7 +4733,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_back_top = np.array(
+            connection_back_top = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -4778,7 +4778,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_right = np.array(
+            connection_top_right = _np.array(
                 [
                     [
                         v_one_half + v_half_contact_length,
@@ -4823,7 +4823,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_top_left = np.array(
+            connection_top_left = _np.array(
                 [
                     [
                         v_one_half - v_half_contact_length,
@@ -4868,7 +4868,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_left = np.array(
+            connection_bottom_left = _np.array(
                 [
                     [
                         v_zero,
@@ -4913,7 +4913,7 @@ class Armadillo(TileBase):
                 ]
             )
 
-            connection_bottom_right = np.array(
+            connection_bottom_right = _np.array(
                 [
                     [
                         v_one,
@@ -4959,63 +4959,63 @@ class Armadillo(TileBase):
             )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_bottom_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_bottom_left)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_bottom_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_bottom_right)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_bottom)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_bottom)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_bottom)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_bottom)
         )
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_top)
-        )
-
-        spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_top)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_top)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_top_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_top)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_top_right)
         )
-
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=right))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=back))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_right)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=back))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_top_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=front))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=left))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_top_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=front))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=top))
+        spline_list.append(
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_right)
+        )
+
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=bottom))
+
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=top))
 
         return (spline_list, None)
 
@@ -5064,8 +5064,8 @@ class Armadillo(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -5078,7 +5078,7 @@ class Armadillo(TileBase):
                 "Derivatives are not implemented for this tile yet"
             )
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -5103,7 +5103,7 @@ class Armadillo(TileBase):
         spline_list = []
 
         # set points:
-        right = np.array(
+        right = _np.array(
             [
                 [
                     v_wall_thickness + v_one_half,
@@ -5148,7 +5148,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_front_right = np.array(
+        connection_front_right = _np.array(
             [
                 [
                     v_wall_thickness + v_one_half,
@@ -5193,7 +5193,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        front = np.array(
+        front = _np.array(
             [
                 [
                     v_inner_half_contact_length + v_one_half,
@@ -5238,7 +5238,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_back_left = np.array(
+        connection_back_left = _np.array(
             [
                 [
                     -v_wall_thickness + v_one_half,
@@ -5283,7 +5283,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        left = np.array(
+        left = _np.array(
             [
                 [
                     v_zero,
@@ -5328,7 +5328,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_front_left = np.array(
+        connection_front_left = _np.array(
             [
                 [
                     v_zero,
@@ -5373,7 +5373,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        back = np.array(
+        back = _np.array(
             [
                 [
                     v_half_contact_length + v_one_half,
@@ -5418,7 +5418,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_back_right = np.array(
+        connection_back_right = _np.array(
             [
                 [
                     v_inner_half_contact_length + v_one_half,
@@ -5463,7 +5463,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        bottom = np.array(
+        bottom = _np.array(
             [
                 [
                     v_one_half + v_half_contact_length,
@@ -5508,7 +5508,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        top = np.array(
+        top = _np.array(
             [
                 [
                     v_one_half + v_inner_half_contact_length,
@@ -5553,7 +5553,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_front_bottom = np.array(
+        connection_front_bottom = _np.array(
             [
                 [
                     v_half_contact_length + v_one_half,
@@ -5598,7 +5598,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_front_top = np.array(
+        connection_front_top = _np.array(
             [
                 [
                     v_half_contact_length + v_one_half,
@@ -5643,7 +5643,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_back_bottom = np.array(
+        connection_back_bottom = _np.array(
             [
                 [
                     v_one_half + v_half_contact_length,
@@ -5688,7 +5688,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_back_top = np.array(
+        connection_back_top = _np.array(
             [
                 [
                     v_one_half + v_half_contact_length,
@@ -5733,7 +5733,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_top_right = np.array(
+        connection_top_right = _np.array(
             [
                 [
                     v_one_half + v_half_contact_length,
@@ -5778,7 +5778,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_top_left = np.array(
+        connection_top_left = _np.array(
             [
                 [
                     v_one_half - v_half_contact_length,
@@ -5823,7 +5823,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_bottom_left = np.array(
+        connection_bottom_left = _np.array(
             [
                 [
                     v_zero,
@@ -5868,7 +5868,7 @@ class Armadillo(TileBase):
             ]
         )
 
-        connection_bottom_right = np.array(
+        connection_bottom_right = _np.array(
             [
                 [
                     v_one,
@@ -5913,63 +5913,63 @@ class Armadillo(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_right)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=back))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=back))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=left))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=front))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=front))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_right)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=top))
-
-        spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_top)
-        )
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=top))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_front_bottom)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_top)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_bottom)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_front_bottom)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_back_top)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_bottom)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_top_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_back_top)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_top_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_top_right)
         )
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_bottom_left)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_top_left)
+        )
+
+        spline_list.append(
+            _Bezier(degrees=[1, 1, 1], control_points=connection_bottom_left)
         )
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=connection_bottom_right)
+            _Bezier(degrees=[1, 1, 1], control_points=connection_bottom_right)
         )
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/crossednuttile2d.py
+++ b/splinepy/microstructure/tiles/crossednuttile2d.py
@@ -1,14 +1,14 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class NutTile2D(TileBase):
+class NutTile2D(_TileBase):
     def __init__(self):
         """Simple tile - looks like a nut"""
         self._dim = 2
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5],
             ]
@@ -54,8 +54,8 @@ class NutTile2D(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self.evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -63,7 +63,7 @@ class NutTile2D(TileBase):
 
         self.check_params(parameters)
 
-        if not (np.all(parameters[0] > 0) and np.all(parameters[0] < 0.5)):
+        if not (_np.all(parameters[0] > 0) and _np.all(parameters[0] < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -78,7 +78,7 @@ class NutTile2D(TileBase):
 
         if closure == "x_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -87,7 +87,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -96,7 +96,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -105,7 +105,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, v_zero],
@@ -114,7 +114,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, v_zero],
@@ -123,7 +123,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_zero, v_one],
@@ -132,7 +132,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -141,7 +141,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -151,7 +151,7 @@ class NutTile2D(TileBase):
             )
 
         elif closure == "x_max":
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, v_zero],
@@ -160,7 +160,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_one],
@@ -169,7 +169,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -178,7 +178,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -187,7 +187,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -196,7 +196,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_zero, v_outer_c_h + v_one_half],
@@ -205,7 +205,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -214,7 +214,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -225,7 +225,7 @@ class NutTile2D(TileBase):
 
         elif closure == "y_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -234,7 +234,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -243,7 +243,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -252,7 +252,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -261,7 +261,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -270,7 +270,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_zero, v_outer_c_h + v_one_half],
@@ -279,7 +279,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_one, v_zero],
@@ -288,7 +288,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_one, v_zero],
@@ -299,7 +299,7 @@ class NutTile2D(TileBase):
 
         elif closure == "y_max":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -308,7 +308,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -317,7 +317,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_one, v_one],
@@ -326,7 +326,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -335,7 +335,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -344,7 +344,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_zero, v_outer_c_h + v_one_half],
@@ -353,7 +353,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -362,7 +362,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -371,21 +371,21 @@ class NutTile2D(TileBase):
                 ]
             )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
 
         return spline_list
 
@@ -431,8 +431,8 @@ class NutTile2D(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -440,7 +440,7 @@ class NutTile2D(TileBase):
 
         self.check_params(parameters)
 
-        if not (np.all(parameters[0] > 0) and np.all(parameters[0] < 0.5)):
+        if not (_np.all(parameters[0] > 0) and _np.all(parameters[0] < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -463,7 +463,7 @@ class NutTile2D(TileBase):
         spline_list = []
 
         # set points:
-        right = np.array(
+        right = _np.array(
             [
                 [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                 [v_one, -v_outer_c_h + v_one_half],
@@ -472,7 +472,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        right_top = np.array(
+        right_top = _np.array(
             [
                 [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                 [v_one, v_outer_c_h + v_one_half],
@@ -481,7 +481,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        top = np.array(
+        top = _np.array(
             [
                 [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                 [v_outer_c_h + v_one_half, v_one],
@@ -490,7 +490,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom_left = np.array(
+        bottom_left = _np.array(
             [
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                 [v_zero, -v_outer_c_h + v_one_half],
@@ -499,7 +499,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        left = np.array(
+        left = _np.array(
             [
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                 [v_zero, -v_outer_c_h + v_one_half],
@@ -508,7 +508,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        top_left = np.array(
+        top_left = _np.array(
             [
                 [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
                 [v_zero, v_outer_c_h + v_one_half],
@@ -517,7 +517,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom = np.array(
+        bottom = _np.array(
             [
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                 [v_outer_c_h + v_one_half, v_zero],
@@ -526,7 +526,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom_right = np.array(
+        bottom_right = _np.array(
             [
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                 [v_outer_c_h + v_one_half, v_zero],
@@ -535,20 +535,20 @@ class NutTile2D(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
 
         return spline_list

--- a/splinepy/microstructure/tiles/crossednuttile2d.py
+++ b/splinepy/microstructure/tiles/crossednuttile2d.py
@@ -385,7 +385,9 @@ class NutTile2D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(
+            _Bezier(degrees=[1, 1], control_points=bottom_right)
+        )
 
         return spline_list
 
@@ -549,6 +551,8 @@ class NutTile2D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(
+            _Bezier(degrees=[1, 1], control_points=bottom_right)
+        )
 
         return spline_list

--- a/splinepy/microstructure/tiles/crosstile2d.py
+++ b/splinepy/microstructure/tiles/crosstile2d.py
@@ -1,15 +1,15 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class CrossTile2D(TileBase):
+class CrossTile2D(_TileBase):
     def __init__(self):
         """Simple crosstile with linear-quadratic branches and a trilinear
         center spline."""
         self._dim = 2
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.0, 0.5],
                 [1.0, 0.5],
@@ -60,8 +60,8 @@ class CrossTile2D(TileBase):
 
         if parameters is None:
             self._logd("Tile request is not parametrized, setting default 0.2")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -69,7 +69,7 @@ class CrossTile2D(TileBase):
 
         self.check_params(parameters)
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError("Thickness out of range (0, .5)")
 
         if not (0.0 < float(boundary_width) < 0.5):
@@ -121,7 +121,7 @@ class CrossTile2D(TileBase):
                 # Minimum x position
                 branch_thickness = parameters[1]
 
-                block0_ctps = np.array(
+                block0_ctps = _np.array(
                     [
                         [v_zero, v_zero],
                         [fill_height, v_zero],
@@ -130,7 +130,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block1_ctps = np.array(
+                block1_ctps = _np.array(
                     [
                         [v_zero, bound_width],
                         [fill_height, bound_width],
@@ -139,7 +139,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block2_ctps = np.array(
+                block2_ctps = _np.array(
                     [
                         [v_zero, inv_bound_width],
                         [fill_height, inv_bound_width],
@@ -148,7 +148,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                branch_ctps = np.array(
+                branch_ctps = _np.array(
                     [
                         [fill_height, bound_width],
                         [ctps_mid_height_top, v_one_half - branch_thickness],
@@ -160,25 +160,25 @@ class CrossTile2D(TileBase):
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block0_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block0_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block1_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block1_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block2_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block2_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[2, 1], control_points=branch_ctps)
+                    _Bezier(degrees=[2, 1], control_points=branch_ctps)
                 )
             elif closure == "x_max":
                 # Maximum x position
                 branch_thickness = parameters[0]
 
-                block0_ctps = np.array(
+                block0_ctps = _np.array(
                     [
                         [inv_fill_height, v_zero],
                         [v_one, v_zero],
@@ -187,7 +187,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block1_ctps = np.array(
+                block1_ctps = _np.array(
                     [
                         [inv_fill_height, bound_width],
                         [v_one, bound_width],
@@ -196,7 +196,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block2_ctps = np.array(
+                block2_ctps = _np.array(
                     [
                         [inv_fill_height, inv_bound_width],
                         [v_one, inv_bound_width],
@@ -205,7 +205,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                branch_ctps = np.array(
+                branch_ctps = _np.array(
                     [
                         [0, v_one_half - branch_thickness],
                         [
@@ -223,25 +223,25 @@ class CrossTile2D(TileBase):
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block0_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block0_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block1_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block1_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block2_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block2_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[2, 1], control_points=branch_ctps)
+                    _Bezier(degrees=[2, 1], control_points=branch_ctps)
                 )
             elif closure == "y_min":
                 # Minimum y position
                 branch_thickness = parameters[3]
 
-                block0_ctps = np.array(
+                block0_ctps = _np.array(
                     [
                         [v_zero, v_zero],
                         [bound_width, v_zero],
@@ -250,7 +250,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block1_ctps = np.array(
+                block1_ctps = _np.array(
                     [
                         [bound_width, v_zero],
                         [inv_bound_width, v_zero],
@@ -259,7 +259,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block2_ctps = np.array(
+                block2_ctps = _np.array(
                     [
                         [inv_bound_width, v_zero],
                         [v_one, v_zero],
@@ -268,7 +268,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                branch_ctps = np.array(
+                branch_ctps = _np.array(
                     [
                         [bound_width, fill_height],
                         [inv_bound_width, fill_height],
@@ -280,25 +280,25 @@ class CrossTile2D(TileBase):
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block0_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block0_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block1_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block1_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block2_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block2_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 2], control_points=branch_ctps)
+                    _Bezier(degrees=[1, 2], control_points=branch_ctps)
                 )
             elif closure == "y_max":
                 # Maximum y position
                 branch_thickness = parameters[2]
 
-                block0_ctps = np.array(
+                block0_ctps = _np.array(
                     [
                         [v_zero, inv_fill_height],
                         [bound_width, inv_fill_height],
@@ -307,7 +307,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block1_ctps = np.array(
+                block1_ctps = _np.array(
                     [
                         [bound_width, inv_fill_height],
                         [inv_bound_width, inv_fill_height],
@@ -316,7 +316,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                block2_ctps = np.array(
+                block2_ctps = _np.array(
                     [
                         [inv_bound_width, inv_fill_height],
                         [v_one, inv_fill_height],
@@ -325,7 +325,7 @@ class CrossTile2D(TileBase):
                     ]
                 )
 
-                branch_ctps = np.array(
+                branch_ctps = _np.array(
                     [
                         [v_one_half - branch_thickness, v_zero],
                         [v_one_half + branch_thickness, v_zero],
@@ -343,19 +343,19 @@ class CrossTile2D(TileBase):
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block0_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block0_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block1_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block1_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 1], control_points=block2_ctps)
+                    _Bezier(degrees=[1, 1], control_points=block2_ctps)
                 )
 
                 spline_list.append(
-                    Bezier(degrees=[1, 2], control_points=branch_ctps)
+                    _Bezier(degrees=[1, 2], control_points=branch_ctps)
                 )
             else:
                 raise NotImplementedError(
@@ -417,8 +417,8 @@ class CrossTile2D(TileBase):
         # set to default if nothing is given
         if parameters is None:
             self._logd("Setting branch thickness to default 0.2")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -426,7 +426,7 @@ class CrossTile2D(TileBase):
 
         self.check_params(parameters)
 
-        if not (np.all(parameters > 0) and np.all(parameters < max_radius)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < max_radius)):
             raise ValueError(f"Thickness out of range (0, {center_expansion})")
 
         self.check_param_derivatives(parameter_sensitivities)
@@ -481,16 +481,16 @@ class CrossTile2D(TileBase):
             spline_list = []
 
             # Create the center-tile
-            center_points = np.array(
+            center_points = _np.array(
                 [
                     [-center_r, -center_r],
                     [center_r, -center_r],
                     [-center_r, center_r],
                     [center_r, center_r],
                 ]
-            ) + np.array([v_one_half, v_one_half])
+            ) + _np.array([v_one_half, v_one_half])
 
-            y_min_ctps = np.array(
+            y_min_ctps = _np.array(
                 [
                     [-y_min_r, -v_one_half],
                     [y_min_r, -v_one_half],
@@ -499,9 +499,9 @@ class CrossTile2D(TileBase):
                     [-center_r, -center_r],
                     [center_r, -center_r],
                 ]
-            ) + np.array([v_one_half, v_one_half])
+            ) + _np.array([v_one_half, v_one_half])
 
-            y_max_ctps = np.array(
+            y_max_ctps = _np.array(
                 [
                     [-center_r, center_r],
                     [center_r, center_r],
@@ -510,9 +510,9 @@ class CrossTile2D(TileBase):
                     [-y_max_r, v_one_half],
                     [y_max_r, v_one_half],
                 ]
-            ) + np.array([v_one_half, v_one_half])
+            ) + _np.array([v_one_half, v_one_half])
 
-            x_min_ctps = np.array(
+            x_min_ctps = _np.array(
                 [
                     [-v_one_half, -x_min_r],
                     [-hd_center, -x_min_r],
@@ -521,9 +521,9 @@ class CrossTile2D(TileBase):
                     [-hd_center, x_min_r],
                     [-center_r, center_r],
                 ]
-            ) + np.array([v_one_half, v_one_half])
+            ) + _np.array([v_one_half, v_one_half])
 
-            x_max_ctps = np.array(
+            x_max_ctps = _np.array(
                 [
                     [center_r, -center_r],
                     [hd_center, -x_max_r],
@@ -532,26 +532,26 @@ class CrossTile2D(TileBase):
                     [hd_center, x_max_r],
                     [v_one_half, x_max_r],
                 ]
-            ) + np.array([v_one_half, v_one_half])
+            ) + _np.array([v_one_half, v_one_half])
 
             spline_list.append(
-                Bezier(degrees=[1, 1], control_points=center_points)
+                _Bezier(degrees=[1, 1], control_points=center_points)
             )
 
             spline_list.append(
-                Bezier(degrees=[2, 1], control_points=x_min_ctps)
+                _Bezier(degrees=[2, 1], control_points=x_min_ctps)
             )
 
             spline_list.append(
-                Bezier(degrees=[2, 1], control_points=x_max_ctps)
+                _Bezier(degrees=[2, 1], control_points=x_max_ctps)
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 2], control_points=y_min_ctps)
+                _Bezier(degrees=[1, 2], control_points=y_min_ctps)
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 2], control_points=y_max_ctps)
+                _Bezier(degrees=[1, 2], control_points=y_max_ctps)
             )
 
             # Pass to output

--- a/splinepy/microstructure/tiles/crosstile3d.py
+++ b/splinepy/microstructure/tiles/crosstile3d.py
@@ -1,15 +1,15 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class CrossTile3D(TileBase):
+class CrossTile3D(_TileBase):
     def __init__(self):
         """Simple crosstile with linear-quadratic branches and a trilinear
         center spline."""
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.0, 0.5, 0.5],
                 [1.0, 0.5, 0.5],
@@ -58,8 +58,8 @@ class CrossTile3D(TileBase):
 
         if parameters is None:
             self._logd("Tile request is not parametrized, setting default 0.2")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -70,7 +70,7 @@ class CrossTile3D(TileBase):
                 "Derivatives are not implemented for this tile yet"
             )
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError("Thickness out of range (0, .5)")
 
         if not (0.0 < float(boundary_width) < 0.5):
@@ -90,7 +90,7 @@ class CrossTile3D(TileBase):
         if closure == "z_min":
             # The branch is located at zmin of current tile
             branch_thickness = parameters[5, 0]
-            ctps_corner = np.array(
+            ctps_corner = _np.array(
                 [
                     [0.0, 0.0, 0.0],
                     [boundary_width, 0.0, 0.0],
@@ -104,40 +104,40 @@ class CrossTile3D(TileBase):
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 1], control_points=ctps_corner)
+                _Bezier(degrees=[1, 1, 1], control_points=ctps_corner)
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
-                        ctps_corner + np.array([0.0, inv_boundary_width, 0.0])
+                        ctps_corner + _np.array([0.0, inv_boundary_width, 0.0])
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
-                        ctps_corner + np.array([inv_boundary_width, 0.0, 0.0])
+                        ctps_corner + _np.array([inv_boundary_width, 0.0, 0.0])
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
                         ctps_corner
-                        + np.array(
+                        + _np.array(
                             [inv_boundary_width, inv_boundary_width, 0.0]
                         )
                     ),
                 )
             )
 
-            center_ctps = np.array(
+            center_ctps = _np.array(
                 [
                     [boundary_width, boundary_width, 0.0],
                     [inv_boundary_width, boundary_width, 0.0],
@@ -151,45 +151,45 @@ class CrossTile3D(TileBase):
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 1], control_points=center_ctps)
+                _Bezier(degrees=[1, 1, 1], control_points=center_ctps)
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.maximum(
-                        center_ctps - np.array([center_width, 0, 0]), 0
+                    control_points=_np.maximum(
+                        center_ctps - _np.array([center_width, 0, 0]), 0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.maximum(
-                        center_ctps - np.array([0, center_width, 0]), 0
+                    control_points=_np.maximum(
+                        center_ctps - _np.array([0, center_width, 0]), 0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.minimum(
-                        center_ctps + np.array([center_width, 0, 0]), 1.0
+                    control_points=_np.minimum(
+                        center_ctps + _np.array([center_width, 0, 0]), 1.0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.minimum(
-                        center_ctps + np.array([0, center_width, 0]), 1.0
+                    control_points=_np.minimum(
+                        center_ctps + _np.array([0, center_width, 0]), 1.0
                     ),
                 )
             )
-            branch_ctps = np.array(
+            branch_ctps = _np.array(
                 [
                     [-r_center, -r_center, filling_height],
                     [r_center, -r_center, filling_height],
@@ -208,17 +208,17 @@ class CrossTile3D(TileBase):
                     [-branch_thickness, branch_thickness, 1.0],
                     [branch_thickness, branch_thickness, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 2], control_points=branch_ctps)
+                _Bezier(degrees=[1, 1, 2], control_points=branch_ctps)
             )
 
             return spline_list
         elif closure == "z_max":
             # The branch is located at zmax of current tile
             branch_thickness = parameters[4, 0]
-            ctps_corner = np.array(
+            ctps_corner = _np.array(
                 [
                     [0.0, 0.0, inv_filling_height],
                     [boundary_width, 0.0, inv_filling_height],
@@ -232,40 +232,40 @@ class CrossTile3D(TileBase):
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 1], control_points=ctps_corner)
+                _Bezier(degrees=[1, 1, 1], control_points=ctps_corner)
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
-                        ctps_corner + np.array([0.0, inv_boundary_width, 0.0])
+                        ctps_corner + _np.array([0.0, inv_boundary_width, 0.0])
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
-                        ctps_corner + np.array([inv_boundary_width, 0.0, 0.0])
+                        ctps_corner + _np.array([inv_boundary_width, 0.0, 0.0])
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=(
                         ctps_corner
-                        + np.array(
+                        + _np.array(
                             [inv_boundary_width, inv_boundary_width, 0.0]
                         )
                     ),
                 )
             )
 
-            center_ctps = np.array(
+            center_ctps = _np.array(
                 [
                     [boundary_width, boundary_width, inv_filling_height],
                     [inv_boundary_width, boundary_width, inv_filling_height],
@@ -283,46 +283,46 @@ class CrossTile3D(TileBase):
             )
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 1], control_points=center_ctps)
+                _Bezier(degrees=[1, 1, 1], control_points=center_ctps)
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.maximum(
-                        center_ctps - np.array([center_width, 0, 0]), 0
+                    control_points=_np.maximum(
+                        center_ctps - _np.array([center_width, 0, 0]), 0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.maximum(
-                        center_ctps - np.array([0, center_width, 0]), 0
+                    control_points=_np.maximum(
+                        center_ctps - _np.array([0, center_width, 0]), 0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.minimum(
-                        center_ctps + np.array([center_width, 0, 0]), 1.0
+                    control_points=_np.minimum(
+                        center_ctps + _np.array([center_width, 0, 0]), 1.0
                     ),
                 )
             )
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.minimum(
-                        center_ctps + np.array([0, center_width, 0]), 1.0
+                    control_points=_np.minimum(
+                        center_ctps + _np.array([0, center_width, 0]), 1.0
                     ),
                 )
             )
 
-            branch_ctps = np.array(
+            branch_ctps = _np.array(
                 [
                     [-branch_thickness, -branch_thickness, 0.0],
                     [branch_thickness, -branch_thickness, 0.0],
@@ -353,10 +353,10 @@ class CrossTile3D(TileBase):
                     [-r_center, r_center, inv_filling_height],
                     [r_center, r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(degrees=[1, 1, 2], control_points=branch_ctps)
+                _Bezier(degrees=[1, 1, 2], control_points=branch_ctps)
             )
 
             return (spline_list, None)
@@ -413,7 +413,7 @@ class CrossTile3D(TileBase):
         if parameters is None:
             self._logd("Setting branch thickness to default 0.2")
             parameters = (
-                np.ones(
+                _np.ones(
                     (
                         self._evaluation_points.shape[0],
                         self._n_info_per_eval_point,
@@ -446,21 +446,21 @@ class CrossTile3D(TileBase):
 
         # Check for type and consistency
         self.check_params(parameters)
-        if np.any(parameters <= 0) or np.any(parameters > max_radius):
+        if _np.any(parameters <= 0) or _np.any(parameters > max_radius):
             raise ValueError(
                 f"Radii must be in (0,{max_radius}) for "
                 f"center_expansion {center_expansion}"
             )
 
         # center radius - mean of radii
-        center_r = np.sum(parameters) / 6.0 * center_expansion
+        center_r = _np.sum(parameters) / 6.0 * center_expansion
         hd_center = 0.5 * (0.5 + center_r)
 
         # Initialize return list
         spline_list = []
 
         # Create the center-tile
-        center_points = np.array(
+        center_points = _np.array(
             [
                 [-center_r, -center_r, -center_r],
                 [center_r, -center_r, -center_r],
@@ -474,7 +474,7 @@ class CrossTile3D(TileBase):
         )
 
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[1, 1, 1],
                 control_points=center_points + [0.5, 0.5, 0.5],
             )
@@ -483,7 +483,7 @@ class CrossTile3D(TileBase):
         # X-Axis branches
         # X-Min-Branch
         aux_x_min = min(x_min_r, center_r)
-        x_min_ctps = np.array(
+        x_min_ctps = _np.array(
             [
                 [-0.5, -x_min_r, -x_min_r],
                 [-hd_center, -aux_x_min, -aux_x_min],
@@ -500,14 +500,14 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[2, 1, 1], control_points=x_min_ctps + [0.5, 0.5, 0.5]
             )
         )
 
         # X-Min-Branch
         aux_x_max = min(x_max_r, center_r)
-        x_max_ctps = np.array(
+        x_max_ctps = _np.array(
             [
                 center_points[1, :],
                 [hd_center, -aux_x_max, -aux_x_max],
@@ -524,7 +524,7 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[2, 1, 1], control_points=x_max_ctps + [0.5, 0.5, 0.5]
             )
         )
@@ -532,7 +532,7 @@ class CrossTile3D(TileBase):
         # Y-Axis branches
         # Y-Min-Branch
         aux_y_min = min(y_min_r, center_r)
-        y_min_ctps = np.array(
+        y_min_ctps = _np.array(
             [
                 [-y_min_r, -0.5, -y_min_r],
                 [y_min_r, -0.5, -y_min_r],
@@ -549,14 +549,14 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[1, 2, 1], control_points=y_min_ctps + [0.5, 0.5, 0.5]
             )
         )
 
         # Y-Min-Branch
         aux_y_max = min(y_max_r, center_r)
-        y_max_ctps = np.array(
+        y_max_ctps = _np.array(
             [
                 center_points[2, :],
                 center_points[3, :],
@@ -573,7 +573,7 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[1, 2, 1], control_points=y_max_ctps + [0.5, 0.5, 0.5]
             )
         )
@@ -581,7 +581,7 @@ class CrossTile3D(TileBase):
         # Y-Axis branches
         # Y-Min-Branch
         aux_z_min = min(z_min_r, center_r)
-        z_min_ctps = np.array(
+        z_min_ctps = _np.array(
             [
                 [-z_min_r, -z_min_r, -0.5],
                 [z_min_r, -z_min_r, -0.5],
@@ -598,14 +598,14 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[1, 1, 2], control_points=z_min_ctps + [0.5, 0.5, 0.5]
             )
         )
 
         # Y-Min-Branch
         aux_z_max = min(z_max_r, center_r)
-        z_max_ctps = np.array(
+        z_max_ctps = _np.array(
             [
                 center_points[4, :],
                 center_points[5, :],
@@ -622,7 +622,7 @@ class CrossTile3D(TileBase):
             ]
         )
         spline_list.append(
-            Bezier(
+            _Bezier(
                 degrees=[1, 1, 2], control_points=z_max_ctps + [0.5, 0.5, 0.5]
             )
         )

--- a/splinepy/microstructure/tiles/cube3d.py
+++ b/splinepy/microstructure/tiles/cube3d.py
@@ -58,7 +58,8 @@ class Cube3D(_TileBase):
         self.check_params(parameters)
 
         if not (
-            _np.all(parameters[:, :2] > 0.0) and _np.all(parameters[:, :2] < 0.5)
+            _np.all(parameters[:, :2] > 0.0)
+            and _np.all(parameters[:, :2] < 0.5)
         ):
             raise ValueError("The wall thickness must be in (0.0 and 0.5)")
 

--- a/splinepy/microstructure/tiles/cube3d.py
+++ b/splinepy/microstructure/tiles/cube3d.py
@@ -1,14 +1,14 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class Cube3D(TileBase):
+class Cube3D(_TileBase):
     def __init__(self):
         """Simple tile - looks like a nut"""
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.0, 0.5, 0.5],
                 [1.0, 0.5, 0.5],
@@ -49,7 +49,7 @@ class Cube3D(TileBase):
         if parameters is None:
             self._logd("Setting parameters to default value (0.2)")
             parameters = (
-                np.ones(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 ).reshape(-1, 1)
                 * 0.2
@@ -58,13 +58,13 @@ class Cube3D(TileBase):
         self.check_params(parameters)
 
         if not (
-            np.all(parameters[:, :2] > 0.0) and np.all(parameters[:, :2] < 0.5)
+            _np.all(parameters[:, :2] > 0.0) and _np.all(parameters[:, :2] < 0.5)
         ):
             raise ValueError("The wall thickness must be in (0.0 and 0.5)")
 
-        if not np.all(
-            (parameters[:, 2:] > np.deg2rad(-30))
-            and (parameters[:, 2:] < np.deg2rad(30))
+        if not _np.all(
+            (parameters[:, 2:] > _np.deg2rad(-30))
+            and (parameters[:, 2:] < _np.deg2rad(30))
         ):
             raise ValueError("Rotation is only allowed between +-30 deg")
 
@@ -107,9 +107,9 @@ class Cube3D(TileBase):
 
             # x_max_z_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_one - z_max, z_max, v_one],
                             [v_one, v_zero, v_one],
@@ -126,9 +126,9 @@ class Cube3D(TileBase):
 
             # x_min_z_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_zero, x_min, x_min],
                             [center, center, center],
@@ -145,9 +145,9 @@ class Cube3D(TileBase):
 
             # x_min_z_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_zero, v_zero, v_one],
                             [z_max, z_max, v_one],
@@ -164,9 +164,9 @@ class Cube3D(TileBase):
 
             # x_max_z_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_one - center, center, center],
                             [v_one, x_max, x_max],
@@ -183,9 +183,9 @@ class Cube3D(TileBase):
 
             # x_max_y_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_one - y_max, v_one, y_max],
                             [v_one, v_one, v_zero],
@@ -202,9 +202,9 @@ class Cube3D(TileBase):
 
             # y_max_z_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_zero, v_one, v_zero],
                             [v_one, v_one, v_zero],
@@ -221,9 +221,9 @@ class Cube3D(TileBase):
 
             # x_min_y_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_zero, v_one, v_zero],
                             [y_max, v_one, y_max],
@@ -240,9 +240,9 @@ class Cube3D(TileBase):
 
             # y_max_z_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [y_max, v_one, v_one - y_max],
                             [v_one - y_max, v_one, v_one - y_max],
@@ -259,9 +259,9 @@ class Cube3D(TileBase):
 
             # x_max_y_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_one - center, center, center],
                             [v_one, x_max, x_max],
@@ -278,9 +278,9 @@ class Cube3D(TileBase):
 
             # x_min_y_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [v_zero, x_min, x_min],
                             [center, center, center],
@@ -297,9 +297,9 @@ class Cube3D(TileBase):
 
             # y_min_z_max
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [center, center, v_one - center],
                             [v_one - center, center, v_one - center],
@@ -316,9 +316,9 @@ class Cube3D(TileBase):
 
             # y_min_z_min
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
-                    control_points=np.array(
+                    control_points=_np.array(
                         [
                             [z_min, z_min, v_zero],
                             [v_one - z_min, z_min, v_zero],

--- a/splinepy/microstructure/tiles/cubevoid.py
+++ b/splinepy/microstructure/tiles/cubevoid.py
@@ -1,10 +1,10 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class Cubevoid(TileBase):
+class Cubevoid(_TileBase):
     """Void in form of an cuboid set into a unit cell.
 
     Parametrization acts on the cuboid's orientation as well as on its
@@ -17,7 +17,7 @@ class Cubevoid(TileBase):
 
     def __init__(self):
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5, 0.5],
             ]
@@ -25,7 +25,7 @@ class Cubevoid(TileBase):
         self._n_info_per_eval_point = 4
 
         # Aux values
-        self._sphere_ctps = np.array(
+        self._sphere_ctps = _np.array(
             [
                 [-0.5, -0.5, -0.5],
                 [0.5, -0.5, -0.5],
@@ -39,20 +39,20 @@ class Cubevoid(TileBase):
         )
 
     def _rotation_matrix_x(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[1, 0, 0], [0, cc, ss], [0, -ss, cc]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[1, 0, 0], [0, cc, ss], [0, -ss, cc]])
 
     def _rotation_matrix_x_deriv(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[0, 0, 0], [0, -ss, cc], [0, -cc, -ss]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[0, 0, 0], [0, -ss, cc], [0, -cc, -ss]])
 
     def _rotation_matrix_y(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[cc, 0, -ss], [0, 1, 0], [ss, 0, cc]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[cc, 0, -ss], [0, 1, 0], [ss, 0, cc]])
 
     def _rotation_matrix_y_deriv(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[-ss, 0, -cc], [0, 1, 0], [cc, 0, -ss]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[-ss, 0, -cc], [0, 1, 0], [cc, 0, -ss]])
 
     def create_tile(
         self,
@@ -89,7 +89,7 @@ class Cubevoid(TileBase):
         derivatives : list<list<splines>> / None
         """  # set to default if nothing is given
         if parameters is None:
-            parameters = np.array([0.5, 0.5, 0, 0]).reshape(1, 1, 4)
+            parameters = _np.array([0.5, 0.5, 0, 0]).reshape(1, 1, 4)
 
         # Create center ellipsoid
         # RotY * RotX * DIAG(r_x, r_yz) * T_base
@@ -104,7 +104,7 @@ class Cubevoid(TileBase):
             derivatives = None
 
         # Prepare auxiliary matrices and values
-        diag = np.diag([r_x, r_yz, r_yz])
+        diag = _np.diag([r_x, r_yz, r_yz])
         rotMx = self._rotation_matrix_x(rot_x)
         rotMy = self._rotation_matrix_y(rot_y)
 
@@ -117,7 +117,7 @@ class Cubevoid(TileBase):
                 v_one_half = 0.5
                 v_one = 1.0
                 v_zero = 0.0
-                ctps = np.einsum(
+                ctps = _np.einsum(
                     "ij,jk,kl,ml->mi",
                     rotMy,
                     rotMx,
@@ -132,26 +132,26 @@ class Cubevoid(TileBase):
                 v_one_half = 0.0
                 v_one = 0.0
                 v_zero = 0.0
-                ddiag = np.diag([dr_x, dr_yz, dr_yz])
+                ddiag = _np.diag([dr_x, dr_yz, dr_yz])
                 drotMx = self._rotation_matrix_x_deriv(rot_x)
                 drotMy = self._rotation_matrix_y_deriv(rot_y)
                 ctps_mat = (
                     drot_y
-                    * np.einsum(
+                    * _np.einsum(
                         "ij,jk,kl->il",
                         drotMy,
                         rotMx,
                         diag,
                     )
-                    + drot_x * np.einsum("ij,jk,kl->il", rotMy, drotMx, diag)
-                    + np.einsum("ij,jk,kl->il", rotMy, rotMx, ddiag)
+                    + drot_x * _np.einsum("ij,jk,kl->il", rotMy, drotMx, diag)
+                    + _np.einsum("ij,jk,kl->il", rotMy, rotMx, ddiag)
                 )
-                ctps = np.einsum("ij,kj->ki", ctps_mat, self._sphere_ctps)
+                ctps = _np.einsum("ij,kj->ki", ctps_mat, self._sphere_ctps)
 
             ctps += [v_one_half, v_one_half, v_one_half]
             # Start the assembly
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -166,7 +166,7 @@ class Cubevoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         ctps[4, :],
@@ -182,7 +182,7 @@ class Cubevoid(TileBase):
             )
             # Y-Axis
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -197,7 +197,7 @@ class Cubevoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         ctps[2, :],
@@ -213,7 +213,7 @@ class Cubevoid(TileBase):
             )
             # Z-Axis
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -228,7 +228,7 @@ class Cubevoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1, 1],
                     control_points=[
                         ctps[1, :],

--- a/splinepy/microstructure/tiles/double_lattice_tile.py
+++ b/splinepy/microstructure/tiles/double_lattice_tile.py
@@ -1,15 +1,15 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class DoubleLatticeTile(TileBase):
+class DoubleLatticeTile(_TileBase):
     def __init__(self):
         """Simple crosstile with linear-quadratic branches and a trilinear
         center spline."""
         self._dim = 2
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5],
             ]
@@ -53,9 +53,9 @@ class DoubleLatticeTile(TileBase):
         # set to default if nothing is given
         if parameters is None:
             self._logd("Tile request is not parametrized, setting default 0.2")
-            parameters = np.ones((1, 1)) * 0.1
+            parameters = _np.ones((1, 1)) * 0.1
         else:
-            if not (np.all(parameters > 0) and np.all(parameters < 0.25)):
+            if not (_np.all(parameters > 0) and _np.all(parameters < 0.25)):
                 raise ValueError("The parameter must be in 0.01 and 0.25")
             pass
         self.check_params(parameters)
@@ -102,7 +102,7 @@ class DoubleLatticeTile(TileBase):
 
             # 1
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a01, a01],
@@ -115,7 +115,7 @@ class DoubleLatticeTile(TileBase):
 
             # 2
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a01, a01],
@@ -128,7 +128,7 @@ class DoubleLatticeTile(TileBase):
 
             # 3
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a04, a01],
@@ -141,7 +141,7 @@ class DoubleLatticeTile(TileBase):
 
             # 4
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a08, a01],
@@ -154,7 +154,7 @@ class DoubleLatticeTile(TileBase):
 
             # 5
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a10, a02],
@@ -167,7 +167,7 @@ class DoubleLatticeTile(TileBase):
 
             # 6
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a11, a04],
@@ -180,7 +180,7 @@ class DoubleLatticeTile(TileBase):
 
             # 7
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a10, a09],
@@ -192,7 +192,7 @@ class DoubleLatticeTile(TileBase):
             )
             # 8
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a09, a10],
@@ -205,7 +205,7 @@ class DoubleLatticeTile(TileBase):
 
             # 9
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a03, a10],
@@ -218,7 +218,7 @@ class DoubleLatticeTile(TileBase):
 
             # 10
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a02, a10],
@@ -231,7 +231,7 @@ class DoubleLatticeTile(TileBase):
 
             # 11
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a01, a08],
@@ -244,7 +244,7 @@ class DoubleLatticeTile(TileBase):
 
             # 12
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a01, a04],
@@ -257,7 +257,7 @@ class DoubleLatticeTile(TileBase):
 
             # 13
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a02, a09],
@@ -270,7 +270,7 @@ class DoubleLatticeTile(TileBase):
 
             # 14
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a02, a10],
@@ -283,7 +283,7 @@ class DoubleLatticeTile(TileBase):
 
             # 15
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a02, a02],
@@ -296,7 +296,7 @@ class DoubleLatticeTile(TileBase):
 
             # 16
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a02, a02],
@@ -309,7 +309,7 @@ class DoubleLatticeTile(TileBase):
 
             # 17
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a09, a02],
@@ -322,7 +322,7 @@ class DoubleLatticeTile(TileBase):
 
             # 18
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a06, a06],
@@ -335,7 +335,7 @@ class DoubleLatticeTile(TileBase):
 
             # 19
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a06, a06],
@@ -348,7 +348,7 @@ class DoubleLatticeTile(TileBase):
 
             # 20
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 1],
                     control_points=[
                         [a06, a06],

--- a/splinepy/microstructure/tiles/ellipsvoid.py
+++ b/splinepy/microstructure/tiles/ellipsvoid.py
@@ -1,10 +1,9 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
-
-class Ellipsvoid(TileBase):
+class Ellipsvoid(_TileBase):
     """Void in form of an ellipse set into a unit cell.
 
     Parametrization acts on the elipsoid's orientation as well as on its
@@ -17,7 +16,7 @@ class Ellipsvoid(TileBase):
 
     def __init__(self):
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5, 0.5],
             ]
@@ -28,7 +27,7 @@ class Ellipsvoid(TileBase):
         c0 = 0.5 / 3**0.5
         aux_1 = 3**0.5 / 2 * 0.5
         aux_0 = aux_1 * 2
-        self._sphere_ctps = np.array(
+        self._sphere_ctps = _np.array(
             [
                 [-c0, -c0, -c0],
                 [0, -aux_1, -aux_1],
@@ -63,20 +62,20 @@ class Ellipsvoid(TileBase):
         )
 
     def _rotation_matrix_x(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[1, 0, 0], [0, cc, ss], [0, -ss, cc]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[1, 0, 0], [0, cc, ss], [0, -ss, cc]])
 
     def _rotation_matrix_x_deriv(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[0, 0, 0], [0, -ss, cc], [0, -cc, -ss]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[0, 0, 0], [0, -ss, cc], [0, -cc, -ss]])
 
     def _rotation_matrix_y(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[cc, 0, -ss], [0, 1, 0], [ss, 0, cc]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[cc, 0, -ss], [0, 1, 0], [ss, 0, cc]])
 
     def _rotation_matrix_y_deriv(self, angle):
-        cc, ss = np.cos(angle), np.sin(angle)
-        return np.array([[-ss, 0, -cc], [0, 1, 0], [cc, 0, -ss]])
+        cc, ss = _np.cos(angle), _np.sin(angle)
+        return _np.array([[-ss, 0, -cc], [0, 1, 0], [cc, 0, -ss]])
 
     def create_tile(
         self,
@@ -113,7 +112,7 @@ class Ellipsvoid(TileBase):
         derivatives: list<list<splines>> / None
         """  # set to default if nothing is given
         if parameters is None:
-            parameters = np.array([0.5, 0.5, 0, 0]).reshape(1, 1, 4)
+            parameters = _np.array([0.5, 0.5, 0, 0]).reshape(1, 1, 4)
 
         # Create center ellipsoid
         # RotY * RotX * DIAG(r_x, r_yz) * T_base
@@ -128,7 +127,7 @@ class Ellipsvoid(TileBase):
             derivatives = None
 
         # Prepare auxiliary matrices and values
-        diag = np.diag([r_x, r_yz, r_yz])
+        diag = _np.diag([r_x, r_yz, r_yz])
         rotMx = self._rotation_matrix_x(rot_x)
         rotMy = self._rotation_matrix_y(rot_y)
 
@@ -141,7 +140,7 @@ class Ellipsvoid(TileBase):
                 v_one_half = 0.5
                 v_one = 1.0
                 v_zero = 0.0
-                ctps = np.einsum(
+                ctps = _np.einsum(
                     "ij,jk,kl,ml->mi",
                     rotMy,
                     rotMx,
@@ -156,26 +155,26 @@ class Ellipsvoid(TileBase):
                 v_one_half = 0.0
                 v_one = 0.0
                 v_zero = 0.0
-                ddiag = np.diag([dr_x, dr_yz, dr_yz])
+                ddiag = _np.diag([dr_x, dr_yz, dr_yz])
                 drotMx = self._rotation_matrix_x_deriv(rot_x)
                 drotMy = self._rotation_matrix_y_deriv(rot_y)
                 ctps_mat = (
                     drot_y
-                    * np.einsum(
+                    * _np.einsum(
                         "ij,jk,kl->il",
                         drotMy,
                         rotMx,
                         diag,
                     )
-                    + drot_x * np.einsum("ij,jk,kl->il", rotMy, drotMx, diag)
-                    + np.einsum("ij,jk,kl->il", rotMy, rotMx, ddiag)
+                    + drot_x * _np.einsum("ij,jk,kl->il", rotMy, drotMx, diag)
+                    + _np.einsum("ij,jk,kl->il", rotMy, rotMx, ddiag)
                 )
-                ctps = np.einsum("ij,kj->ki", ctps_mat, self._sphere_ctps)
+                ctps = _np.einsum("ij,kj->ki", ctps_mat, self._sphere_ctps)
 
             ctps += [v_one_half, v_one_half, v_one_half]
             # Start the assembly
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 1],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -200,7 +199,7 @@ class Ellipsvoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 1],
                     control_points=[
                         ctps[18, :],
@@ -226,7 +225,7 @@ class Ellipsvoid(TileBase):
             )
             # Y-Axis
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -251,7 +250,7 @@ class Ellipsvoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=[
                         ctps[6, :],
@@ -277,7 +276,7 @@ class Ellipsvoid(TileBase):
             )
             # Z-Axis
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=[
                         [v_zero, v_zero, v_zero],
@@ -302,7 +301,7 @@ class Ellipsvoid(TileBase):
                 )
             )
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=[
                         ctps[2, :],

--- a/splinepy/microstructure/tiles/ellipsvoid.py
+++ b/splinepy/microstructure/tiles/ellipsvoid.py
@@ -3,6 +3,7 @@ import numpy as _np
 from splinepy.bezier import Bezier as _Bezier
 from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
+
 class Ellipsvoid(_TileBase):
     """Void in form of an ellipse set into a unit cell.
 

--- a/splinepy/microstructure/tiles/inversecrosstile3d.py
+++ b/splinepy/microstructure/tiles/inversecrosstile3d.py
@@ -946,7 +946,9 @@ class InverseCrossTile3D(_TileBase):
 
         self.check_params(parameters)
 
-        if _np.any(parameters < min_radius) or _np.any(parameters > max_radius):
+        if _np.any(parameters < min_radius) or _np.any(
+            parameters > max_radius
+        ):
             raise ValueError(
                 f"Radii must be in (0,{max_radius}) for "
                 f"center_expansion {center_expansion}"

--- a/splinepy/microstructure/tiles/inversecrosstile3d.py
+++ b/splinepy/microstructure/tiles/inversecrosstile3d.py
@@ -1,10 +1,10 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class InverseCrossTile3D(TileBase):
+class InverseCrossTile3D(_TileBase):
     """Class that provides necessary functions to create inverse microtile,
     that can be used to describe the domain within a microstructure."""
 
@@ -12,7 +12,7 @@ class InverseCrossTile3D(TileBase):
         """Simple inverse crosstile to tile with linear-quadratic branches and
         a trilinear center spline."""
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.0, 0.5, 0.5],
                 [1.0, 0.5, 0.5],
@@ -67,7 +67,7 @@ class InverseCrossTile3D(TileBase):
         if parameters is None:
             self._logd("Tile request is not parametrized, setting default 0.2")
             parameters = (
-                np.ones(
+                _np.ones(
                     (
                         self._evaluation_points.shape[0],
                         self._n_info_per_eval_point,
@@ -83,7 +83,7 @@ class InverseCrossTile3D(TileBase):
                 "Derivatives are not implemented for this tile yet"
             )
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError("Thickness out of range (0, .5)")
 
         if not (0.0 < float(boundary_width) < 0.5):
@@ -104,7 +104,7 @@ class InverseCrossTile3D(TileBase):
         spline_list = []
         if closure == "z_min":
             branch_thickness = parameters.flatten()[5]
-            branch_neighbor_x_min_ctps = np.array(
+            branch_neighbor_x_min_ctps = _np.array(
                 [
                     [-0.5, -r_center, filling_height],
                     [-half_r_center, -r_center, filling_height],
@@ -137,16 +137,16 @@ class InverseCrossTile3D(TileBase):
                     [-seperator_distance, aux_column_width, 1.0],
                     [-branch_thickness, branch_thickness, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=branch_neighbor_x_min_ctps,
                 )
             )
 
-            branch_neighbor_x_max_ctps = np.array(
+            branch_neighbor_x_max_ctps = _np.array(
                 [
                     [r_center, -r_center, filling_height],
                     [half_r_center, -r_center, filling_height],
@@ -175,16 +175,16 @@ class InverseCrossTile3D(TileBase):
                     [seperator_distance, aux_column_width, 1.0],
                     [0.5, aux_column_width, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=branch_neighbor_x_max_ctps,
                 )
             )
 
-            branch_neighbor_y_min_ctps = np.array(
+            branch_neighbor_y_min_ctps = _np.array(
                 [
                     [-r_center, -0.5, filling_height],
                     [r_center, -0.5, filling_height],
@@ -217,16 +217,16 @@ class InverseCrossTile3D(TileBase):
                     [-branch_thickness, -branch_thickness, 1.0],
                     [branch_thickness, -branch_thickness, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=branch_neighbor_y_min_ctps,
                 )
             )
 
-            branch_neighbor_y_max_ctps = np.array(
+            branch_neighbor_y_max_ctps = _np.array(
                 [
                     [-r_center, r_center, filling_height],
                     [r_center, r_center, filling_height],
@@ -255,16 +255,16 @@ class InverseCrossTile3D(TileBase):
                     [-aux_column_width, 0.5, 1.0],
                     [aux_column_width, 0.5, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=branch_neighbor_y_max_ctps,
                 )
             )
 
-            branch_x_min_y_min_ctps = np.array(
+            branch_x_min_y_min_ctps = _np.array(
                 [
                     [-0.5, -0.5, filling_height],
                     [-half_r_center, -0.5, filling_height],
@@ -310,15 +310,15 @@ class InverseCrossTile3D(TileBase):
                     [-seperator_distance, -aux_column_width, 1.0],
                     [-branch_thickness, -branch_thickness, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_min_y_min_ctps
                 )
             )
 
-            branch_x_min_y_max_ctps = np.array(
+            branch_x_min_y_max_ctps = _np.array(
                 [
                     [-0.5, r_center, filling_height],
                     [-half_r_center, r_center, filling_height],
@@ -360,15 +360,15 @@ class InverseCrossTile3D(TileBase):
                     [-seperator_distance, 0.5, 1.0],
                     [-aux_column_width, 0.5, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_min_y_max_ctps
                 )
             )
 
-            branch_x_max_y_min_ctps = np.array(
+            branch_x_max_y_min_ctps = _np.array(
                 [
                     [r_center, -0.5, filling_height],
                     [half_r_center, -0.5, filling_height],
@@ -410,15 +410,15 @@ class InverseCrossTile3D(TileBase):
                     [seperator_distance, -aux_column_width, 1.0],
                     [0.5, -aux_column_width, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_max_y_min_ctps
                 )
             )
 
-            branch_x_max_y_max_ctps = np.array(
+            branch_x_max_y_max_ctps = _np.array(
                 [
                     [r_center, r_center, filling_height],
                     [half_r_center, r_center, filling_height],
@@ -460,10 +460,10 @@ class InverseCrossTile3D(TileBase):
                     [seperator_distance, 0.5, 1.0],
                     [0.5, 0.5, 1.0],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_max_y_max_ctps
                 )
             )
@@ -472,7 +472,7 @@ class InverseCrossTile3D(TileBase):
 
         elif closure == "z_max":
             branch_thickness = parameters.flatten()[4]
-            branch_neighbor_x_min_ctps = np.array(
+            branch_neighbor_x_min_ctps = _np.array(
                 [
                     [-0.5, -aux_column_width, 0.0],
                     [-seperator_distance, -aux_column_width, 0.0],
@@ -509,16 +509,16 @@ class InverseCrossTile3D(TileBase):
                     [-half_r_center, r_center, inv_filling_height],
                     [-r_center, r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=branch_neighbor_x_min_ctps,
                 )
             )
 
-            branch_neighbor_x_max_ctps = np.array(
+            branch_neighbor_x_max_ctps = _np.array(
                 [
                     [branch_thickness, -branch_thickness, 0.0],
                     [seperator_distance, -aux_column_width, 0.0],
@@ -555,16 +555,16 @@ class InverseCrossTile3D(TileBase):
                     [half_r_center, r_center, inv_filling_height],
                     [0.5, r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 1, 2],
                     control_points=branch_neighbor_x_max_ctps,
                 )
             )
 
-            branch_neighbor_y_min_ctps = np.array(
+            branch_neighbor_y_min_ctps = _np.array(
                 [
                     [-aux_column_width, -0.5, 0.0],
                     [aux_column_width, -0.5, 0.0],
@@ -601,16 +601,16 @@ class InverseCrossTile3D(TileBase):
                     [-r_center, -r_center, inv_filling_height],
                     [r_center, -r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=branch_neighbor_y_min_ctps,
                 )
             )
 
-            branch_neighbor_y_max_ctps = np.array(
+            branch_neighbor_y_max_ctps = _np.array(
                 [
                     [-branch_thickness, branch_thickness, 0.0],
                     [branch_thickness, branch_thickness, 0.0],
@@ -647,16 +647,16 @@ class InverseCrossTile3D(TileBase):
                     [-r_center, 0.5, inv_filling_height],
                     [r_center, 0.5, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[1, 2, 2],
                     control_points=branch_neighbor_y_max_ctps,
                 )
             )
 
-            branch_x_min_y_min_ctps = np.array(
+            branch_x_min_y_min_ctps = _np.array(
                 [
                     [-0.5, -0.5, 0.0],
                     [-seperator_distance, -0.5, 0.0],
@@ -702,15 +702,15 @@ class InverseCrossTile3D(TileBase):
                     [-half_r_center, -r_center, inv_filling_height],
                     [-r_center, -r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_min_y_min_ctps
                 )
             )
 
-            branch_x_max_y_max_ctps = np.array(
+            branch_x_max_y_max_ctps = _np.array(
                 [
                     [branch_thickness, branch_thickness, 0.0],
                     [seperator_distance, aux_column_width, 0.0],
@@ -756,15 +756,15 @@ class InverseCrossTile3D(TileBase):
                     [half_r_center, 0.5, inv_filling_height],
                     [0.5, 0.5, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_max_y_max_ctps
                 )
             )
 
-            branch_x_max_y_min_ctps = np.array(
+            branch_x_max_y_min_ctps = _np.array(
                 [
                     [aux_column_width, -0.5, 0.0],
                     [seperator_distance, -0.5, 0.0],
@@ -810,15 +810,15 @@ class InverseCrossTile3D(TileBase):
                     [half_r_center, -r_center, inv_filling_height],
                     [0.5, -r_center, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_max_y_min_ctps
                 )
             )
 
-            branch_x_min_y_max_ctps = np.array(
+            branch_x_min_y_max_ctps = _np.array(
                 [
                     [-0.5, aux_column_width, 0.0],
                     [-seperator_distance, aux_column_width, 0.0],
@@ -864,10 +864,10 @@ class InverseCrossTile3D(TileBase):
                     [-half_r_center, 0.5, inv_filling_height],
                     [-r_center, 0.5, inv_filling_height],
                 ]
-            ) + np.array([0.5, 0.5, 0.0])
+            ) + _np.array([0.5, 0.5, 0.0])
 
             spline_list.append(
-                Bezier(
+                _Bezier(
                     degrees=[2, 2, 2], control_points=branch_x_min_y_max_ctps
                 )
             )
@@ -933,7 +933,7 @@ class InverseCrossTile3D(TileBase):
         if parameters is None:
             self._logd("Setting branch thickness to default 0.2")
             parameters = (
-                np.ones(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -946,7 +946,7 @@ class InverseCrossTile3D(TileBase):
 
         self.check_params(parameters)
 
-        if np.any(parameters < min_radius) or np.any(parameters > max_radius):
+        if _np.any(parameters < min_radius) or _np.any(parameters > max_radius):
             raise ValueError(
                 f"Radii must be in (0,{max_radius}) for "
                 f"center_expansion {center_expansion}"
@@ -971,7 +971,7 @@ class InverseCrossTile3D(TileBase):
         ] = parameters.flatten()
 
         # center radius
-        center_r = np.sum(parameters) / 6.0 * center_expansion
+        center_r = _np.sum(parameters) / 6.0 * center_expansion
 
         # Auxiliary values for smooothing (mid-branch thickness)
         [
@@ -981,7 +981,7 @@ class InverseCrossTile3D(TileBase):
             aux_y_max,
             aux_z_min,
             aux_z_max,
-        ] = np.minimum(parameters.ravel(), center_r)
+        ] = _np.minimum(parameters.ravel(), center_r)
         # Branch midlength
         hd_center = 0.5 * (0.5 + center_r)
         aux_column_width = 0.5 - 2 * (0.5 - seperator_distance)
@@ -990,7 +990,7 @@ class InverseCrossTile3D(TileBase):
         spline_list = []
 
         # Start with branch interconnections
-        x_min_y_min = np.array(
+        x_min_y_min = _np.array(
             [
                 [-0.5, -0.5, -aux_column_width],
                 [-seperator_distance, -0.5, -aux_column_width],
@@ -1011,13 +1011,13 @@ class InverseCrossTile3D(TileBase):
                 [-hd_center, -aux_x_min, aux_x_min],
                 [-center_r, -center_r, center_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 1], control_points=x_min_y_min)
+            _Bezier(degrees=[2, 2, 1], control_points=x_min_y_min)
         )
 
-        x_max_y_min = np.array(
+        x_max_y_min = _np.array(
             [
                 [y_min_r, -0.5, -y_min_r],
                 [seperator_distance, -0.5, -aux_column_width],
@@ -1038,13 +1038,13 @@ class InverseCrossTile3D(TileBase):
                 [hd_center, -aux_x_max, aux_x_max],
                 [0.5, -x_max_r, x_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 1], control_points=x_max_y_min)
+            _Bezier(degrees=[2, 2, 1], control_points=x_max_y_min)
         )
 
-        x_min_y_max = np.array(
+        x_min_y_max = _np.array(
             [
                 [-0.5, x_min_r, -x_min_r],
                 [-hd_center, aux_x_min, -aux_x_min],
@@ -1065,13 +1065,13 @@ class InverseCrossTile3D(TileBase):
                 [-seperator_distance, 0.5, aux_column_width],
                 [-y_max_r, 0.5, y_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 1], control_points=x_min_y_max)
+            _Bezier(degrees=[2, 2, 1], control_points=x_min_y_max)
         )
 
-        x_max_y_max = np.array(
+        x_max_y_max = _np.array(
             [
                 [center_r, center_r, -center_r],
                 [hd_center, aux_x_max, -aux_x_max],
@@ -1092,13 +1092,13 @@ class InverseCrossTile3D(TileBase):
                 [seperator_distance, 0.5, aux_column_width],
                 [0.5, 0.5, aux_column_width],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 1], control_points=x_max_y_max)
+            _Bezier(degrees=[2, 2, 1], control_points=x_max_y_max)
         )
 
-        x_min_z_min = np.array(
+        x_min_z_min = _np.array(
             [
                 [-0.5, -aux_column_width, -0.5],
                 [-seperator_distance, -aux_column_width, -0.5],
@@ -1119,13 +1119,13 @@ class InverseCrossTile3D(TileBase):
                 [-hd_center, aux_x_min, -aux_x_min],
                 [-center_r, center_r, -center_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 1, 2], control_points=x_min_z_min)
+            _Bezier(degrees=[2, 1, 2], control_points=x_min_z_min)
         )
 
-        x_max_z_min = np.array(
+        x_max_z_min = _np.array(
             [
                 [z_min_r, -z_min_r, -0.5],
                 [seperator_distance, -aux_column_width, -0.5],
@@ -1146,13 +1146,13 @@ class InverseCrossTile3D(TileBase):
                 [hd_center, aux_x_max, -aux_x_max],
                 [0.5, x_max_r, -x_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 1, 2], control_points=x_max_z_min)
+            _Bezier(degrees=[2, 1, 2], control_points=x_max_z_min)
         )
 
-        x_min_z_max = np.array(
+        x_min_z_max = _np.array(
             [
                 [-0.5, -x_min_r, x_min_r],
                 [-hd_center, -aux_x_min, aux_x_min],
@@ -1173,13 +1173,13 @@ class InverseCrossTile3D(TileBase):
                 [-seperator_distance, aux_column_width, 0.5],
                 [-z_max_r, z_max_r, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 1, 2], control_points=x_min_z_max)
+            _Bezier(degrees=[2, 1, 2], control_points=x_min_z_max)
         )
 
-        x_max_z_max = np.array(
+        x_max_z_max = _np.array(
             [
                 [center_r, -center_r, center_r],
                 [hd_center, -aux_x_max, aux_x_max],
@@ -1200,13 +1200,13 @@ class InverseCrossTile3D(TileBase):
                 [seperator_distance, aux_column_width, 0.5],
                 [0.5, aux_column_width, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 1, 2], control_points=x_max_z_max)
+            _Bezier(degrees=[2, 1, 2], control_points=x_max_z_max)
         )
 
-        y_min_z_min = np.array(
+        y_min_z_min = _np.array(
             [
                 [-aux_column_width, -0.5, -0.5],
                 [aux_column_width, -0.5, -0.5],
@@ -1227,13 +1227,13 @@ class InverseCrossTile3D(TileBase):
                 [-center_r, -center_r, -center_r],
                 [center_r, -center_r, -center_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[1, 2, 2], control_points=y_min_z_min)
+            _Bezier(degrees=[1, 2, 2], control_points=y_min_z_min)
         )
 
-        y_max_z_min = np.array(
+        y_max_z_min = _np.array(
             [
                 [-z_min_r, z_min_r, -0.5],
                 [z_min_r, z_min_r, -0.5],
@@ -1254,13 +1254,13 @@ class InverseCrossTile3D(TileBase):
                 [-y_max_r, 0.5, -y_max_r],
                 [y_max_r, 0.5, -y_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[1, 2, 2], control_points=y_max_z_min)
+            _Bezier(degrees=[1, 2, 2], control_points=y_max_z_min)
         )
 
-        y_min_z_max = np.array(
+        y_min_z_max = _np.array(
             [
                 [-y_min_r, -0.5, y_min_r],
                 [y_min_r, -0.5, y_min_r],
@@ -1281,13 +1281,13 @@ class InverseCrossTile3D(TileBase):
                 [-z_max_r, -z_max_r, 0.5],
                 [z_max_r, -z_max_r, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[1, 2, 2], control_points=y_min_z_max)
+            _Bezier(degrees=[1, 2, 2], control_points=y_min_z_max)
         )
 
-        y_max_z_max = np.array(
+        y_max_z_max = _np.array(
             [
                 [-center_r, center_r, center_r],
                 [center_r, center_r, center_r],
@@ -1308,13 +1308,13 @@ class InverseCrossTile3D(TileBase):
                 [-aux_column_width, 0.5, 0.5],
                 [aux_column_width, 0.5, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[1, 2, 2], control_points=y_max_z_max)
+            _Bezier(degrees=[1, 2, 2], control_points=y_max_z_max)
         )
 
-        x_min_y_min_z_min = np.array(
+        x_min_y_min_z_min = _np.array(
             [
                 [-0.5, -0.5, -0.5],
                 [-seperator_distance, -0.5, -0.5],
@@ -1344,13 +1344,13 @@ class InverseCrossTile3D(TileBase):
                 [-hd_center, -aux_x_min, -aux_x_min],
                 [-center_r, -center_r, -center_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_min_y_min_z_min)
+            _Bezier(degrees=[2, 2, 2], control_points=x_min_y_min_z_min)
         )
 
-        x_max_y_min_z_min = np.array(
+        x_max_y_min_z_min = _np.array(
             [
                 [aux_column_width, -0.5, -0.5],
                 [seperator_distance, -0.5, -0.5],
@@ -1380,13 +1380,13 @@ class InverseCrossTile3D(TileBase):
                 [hd_center, -aux_x_max, -aux_x_max],
                 [0.5, -x_max_r, -x_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_max_y_min_z_min)
+            _Bezier(degrees=[2, 2, 2], control_points=x_max_y_min_z_min)
         )
 
-        x_min_y_max_z_min = np.array(
+        x_min_y_max_z_min = _np.array(
             [
                 [-0.5, aux_column_width, -0.5],
                 [-seperator_distance, aux_column_width, -0.5],
@@ -1416,13 +1416,13 @@ class InverseCrossTile3D(TileBase):
                 [-seperator_distance, 0.5, -aux_column_width],
                 [-y_max_r, 0.5, -y_max_r],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_min_y_max_z_min)
+            _Bezier(degrees=[2, 2, 2], control_points=x_min_y_max_z_min)
         )
 
-        x_max_y_max_z_min = np.array(
+        x_max_y_max_z_min = _np.array(
             [
                 [z_min_r, z_min_r, -0.5],
                 [seperator_distance, aux_column_width, -0.5],
@@ -1452,13 +1452,13 @@ class InverseCrossTile3D(TileBase):
                 [seperator_distance, 0.5, -aux_column_width],
                 [0.5, 0.5, -aux_column_width],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_min)
+            _Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_min)
         )
 
-        x_min_y_min_z_max = np.array(
+        x_min_y_min_z_max = _np.array(
             [
                 [-0.5, -0.5, aux_column_width],
                 [-seperator_distance, -0.5, aux_column_width],
@@ -1488,13 +1488,13 @@ class InverseCrossTile3D(TileBase):
                 [-seperator_distance, -aux_column_width, 0.5],
                 [-z_max_r, -z_max_r, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_min_y_min_z_max)
+            _Bezier(degrees=[2, 2, 2], control_points=x_min_y_min_z_max)
         )
 
-        x_max_y_min_z_max = np.array(
+        x_max_y_min_z_max = _np.array(
             [
                 [y_min_r, -0.5, y_min_r],
                 [seperator_distance, -0.5, aux_column_width],
@@ -1524,13 +1524,13 @@ class InverseCrossTile3D(TileBase):
                 [seperator_distance, -aux_column_width, 0.5],
                 [0.5, -aux_column_width, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_max_y_min_z_max)
+            _Bezier(degrees=[2, 2, 2], control_points=x_max_y_min_z_max)
         )
 
-        x_min_y_max_z_max = np.array(
+        x_min_y_max_z_max = _np.array(
             [
                 [-0.5, x_min_r, x_min_r],
                 [-hd_center, aux_x_min, aux_x_min],
@@ -1560,13 +1560,13 @@ class InverseCrossTile3D(TileBase):
                 [-seperator_distance, 0.5, 0.5],
                 [-aux_column_width, 0.5, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_min_y_max_z_max)
+            _Bezier(degrees=[2, 2, 2], control_points=x_min_y_max_z_max)
         )
 
-        x_max_y_max_z_max = np.array(
+        x_max_y_max_z_max = _np.array(
             [
                 [center_r, center_r, center_r],
                 [hd_center, aux_x_max, aux_x_max],
@@ -1596,10 +1596,10 @@ class InverseCrossTile3D(TileBase):
                 [seperator_distance, 0.5, 0.5],
                 [0.5, 0.5, 0.5],
             ]
-        ) + np.array([0.5, 0.5, 0.5])
+        ) + _np.array([0.5, 0.5, 0.5])
 
         spline_list.append(
-            Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_max)
+            _Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_max)
         )
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/nuttile2d.py
+++ b/splinepy/microstructure/tiles/nuttile2d.py
@@ -390,7 +390,9 @@ class NutTile2D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(
+            _Bezier(degrees=[1, 1], control_points=bottom_right)
+        )
 
         return (spline_list, None)
 
@@ -561,6 +563,8 @@ class NutTile2D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(
+            _Bezier(degrees=[1, 1], control_points=bottom_right)
+        )
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/nuttile2d.py
+++ b/splinepy/microstructure/tiles/nuttile2d.py
@@ -1,14 +1,14 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class NutTile2D(TileBase):
+class NutTile2D(_TileBase):
     def __init__(self):
         """Simple tile - looks like a nut"""
         self._dim = 2
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5],
             ]
@@ -49,14 +49,14 @@ class NutTile2D(TileBase):
 
         if parameters is None:
             self._log("Tile request is not parametrized, setting default 0.2")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
             )
 
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -83,7 +83,7 @@ class NutTile2D(TileBase):
 
         if closure == "x_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -92,7 +92,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -101,7 +101,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -110,7 +110,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, v_zero],
@@ -119,7 +119,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, v_zero],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -128,7 +128,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_one],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -137,7 +137,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -146,7 +146,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -156,7 +156,7 @@ class NutTile2D(TileBase):
             )
 
         elif closure == "x_max":
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, v_zero],
@@ -165,7 +165,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_one],
@@ -174,7 +174,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -183,7 +183,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -192,7 +192,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -201,7 +201,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -210,7 +210,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -219,7 +219,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -230,7 +230,7 @@ class NutTile2D(TileBase):
 
         elif closure == "y_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -239,7 +239,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -248,7 +248,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -257,7 +257,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -266,7 +266,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -275,7 +275,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -284,7 +284,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_one, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -293,7 +293,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_one, v_zero],
@@ -304,7 +304,7 @@ class NutTile2D(TileBase):
 
         elif closure == "y_max":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -313,7 +313,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -322,7 +322,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_one, v_one],
@@ -331,7 +331,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -340,7 +340,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -349,7 +349,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -358,7 +358,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -367,7 +367,7 @@ class NutTile2D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -376,21 +376,21 @@ class NutTile2D(TileBase):
                 ]
             )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
 
         return (spline_list, None)
 
@@ -438,8 +438,8 @@ class NutTile2D(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -453,7 +453,7 @@ class NutTile2D(TileBase):
         self.check_params(parameters)
 
         v_h_void = parameters[0, 0]
-        if not (np.all(parameters > 0) and np.all(parameters < 0.5)):
+        if not (_np.all(parameters > 0) and _np.all(parameters < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -475,7 +475,7 @@ class NutTile2D(TileBase):
         spline_list = []
 
         # set points:
-        right = np.array(
+        right = _np.array(
             [
                 [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                 [v_one, -v_outer_c_h + v_one_half],
@@ -484,7 +484,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        right_top = np.array(
+        right_top = _np.array(
             [
                 [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                 [v_one, v_outer_c_h + v_one_half],
@@ -493,7 +493,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        top = np.array(
+        top = _np.array(
             [
                 [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                 [v_outer_c_h + v_one_half, v_one],
@@ -502,7 +502,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom_left = np.array(
+        bottom_left = _np.array(
             [
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                 [v_zero, -v_outer_c_h + v_one_half],
@@ -511,7 +511,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        left = np.array(
+        left = _np.array(
             [
                 [v_zero, -v_outer_c_h + v_one_half],
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -520,7 +520,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        top_left = np.array(
+        top_left = _np.array(
             [
                 [v_zero, v_outer_c_h + v_one_half],
                 [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -529,7 +529,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom = np.array(
+        bottom = _np.array(
             [
                 [v_outer_c_h + v_one_half, v_zero],
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -538,7 +538,7 @@ class NutTile2D(TileBase):
             ]
         )
 
-        bottom_right = np.array(
+        bottom_right = _np.array(
             [
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                 [v_outer_c_h + v_one_half, v_zero],
@@ -547,20 +547,20 @@ class NutTile2D(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/nuttile3d.py
+++ b/splinepy/microstructure/tiles/nuttile3d.py
@@ -189,7 +189,9 @@ class NutTile3D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right))
 
-        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right_top))
+        spline_list.append(
+            _Bezier(degrees=[1, 1, 1], control_points=right_top)
+        )
 
         spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=bottom))
 
@@ -587,6 +589,8 @@ class NutTile3D(_TileBase):
 
         spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(
+            _Bezier(degrees=[1, 1], control_points=bottom_right)
+        )
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/nuttile3d.py
+++ b/splinepy/microstructure/tiles/nuttile3d.py
@@ -1,14 +1,14 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class NutTile3D(TileBase):
+class NutTile3D(_TileBase):
     def __init__(self):
         """Simple tile - looks like a nut"""
         self._dim = 3
-        self._evaluation_points = np.array(
+        self._evaluation_points = _np.array(
             [
                 [0.5, 0.5, 0.5],
             ]
@@ -54,8 +54,8 @@ class NutTile3D(TileBase):
 
         if parameters is None:
             self._logd("Setting parameters to default values (0.2)")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
@@ -83,7 +83,7 @@ class NutTile3D(TileBase):
         spline_list = []
 
         # set points:
-        right = np.array(
+        right = _np.array(
             [
                 [v_h_void + v_one_half, -v_inner_c_h + v_one_half, v_zero],
                 [v_one, -v_outer_c_h + v_one_half, 0.0],
@@ -96,7 +96,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        right_top = np.array(
+        right_top = _np.array(
             [
                 [v_h_void + v_one_half, v_inner_c_h + v_one_half, v_zero],
                 [v_one, v_outer_c_h + v_one_half, v_zero],
@@ -109,7 +109,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        top = np.array(
+        top = _np.array(
             [
                 [v_inner_c_h + v_one_half, v_h_void + v_one_half, v_zero],
                 [v_outer_c_h + v_one_half, v_one, v_zero],
@@ -122,7 +122,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        bottom_left = np.array(
+        bottom_left = _np.array(
             [
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half, v_zero],
                 [v_zero, -v_outer_c_h + v_one_half, v_zero],
@@ -135,7 +135,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        left = np.array(
+        left = _np.array(
             [
                 [v_zero, -v_outer_c_h + v_one_half, v_zero],
                 [-v_h_void + v_one_half, -v_inner_c_h + v_one_half, v_zero],
@@ -148,7 +148,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        top_left = np.array(
+        top_left = _np.array(
             [
                 [v_zero, v_outer_c_h + v_one_half, v_zero],
                 [-v_h_void + v_one_half, v_inner_c_h + v_one_half, v_zero],
@@ -161,7 +161,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        bottom = np.array(
+        bottom = _np.array(
             [
                 [v_outer_c_h + v_one_half, v_zero, v_zero],
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half, v_zero],
@@ -174,7 +174,7 @@ class NutTile3D(TileBase):
             ]
         )
 
-        bottom_right = np.array(
+        bottom_right = _np.array(
             [
                 [v_inner_c_h + v_one_half, -v_h_void + v_one_half, v_zero],
                 [v_outer_c_h + v_one_half, v_zero, v_zero],
@@ -187,24 +187,24 @@ class NutTile3D(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=bottom))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=bottom_left)
+            _Bezier(degrees=[1, 1, 1], control_points=bottom_left)
         )
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1, 1], control_points=top))
 
         spline_list.append(
-            Bezier(degrees=[1, 1, 1], control_points=bottom_right)
+            _Bezier(degrees=[1, 1, 1], control_points=bottom_right)
         )
 
         return (spline_list, None)
@@ -246,14 +246,14 @@ class NutTile3D(TileBase):
 
         if parameters is None:
             self._log("Tile request is not parametrized, setting default 0.2")
-            parameters = np.array(
-                np.ones(
+            parameters = _np.array(
+                _np.ones(
                     (len(self._evaluation_points), self._n_info_per_eval_point)
                 )
                 * 0.2
             )
 
-        if not (np.all(parameters[0] > 0) and np.all(parameters[0] < 0.5)):
+        if not (_np.all(parameters[0] > 0) and _np.all(parameters[0] < 0.5)):
             raise ValueError(
                 "The thickness of the wall must be in (0.01 and 0.49)"
             )
@@ -280,7 +280,7 @@ class NutTile3D(TileBase):
 
         if closure == "x_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -289,7 +289,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -298,7 +298,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -307,7 +307,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, v_zero],
@@ -316,7 +316,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, v_zero],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -325,7 +325,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_one],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -334,7 +334,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -343,7 +343,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -353,7 +353,7 @@ class NutTile3D(TileBase):
             )
 
         elif closure == "x_max":
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, v_zero],
@@ -362,7 +362,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_one],
@@ -371,7 +371,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -380,7 +380,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -389,7 +389,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -398,7 +398,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -407,7 +407,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -416,7 +416,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -427,7 +427,7 @@ class NutTile3D(TileBase):
 
         elif closure == "y_min":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -436,7 +436,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -445,7 +445,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_one],
@@ -454,7 +454,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -463,7 +463,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -472,7 +472,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -481,7 +481,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_one, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -490,7 +490,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_one, v_zero],
@@ -501,7 +501,7 @@ class NutTile3D(TileBase):
 
         elif closure == "y_max":
             # set points:
-            right = np.array(
+            right = _np.array(
                 [
                     [v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_one, -v_outer_c_h + v_one_half],
@@ -510,7 +510,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            right_top = np.array(
+            right_top = _np.array(
                 [
                     [v_h_void + v_one_half, v_inner_c_h + v_one_half],
                     [v_one, v_outer_c_h + v_one_half],
@@ -519,7 +519,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top = np.array(
+            top = _np.array(
                 [
                     [v_inner_c_h + v_one_half, v_h_void + v_one_half],
                     [v_one, v_one],
@@ -528,7 +528,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_left = np.array(
+            bottom_left = _np.array(
                 [
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
                     [v_zero, -v_outer_c_h + v_one_half],
@@ -537,7 +537,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            left = np.array(
+            left = _np.array(
                 [
                     [v_zero, -v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, -v_inner_c_h + v_one_half],
@@ -546,7 +546,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            top_left = np.array(
+            top_left = _np.array(
                 [
                     [v_zero, v_outer_c_h + v_one_half],
                     [-v_h_void + v_one_half, v_inner_c_h + v_one_half],
@@ -555,7 +555,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom = np.array(
+            bottom = _np.array(
                 [
                     [v_outer_c_h + v_one_half, v_zero],
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
@@ -564,7 +564,7 @@ class NutTile3D(TileBase):
                 ]
             )
 
-            bottom_right = np.array(
+            bottom_right = _np.array(
                 [
                     [v_inner_c_h + v_one_half, -v_h_void + v_one_half],
                     [v_outer_c_h + v_one_half, v_zero],
@@ -573,20 +573,20 @@ class NutTile3D(TileBase):
                 ]
             )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=right_top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=right_top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top_left))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top_left))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=top))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=top))
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=bottom_right))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=bottom_right))
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/snappytile.py
+++ b/splinepy/microstructure/tiles/snappytile.py
@@ -1,16 +1,16 @@
-import numpy as np
+import numpy as _np
 
-from splinepy.bezier import Bezier
-from splinepy.microstructure.tiles.tilebase import TileBase
+from splinepy.bezier import Bezier as _Bezier
+from splinepy.microstructure.tiles.tilebase import TileBase as _TileBase
 
 
-class SnappyTile(TileBase):
+class SnappyTile(_TileBase):
     def __init__(self):
         """Snap-through tile consisting of a thin truss and a thick truss that
         collide into each other"""
         self._dim = 2
         # Dummy point
-        self._evaluation_points = np.array([[0.5, 0.5]])
+        self._evaluation_points = _np.array([[0.5, 0.5]])
         self._n_info_per_eval_point = 1
 
     def _closing_tile(
@@ -70,7 +70,7 @@ class SnappyTile(TileBase):
 
         if closure == "y_min":
             # set points:
-            spline_1 = np.array(
+            spline_1 = _np.array(
                 [
                     [v_zero, v_zero],
                     [cl_2, v_zero],
@@ -79,8 +79,8 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_1))
-            spline_2 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_1))
+            spline_2 = _np.array(
                 [
                     [cl_2_inv, v_zero],
                     [v_one, v_zero],
@@ -89,8 +89,8 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_2))
-            spline_3 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_2))
+            spline_3 = _np.array(
                 [
                     [v_zero, a_inv],
                     [cl_2, a_inv],
@@ -99,8 +99,8 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_3))
-            spline_4 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_3))
+            spline_4 = _np.array(
                 [
                     [cl_2_inv, a_inv],
                     [v_one, a_inv],
@@ -109,9 +109,9 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_4))
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_4))
 
-            spline_5 = np.array(
+            spline_5 = _np.array(
                 [
                     [v_one_half - cl_2, v_zero],
                     [v_one_half + cl_2, v_zero],
@@ -120,9 +120,9 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_5))
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_5))
 
-            spline_6 = np.array(
+            spline_6 = _np.array(
                 [
                     [v_one_half - cl_2, v_one_half],
                     [v_one_half + cl_2, v_one_half],
@@ -131,9 +131,9 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_6))
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_6))
 
-            spline_7 = np.array(
+            spline_7 = _np.array(
                 [
                     [cl_2, v_zero],
                     [cl_2 + r, v_zero],
@@ -146,9 +146,9 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[3, 1], control_points=spline_7))
+            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_7))
 
-            spline_8 = np.array(
+            spline_8 = _np.array(
                 [
                     [cl_2, v_zero],
                     [cl_2 + r, v_zero],
@@ -161,9 +161,9 @@ class SnappyTile(TileBase):
                 ]
             ) + [v_one_half, v_zero]
 
-            spline_list.append(Bezier(degrees=[3, 1], control_points=spline_8))
+            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_8))
 
-            spline_9 = np.array(
+            spline_9 = _np.array(
                 [
                     [cl_2, a_inv],
                     [cl_2 + r, a_inv],
@@ -176,9 +176,9 @@ class SnappyTile(TileBase):
                 ]
             )
 
-            spline_list.append(Bezier(degrees=[3, 1], control_points=spline_9))
+            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_9))
 
-            spline_10 = np.array(
+            spline_10 = _np.array(
                 [
                     [cl_2, v_one_half],
                     [cl_2 + r, v_one_half],
@@ -192,11 +192,11 @@ class SnappyTile(TileBase):
             ) + [v_one_half, v_zero]
 
             spline_list.append(
-                Bezier(degrees=[3, 1], control_points=spline_10)
+                _Bezier(degrees=[3, 1], control_points=spline_10)
             )
             return spline_list
         elif closure == "y_max":
-            spline_1 = np.array(
+            spline_1 = _np.array(
                 [
                     [v_zero, v_zero],
                     [cl_2, v_zero],
@@ -204,8 +204,8 @@ class SnappyTile(TileBase):
                     [cl_2, v_one],
                 ]
             )
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_1))
-            spline_2 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_1))
+            spline_2 = _np.array(
                 [
                     [cl_2_inv, v_zero],
                     [v_one, v_zero],
@@ -213,8 +213,8 @@ class SnappyTile(TileBase):
                     [v_one, v_one],
                 ]
             )
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_2))
-            spline_3 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_2))
+            spline_3 = _np.array(
                 [
                     [v_one_half - cl_2, v_one_half - b],
                     [v_one_half + cl_2, v_one_half - b],
@@ -222,8 +222,8 @@ class SnappyTile(TileBase):
                     [v_one_half + cl_2, v_one],
                 ]
             )
-            spline_list.append(Bezier(degrees=[1, 1], control_points=spline_3))
-            spline_4 = np.array(
+            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_3))
+            spline_4 = _np.array(
                 [
                     [cl_2, v_zero],
                     [cl_2 + r, v_zero],
@@ -235,8 +235,8 @@ class SnappyTile(TileBase):
                     [v_one_half - cl_2, v_one],
                 ]
             )
-            spline_list.append(Bezier(degrees=[3, 1], control_points=spline_4))
-            spline_5 = np.array(
+            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_4))
+            spline_5 = _np.array(
                 [
                     [cl_2, v_one_half - b],
                     [cl_2 + r, v_one_half - b],
@@ -249,7 +249,7 @@ class SnappyTile(TileBase):
                 ]
             ) + [v_one_half, v_zero]
 
-            spline_list.append(Bezier(degrees=[3, 1], control_points=spline_5))
+            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_5))
             return (spline_list, None)
         else:
             raise ValueError(
@@ -356,7 +356,7 @@ class SnappyTile(TileBase):
         spline_list = []
 
         # set points:
-        spline_1 = np.array(
+        spline_1 = _np.array(
             [
                 [v_zero, v_zero],
                 [cl_2, v_zero],
@@ -365,8 +365,8 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_1))
-        spline_2 = np.array(
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_1))
+        spline_2 = _np.array(
             [
                 [cl_2_inv, v_zero],
                 [v_one, v_zero],
@@ -375,8 +375,8 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_2))
-        spline_3 = np.array(
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_2))
+        spline_3 = _np.array(
             [
                 [v_zero, a_inv],
                 [cl_2, a_inv],
@@ -385,8 +385,8 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_3))
-        spline_4 = np.array(
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_3))
+        spline_4 = _np.array(
             [
                 [cl_2_inv, a_inv],
                 [v_one, a_inv],
@@ -395,9 +395,9 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_4))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_4))
 
-        spline_5 = np.array(
+        spline_5 = _np.array(
             [
                 [v_one_half - cl_2, v_one_half - b],
                 [v_one_half + cl_2, v_one_half - b],
@@ -406,9 +406,9 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_5))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_5))
 
-        spline_6 = np.array(
+        spline_6 = _np.array(
             [
                 [v_one_half - cl_2, v_one_half],
                 [v_one_half + cl_2, v_one_half],
@@ -417,9 +417,9 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[1, 1], control_points=spline_6))
+        spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_6))
 
-        spline_7 = np.array(
+        spline_7 = _np.array(
             [
                 [cl_2, v_zero],
                 [cl_2 + r, v_zero],
@@ -432,9 +432,9 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[3, 1], control_points=spline_7))
+        spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_7))
 
-        spline_8 = np.array(
+        spline_8 = _np.array(
             [
                 [cl_2, v_one_half - b],
                 [cl_2 + r, v_one_half - b],
@@ -447,9 +447,9 @@ class SnappyTile(TileBase):
             ]
         ) + [v_one_half, v_zero]
 
-        spline_list.append(Bezier(degrees=[3, 1], control_points=spline_8))
+        spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_8))
 
-        spline_9 = np.array(
+        spline_9 = _np.array(
             [
                 [cl_2, a_inv],
                 [cl_2 + r, a_inv],
@@ -462,9 +462,9 @@ class SnappyTile(TileBase):
             ]
         )
 
-        spline_list.append(Bezier(degrees=[3, 1], control_points=spline_9))
+        spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_9))
 
-        spline_10 = np.array(
+        spline_10 = _np.array(
             [
                 [cl_2, v_one_half],
                 [cl_2 + r, v_one_half],
@@ -477,6 +477,6 @@ class SnappyTile(TileBase):
             ]
         ) + [v_one_half, v_zero]
 
-        spline_list.append(Bezier(degrees=[3, 1], control_points=spline_10))
+        spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_10))
 
         return (spline_list, None)

--- a/splinepy/microstructure/tiles/snappytile.py
+++ b/splinepy/microstructure/tiles/snappytile.py
@@ -79,7 +79,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_1))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_1)
+            )
             spline_2 = _np.array(
                 [
                     [cl_2_inv, v_zero],
@@ -89,7 +91,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_2))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_2)
+            )
             spline_3 = _np.array(
                 [
                     [v_zero, a_inv],
@@ -99,7 +103,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_3))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_3)
+            )
             spline_4 = _np.array(
                 [
                     [cl_2_inv, a_inv],
@@ -109,7 +115,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_4))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_4)
+            )
 
             spline_5 = _np.array(
                 [
@@ -120,7 +128,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_5))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_5)
+            )
 
             spline_6 = _np.array(
                 [
@@ -131,7 +141,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_6))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_6)
+            )
 
             spline_7 = _np.array(
                 [
@@ -146,7 +158,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_7))
+            spline_list.append(
+                _Bezier(degrees=[3, 1], control_points=spline_7)
+            )
 
             spline_8 = _np.array(
                 [
@@ -161,7 +175,9 @@ class SnappyTile(_TileBase):
                 ]
             ) + [v_one_half, v_zero]
 
-            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_8))
+            spline_list.append(
+                _Bezier(degrees=[3, 1], control_points=spline_8)
+            )
 
             spline_9 = _np.array(
                 [
@@ -176,7 +192,9 @@ class SnappyTile(_TileBase):
                 ]
             )
 
-            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_9))
+            spline_list.append(
+                _Bezier(degrees=[3, 1], control_points=spline_9)
+            )
 
             spline_10 = _np.array(
                 [
@@ -204,7 +222,9 @@ class SnappyTile(_TileBase):
                     [cl_2, v_one],
                 ]
             )
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_1))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_1)
+            )
             spline_2 = _np.array(
                 [
                     [cl_2_inv, v_zero],
@@ -213,7 +233,9 @@ class SnappyTile(_TileBase):
                     [v_one, v_one],
                 ]
             )
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_2))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_2)
+            )
             spline_3 = _np.array(
                 [
                     [v_one_half - cl_2, v_one_half - b],
@@ -222,7 +244,9 @@ class SnappyTile(_TileBase):
                     [v_one_half + cl_2, v_one],
                 ]
             )
-            spline_list.append(_Bezier(degrees=[1, 1], control_points=spline_3))
+            spline_list.append(
+                _Bezier(degrees=[1, 1], control_points=spline_3)
+            )
             spline_4 = _np.array(
                 [
                     [cl_2, v_zero],
@@ -235,7 +259,9 @@ class SnappyTile(_TileBase):
                     [v_one_half - cl_2, v_one],
                 ]
             )
-            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_4))
+            spline_list.append(
+                _Bezier(degrees=[3, 1], control_points=spline_4)
+            )
             spline_5 = _np.array(
                 [
                     [cl_2, v_one_half - b],
@@ -249,7 +275,9 @@ class SnappyTile(_TileBase):
                 ]
             ) + [v_one_half, v_zero]
 
-            spline_list.append(_Bezier(degrees=[3, 1], control_points=spline_5))
+            spline_list.append(
+                _Bezier(degrees=[3, 1], control_points=spline_5)
+            )
             return (spline_list, None)
         else:
             raise ValueError(

--- a/splinepy/microstructure/tiles/tilebase.py
+++ b/splinepy/microstructure/tiles/tilebase.py
@@ -98,7 +98,9 @@ class TileBase(_SplinepyBase):
         if derivatives is None:
             return False
 
-        if not (isinstance(derivatives, _np.ndarray) and derivatives.ndim == 3):
+        if not (
+            isinstance(derivatives, _np.ndarray) and derivatives.ndim == 3
+        ):
             raise TypeError("parameters must be three-dimensional np array")
 
         if not (

--- a/splinepy/microstructure/tiles/tilebase.py
+++ b/splinepy/microstructure/tiles/tilebase.py
@@ -1,9 +1,9 @@
-import numpy as np
+import numpy as _np
 
-from splinepy._base import SplinepyBase
+from splinepy._base import SplinepyBase as _SplinepyBase
 
 
-class TileBase(SplinepyBase):
+class TileBase(_SplinepyBase):
     """
     Base class for tile objects
     """
@@ -68,7 +68,7 @@ class TileBase(SplinepyBase):
         """
         # check if tuple
 
-        if not (isinstance(params, np.ndarray) and params.ndim == 2):
+        if not (isinstance(params, _np.ndarray) and params.ndim == 2):
             raise TypeError("parameters must be two-dimensional np array")
 
         if not (
@@ -98,7 +98,7 @@ class TileBase(SplinepyBase):
         if derivatives is None:
             return False
 
-        if not (isinstance(derivatives, np.ndarray) and derivatives.ndim == 3):
+        if not (isinstance(derivatives, _np.ndarray) and derivatives.ndim == 3):
             raise TypeError("parameters must be three-dimensional np array")
 
         if not (

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -2,18 +2,20 @@
 Multipatch Spline Configuration
 """
 
-import numpy as np
+import numpy as _np
 
-from splinepy import settings
-from splinepy._base import SplinepyBase
-from splinepy.helpme import visualize
-from splinepy.helpme.extract import Extractor
-from splinepy.spline import _default_if_none, _get_helper
-from splinepy.splinepy_core import PyMultipatch, boundaries_from_continuity
-from splinepy.utils.data import MultipatchData
+from splinepy import settings as _settings
+from splinepy._base import SplinepyBase as _SplinepyBase
+from splinepy.helpme import visualize as _visualize
+from splinepy.helpme.extract import Extractor as _Extractor
+from splinepy.spline import _default_if_none
+from splinepy.spline import _get_helper
+from splinepy.splinepy_core import PyMultipatch as _PyMultipatch
+from splinepy.splinepy_core import boundaries_from_continuity as _boundaries_from_continuity
+from splinepy.utils.data import MultipatchData as _MultipatchData
 
 
-class Multipatch(SplinepyBase, PyMultipatch):
+class Multipatch(_SplinepyBase, _PyMultipatch):
     """
     System of patches to store information such as boundaries and
     interfaces
@@ -25,7 +27,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         "_spline_data",
     )
 
-    __show_option__ = visualize.SplineShowOption
+    __show_option__ = _visualize.SplineShowOption
 
     def __init__(self, splines=None, interfaces=None, *, spline=None):
         """
@@ -47,11 +49,11 @@ class Multipatch(SplinepyBase, PyMultipatch):
         """
         # Init values
         if spline is not None:
-            if not isinstance(spline, PyMultipatch):
+            if not isinstance(spline, _PyMultipatch):
                 raise TypeError("spline must be PyMultipatch.")
             super().__init__(spline)
         elif splines is not None:
-            super().__init__(splines, settings.NTHREADS, False)
+            super().__init__(splines, _settings.NTHREADS, False)
         else:
             super().__init__()
 
@@ -76,7 +78,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
 
     @patches.setter
     def patches(self, list_of_splines):
-        PyMultipatch.patches.fset(self, list_of_splines)
+        _PyMultipatch.patches.fset(self, list_of_splines)
 
     @property
     def interfaces(self):
@@ -144,7 +146,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         boundary_list = []
         for i_bid in range(-1, max_BID - 1, -1):
             self._logd(f"Extracting boundary with ID {abs(i_bid)}")
-            boundary_list.append(np.where(self.interfaces == i_bid))
+            boundary_list.append(_np.where(self.interfaces == i_bid))
             self._logd(
                 f"Found {boundary_list[-1][1].size} boundary "
                 f"elements on boundary {abs(i_bid)}"
@@ -167,7 +169,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
           Embedded splines representing boundaries of system
         """
         if nthreads is None:
-            nthreads = settings.NTHREADS
+            nthreads = _settings.NTHREADS
 
         # apply nthreads
         previous_nthreads = self.n_default_threads
@@ -290,7 +292,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         interfaces : array-like (n_patch x n_boundaries)
         """
         if tolerance is None:
-            tolerance = settings.TOLERANCE
+            tolerance = _settings.TOLERANCE
 
         # save previous default tol
         previous_tol = self.tolerance
@@ -351,7 +353,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         if mask is None:
             boundary_ids = self.interfaces < 0
         else:
-            boundary_ids = np.isin(-self.interfaces, np.abs(mask))
+            boundary_ids = _np.isin(-self.interfaces, _np.abs(mask))
 
         # Check if there is a boundary
         if not boundary_ids.any():
@@ -367,7 +369,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         ]
 
         # Cols and Rows
-        row_ids, col_ids = np.where(boundary_ids)
+        row_ids, col_ids = _np.where(boundary_ids)
 
         # Function is applied to all face centers
         try:
@@ -397,7 +399,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         -------
         spline_data: MultipatchData
         """
-        return _get_helper(self, "_spline_data", MultipatchData)
+        return _get_helper(self, "_spline_data", _MultipatchData)
 
     @property
     def show_options(self):
@@ -432,10 +434,10 @@ class Multipatch(SplinepyBase, PyMultipatch):
         -------
         spline_showable: dict
         """
-        return visualize.show(self, return_showable=True, **kwargs)
+        return _visualize.show(self, return_showable=True, **kwargs)
 
     def show(self, **kwargs):
-        return visualize.show(self, **kwargs)
+        return _visualize.show(self, **kwargs)
 
     def boundaries_from_continuity(
         self,
@@ -459,14 +461,14 @@ class Multipatch(SplinepyBase, PyMultipatch):
         None
         """
         if tolerance is None:
-            tolerance = settings.TOLERANCE
+            tolerance = _settings.TOLERANCE
         if nthreads is None:
-            nthreads = settings.NTHREADS
+            nthreads = _settings.NTHREADS
         b_patches = self.boundary_multipatch(nthreads=nthreads)
 
         # Pass information to c++ backend
         self._logd("Start propagation of information...")
-        n_new_boundaries = boundaries_from_continuity(
+        n_new_boundaries = _boundaries_from_continuity(
             b_patches.patches,
             b_patches.interfaces,
             self.interfaces,
@@ -490,7 +492,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         None
         """
         # retrieve all boundary elements
-        boundary_ids = np.isin(-self.interfaces, np.abs(mask))
+        boundary_ids = _np.isin(-self.interfaces, _np.abs(mask))
 
         if not boundary_ids.any():
             self._logd(
@@ -499,7 +501,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
             )
             return None
 
-        self.interfaces[boundary_ids] = np.min(mask)
+        self.interfaces[boundary_ids] = _np.min(mask)
 
     def add_fields(
         self,
@@ -533,7 +535,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         None
         """
         if nthreads is None:
-            nthreads = settings.NTHREADS
+            nthreads = _settings.NTHREADS
 
         super().add_fields(
             fields,
@@ -588,7 +590,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
         )
         return super().sample(
             resolutions,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
             same_parametric_bounds=False,
         )
 
@@ -610,7 +612,7 @@ class Multipatch(SplinepyBase, PyMultipatch):
 
         return super().evaluate(
             queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     @property
@@ -626,4 +628,4 @@ class Multipatch(SplinepyBase, PyMultipatch):
         --------
         extractor: Extractor
         """
-        return _get_helper(self, "_extractor", Extractor)
+        return _get_helper(self, "_extractor", _Extractor)

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -8,10 +8,11 @@ from splinepy import settings as _settings
 from splinepy._base import SplinepyBase as _SplinepyBase
 from splinepy.helpme import visualize as _visualize
 from splinepy.helpme.extract import Extractor as _Extractor
-from splinepy.spline import _default_if_none
-from splinepy.spline import _get_helper
+from splinepy.spline import _default_if_none, _get_helper
 from splinepy.splinepy_core import PyMultipatch as _PyMultipatch
-from splinepy.splinepy_core import boundaries_from_continuity as _boundaries_from_continuity
+from splinepy.splinepy_core import (
+    boundaries_from_continuity as _boundaries_from_continuity,
+)
 from splinepy.utils.data import MultipatchData as _MultipatchData
 
 

--- a/splinepy/nurbs.py
+++ b/splinepy/nurbs.py
@@ -1,7 +1,7 @@
-from splinepy.bspline import BSplineBase
+from splinepy.bspline import BSplineBase as _BSplineBase
 
 
-class NURBS(BSplineBase):
+class NURBS(_BSplineBase):
     r"""
     Non-Uniform Rational B-Spline.
 

--- a/splinepy/rational_bezier.py
+++ b/splinepy/rational_bezier.py
@@ -1,8 +1,9 @@
-from splinepy import settings, splinepy_core
-from splinepy.bezier import BezierBase
+from splinepy import settings as _settings
+from splinepy import splinepy_core as _splinepy_core
+from splinepy.bezier import BezierBase as _BezierBase
 
 
-class RationalBezier(BezierBase):
+class RationalBezier(_BezierBase):
     r"""
     RationalBezier (Spline).
 
@@ -132,6 +133,6 @@ class RationalBezier(BezierBase):
 
     @property
     def nurbs(self):
-        return settings.NAME_TO_TYPE["NURBS"](
-            spline=splinepy_core.same_spline_with_knot_vectors(self)
+        return _settings.NAME_TO_TYPE["NURBS"](
+            spline=_splinepy_core.same_spline_with_knot_vectors(self)
         )

--- a/splinepy/settings.py
+++ b/splinepy/settings.py
@@ -7,14 +7,18 @@ def __splinepy_name_to_type__():
     """Workaround to provide flexible string to type conversion without
     causing circular import
     """
-    from splinepy import NURBS, Bezier, BSpline, Multipatch, RationalBezier
+    from splinepy import NURBS as _NURBS
+    from splinepy import Bezier as _Bezier
+    from splinepy import BSpline as _BSpline
+    from splinepy import Multipatch as _Multipatch
+    from splinepy import RationalBezier as _RationalBezier
 
     return {
-        "Bezier": Bezier,
-        "RationalBezier": RationalBezier,
-        "BSpline": BSpline,
-        "NURBS": NURBS,
-        "Multipatch": Multipatch,
+        "Bezier": _Bezier,
+        "RationalBezier": _RationalBezier,
+        "BSpline": _BSpline,
+        "NURBS": _NURBS,
+        "Multipatch": _Multipatch,
     }
 
 

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1,23 +1,27 @@
 """
 Abstract Spline
 """
-import copy
-import os
+import copy as _copy
+import os as _os
 
-import numpy as np
+import numpy as _np
 
-from splinepy import helpme, io, settings, utils
-from splinepy import splinepy_core as core
-from splinepy._base import SplinepyBase
-from splinepy.helpme import visualize
-from splinepy.helpme.check import Checker
-from splinepy.helpme.create import Creator
-from splinepy.helpme.extract import Extractor
-from splinepy.helpme.integrate import Integrator
-from splinepy.utils.data import SplineData, cartesian_product
+from splinepy import helpme as _helpme
+from splinepy import io as _io
+from splinepy import settings as _settings
+from splinepy import utils as _utils
+from splinepy import splinepy_core as _core
+from splinepy._base import SplinepyBase as _SplinepyBase
+from splinepy.helpme import visualize as _visualize
+from splinepy.helpme.check import Checker as _Checker
+from splinepy.helpme.create import Creator as _Creator
+from splinepy.helpme.extract import Extractor as _Extractor
+from splinepy.helpme.integrate import Integrator as _Integrator
+from splinepy.utils.data import SplineData as _SplineData
+from splinepy.utils.data import cartesian_product as _cartesian_product
 
 
-class RequiredProperties(SplinepyBase):
+class RequiredProperties(_SplinepyBase):
     """
     Helper class to hold required properties of each spline.
     """
@@ -188,7 +192,7 @@ def _prepare_coordinates(spl):
     -------
     None
     """
-    if not core.has_core(spl):
+    if not _core.has_core(spl):
         return None
 
     ws = True  # dummy init
@@ -206,12 +210,12 @@ def _prepare_coordinates(spl):
     # get coordinate pointers
     coordinate_pointers = spl._coordinate_pointers()
 
-    cps = cps.view(utils.data.PhysicalSpaceArray)
+    cps = cps.view(_utils.data.PhysicalSpaceArray)
     cps._source_ptr = coordinate_pointers[0]
     spl._data["control_points"] = cps
 
     if spl.is_rational:
-        ws = ws.view(utils.data.PhysicalSpaceArray)
+        ws = ws.view(_utils.data.PhysicalSpaceArray)
         ws._source_ptr = coordinate_pointers[1]
         spl._data["weights"] = ws
 
@@ -271,7 +275,7 @@ def _call_required_properties(spl, exclude="?"):
             _ = getattr(spl, rp, None)
 
 
-class Spline(SplinepyBase, core.PySpline):
+class Spline(_SplinepyBase, _core.PySpline):
     r"""
     Spline base class. Extends :class:`.PySpline` with documentation.
 
@@ -322,7 +326,7 @@ class Spline(SplinepyBase, core.PySpline):
         "_spline_data",
     )
 
-    __show_option__ = visualize.SplineShowOption
+    __show_option__ = _visualize.SplineShowOption
 
     def __init__(self, spline=None, **kwargs):
         # return if this is an empty init
@@ -331,7 +335,7 @@ class Spline(SplinepyBase, core.PySpline):
             return None
 
         # current core spline based init if given spline has no local changes
-        if spline is not None and isinstance(spline, core.PySpline):
+        if spline is not None and isinstance(spline, _core.PySpline):
             # spline based init - takes SplinepyBase, even the nullptr
             super().__init__(spline)
             # this should keep all the cps and kv references if there's any
@@ -495,7 +499,7 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         extractor: Extractor
         """
-        return _get_helper(self, "_extractor", Extractor)
+        return _get_helper(self, "_extractor", _Extractor)
 
     @property
     def check(self):
@@ -514,7 +518,7 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         extractor: Extractor
         """
-        return _get_helper(self, "_checker", Checker)
+        return _get_helper(self, "_checker", _Checker)
 
     @property
     def integrate(self):
@@ -536,7 +540,7 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         integrator: Integrator
         """
-        return _get_helper(self, "_integrator", Integrator)
+        return _get_helper(self, "_integrator", _Integrator)
 
     @property
     def create(self):
@@ -555,7 +559,7 @@ class Spline(SplinepyBase, core.PySpline):
         -------
         creator: spline.Creator
         """
-        return _get_helper(self, "_creator", Creator)
+        return _get_helper(self, "_creator", _Creator)
 
     @property
     def show_options(self):
@@ -585,7 +589,7 @@ class Spline(SplinepyBase, core.PySpline):
         -------
         spline_data: SplineData
         """
-        return _get_helper(self, "_spline_data", SplineData)
+        return _get_helper(self, "_spline_data", _SplineData)
 
     def clear(self):
         """
@@ -600,7 +604,7 @@ class Spline(SplinepyBase, core.PySpline):
         None
         """
         # annulment of core
-        core.annul_core(self)
+        _core.annul_core(self)
         self._data = {}
 
     def _new_core(self, *, keep_properties=False, raise_=True, **kwargs):
@@ -625,13 +629,13 @@ class Spline(SplinepyBase, core.PySpline):
         core_created: bool
         """
         # let's remove None valued items and make values contiguous array
-        kwargs = utils.data.enforce_contiguous_values(kwargs)
+        kwargs = _utils.data.enforce_contiguous_values(kwargs)
 
         # type check for knot vectors
         kvs = kwargs.get("knot_vectors", None)
         if kvs is not None:
             kwargs["knot_vectors"] = [
-                kv.numpy() if isinstance(kv, core.KnotVector) else kv
+                kv.numpy() if isinstance(kv, _core.KnotVector) else kv
                 for kv in kvs
             ]
 
@@ -680,7 +684,7 @@ class Spline(SplinepyBase, core.PySpline):
             else:
                 self._data = {}
 
-        return core.has_core(self)
+        return _core.has_core(self)
 
     @property
     def degrees(self):
@@ -697,7 +701,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         ds = self._data.get("degrees", None)
 
-        if core.has_core(self):
+        if _core.has_core(self):
             if ds is None:
                 ds = self._current_core_degrees()
                 ds.flags.writeable = False
@@ -722,7 +726,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         # clear core and return
         if degrees is None:
-            core.annul_core(self)
+            _core.annul_core(self)
             self._data = {}
             return None
 
@@ -736,12 +740,12 @@ class Spline(SplinepyBase, core.PySpline):
             )
 
         # set - copies
-        self._data["degrees"] = np.asarray(
+        self._data["degrees"] = _np.asarray(
             degrees, dtype="int32", order="C"
         ).copy()
 
         # make sure _new_core call works
-        if core.has_core(self):
+        if _core.has_core(self):
             _call_required_properties(self, exclude="degrees")
 
         # try to sync core with current status
@@ -766,12 +770,12 @@ class Spline(SplinepyBase, core.PySpline):
         """
         kvs = self._data.get("knot_vectors", None)
 
-        if core.has_core(self):
+        if _core.has_core(self):
             if not self.has_knot_vectors:
                 return None
 
             # check type and early exit if it is core type
-            if kvs is not None and isinstance(kvs[0], core.KnotVector):
+            if kvs is not None and isinstance(kvs[0], _core.KnotVector):
                 return kvs
 
             # get one from the core
@@ -795,7 +799,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         # clear core and return
         if knot_vectors is None:
-            core.annul_core(self)
+            _core.annul_core(self)
             self._data = {}
             return None
 
@@ -809,15 +813,15 @@ class Spline(SplinepyBase, core.PySpline):
         # set - copies
         new_kvs = []
         for kv in knot_vectors:
-            if isinstance(kv, core.KnotVector):
+            if isinstance(kv, _core.KnotVector):
                 new_kvs.append(kv.numpy())
             else:
-                new_kvs.append(utils.data.enforce_contiguous(kv, "float64"))
+                new_kvs.append(_utils.data.enforce_contiguous(kv, "float64"))
 
         self._data["knot_vectors"] = new_kvs
 
         # make sure _new_core call works
-        if core.has_core(self):
+        if _core.has_core(self):
             _call_required_properties(self, exclude="knot_vectors")
 
         # try to sync core with current status
@@ -906,8 +910,8 @@ class Spline(SplinepyBase, core.PySpline):
         """
         cps = self._data.get("control_points", None)
 
-        if core.has_core(self) and not isinstance(
-            cps, utils.data.PhysicalSpaceArray
+        if _core.has_core(self) and not isinstance(
+            cps, _utils.data.PhysicalSpaceArray
         ):
             _prepare_coordinates(self)
 
@@ -928,7 +932,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         # clear core and return
         if control_points is None:
-            core.annul_core(self)
+            _core.annul_core(self)
             self._data = {}
             return None
 
@@ -941,20 +945,20 @@ class Spline(SplinepyBase, core.PySpline):
                 )
             # we need to remove existing weights so that pointers don't get
             # mixed
-            if isinstance(self.weights, utils.data.PhysicalSpaceArray):
+            if isinstance(self.weights, _utils.data.PhysicalSpaceArray):
                 self._data["weights"] = self._data["weights"].copy()
 
         # set - copies
-        if isinstance(control_points, utils.data.PhysicalSpaceArray):
+        if isinstance(control_points, _utils.data.PhysicalSpaceArray):
             # don't want to have two arrays updating
             # same cps
             self._data["control_points"] = control_points.copy(order="C")
         else:
-            self._data["control_points"] = np.asarray(
+            self._data["control_points"] = _np.asarray(
                 control_points, dtype="float64", order="C"
             ).copy()
         # make sure _new_core call works
-        if core.has_core(self):
+        if _core.has_core(self):
             _call_required_properties(self, exclude="control_points")
 
         # try to sync core with current status
@@ -979,7 +983,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         cps = self.control_points
 
-        return np.vstack((cps.min(axis=0), cps.max(axis=0)))
+        return _np.vstack((cps.min(axis=0), cps.max(axis=0)))
 
     @property
     def control_mesh_resolutions(self):
@@ -1010,7 +1014,7 @@ class Spline(SplinepyBase, core.PySpline):
         mapper : Mapper
           Mapper to calculate physical gradients and hessians
         """
-        return helpme.mapper.Mapper(self, reference=reference)
+        return _helpme.mapper.Mapper(self, reference=reference)
 
     def greville_abscissae(self, duplicate_tolerance=None):
         """
@@ -1028,7 +1032,7 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         greville_abscissae: (para_dim) np.ndarray
         """
-        return cartesian_product(
+        return _cartesian_product(
             super()._greville_abscissae_list(
                 _default_if_none(duplicate_tolerance, -1.0),
             )
@@ -1055,7 +1059,7 @@ class Spline(SplinepyBase, core.PySpline):
 
         # not stored, create one
         # this is okay to be copied together in copy()
-        self._data["multi_index"] = helpme.multi_index.MultiIndex(
+        self._data["multi_index"] = _helpme.multi_index.MultiIndex(
             self.control_mesh_resolutions
         )
 
@@ -1076,8 +1080,8 @@ class Spline(SplinepyBase, core.PySpline):
         """
         ws = self._data.get("weights", None)
 
-        if core.has_core(self) and not isinstance(
-            ws, utils.data.PhysicalSpaceArray
+        if _core.has_core(self) and not isinstance(
+            ws, _utils.data.PhysicalSpaceArray
         ):
             _prepare_coordinates(self)
 
@@ -1098,7 +1102,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         # clear core and return
         if weights is None:
-            core.annul_core(self)
+            _core.annul_core(self)
             self._data = {}
             return None
 
@@ -1111,25 +1115,25 @@ class Spline(SplinepyBase, core.PySpline):
                 )
 
             # we need to remove existing cps so that pointers don't get mixed
-            if isinstance(self.control_points, utils.data.PhysicalSpaceArray):
+            if isinstance(self.control_points, _utils.data.PhysicalSpaceArray):
                 self._data["control_points"] = self._data[
                     "control_points"
                 ].copy()
 
         # set - copies
-        if isinstance(weights, utils.data.PhysicalSpaceArray):
+        if isinstance(weights, _utils.data.PhysicalSpaceArray):
             # don't want to have two arrays updating
             # same cps
             self._data["weights"] = weights.copy(order="C").reshape(-1, 1)
         else:
             self._data["weights"] = (
-                np.asarray(weights, dtype="float64", order="C")
+                _np.asarray(weights, dtype="float64", order="C")
                 .copy()
                 .reshape(-1, 1)
             )
 
         # make sure _new_core call works
-        if core.has_core(self):
+        if _core.has_core(self):
             _call_required_properties(self, exclude="weights")
 
         # try to sync core with current status
@@ -1154,16 +1158,16 @@ class Spline(SplinepyBase, core.PySpline):
         """
         self._logd("Evaluating spline")
 
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
         return super().evaluate(
             queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def sample(self, resolutions, nthreads=None):
@@ -1179,14 +1183,14 @@ class Spline(SplinepyBase, core.PySpline):
         --------
         results: (math.product(resolutions), dim) np.ndarray
         """
-        from gustaf.utils import arr
+        from gustaf.utils import arr as _arr
 
-        resolutions = arr.enforce_len(resolutions, self.para_dim)
+        resolutions = _arr.enforce_len(resolutions, self.para_dim)
 
-        self._logd(f"Sampling {np.prod(resolutions)} points from spline.")
+        self._logd(f"Sampling {_np.prod(resolutions)} points from spline.")
 
         return super().sample(
-            resolutions, nthreads=_default_if_none(nthreads, settings.NTHREADS)
+            resolutions, nthreads=_default_if_none(nthreads, _settings.NTHREADS)
         )
 
     def derivative(self, queries, orders, nthreads=None):
@@ -1205,19 +1209,19 @@ class Spline(SplinepyBase, core.PySpline):
         """
         self._logd("Evaluating derivatives of the spline")
 
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
-        orders = utils.data.enforce_contiguous(orders, dtype="int32")
+        orders = _utils.data.enforce_contiguous(orders, dtype="int32")
 
         return super().derivative(
             queries=queries,
             orders=orders,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def jacobian(self, queries, nthreads=None):
@@ -1235,16 +1239,16 @@ class Spline(SplinepyBase, core.PySpline):
         """
         self._logd("Determining spline jacobians")
 
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
         return super().jacobian(
             queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def support(self, queries, nthreads=None):
@@ -1261,16 +1265,16 @@ class Spline(SplinepyBase, core.PySpline):
         support: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating support ids")
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
         return super().support(
             queries=queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def basis(self, queries, nthreads=None):
@@ -1287,16 +1291,16 @@ class Spline(SplinepyBase, core.PySpline):
         basis: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating basis functions")
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
         return super().basis(
             queries=queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def basis_and_support(self, queries, nthreads=None):
@@ -1315,16 +1319,16 @@ class Spline(SplinepyBase, core.PySpline):
         support: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating basis functions and support")
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
         return super().basis_and_support(
             queries=queries,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def basis_derivative(self, queries, orders, nthreads=None):
@@ -1343,19 +1347,19 @@ class Spline(SplinepyBase, core.PySpline):
         basis_derivatives: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating basis function derivatives")
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
-        orders = utils.data.enforce_contiguous(orders, dtype="int32")
+        orders = _utils.data.enforce_contiguous(orders, dtype="int32")
 
         return super().basis_derivative(
             queries=queries,
             orders=orders,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def basis_derivative_and_support(self, queries, orders, nthreads=None):
@@ -1376,19 +1380,19 @@ class Spline(SplinepyBase, core.PySpline):
         supports: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating basis function derivatives")
-        queries = utils.data.enforce_contiguous(
-            queries, dtype="float64", asarray=settings.CHECK_BOUNDS
+        queries = _utils.data.enforce_contiguous(
+            queries, dtype="float64", asarray=_settings.CHECK_BOUNDS
         )
 
-        if settings.CHECK_BOUNDS:
+        if _settings.CHECK_BOUNDS:
             self.check.valid_queries(queries)
 
-        orders = utils.data.enforce_contiguous(orders, dtype="int32")
+        orders = _utils.data.enforce_contiguous(orders, dtype="int32")
 
         return super().basis_derivative_and_support(
             queries=queries,
             orders=orders,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def proximities(
@@ -1453,7 +1457,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         self._logd("Searching for nearest parametric coord")
 
-        queries = utils.data.enforce_contiguous(queries, dtype="float64")
+        queries = _utils.data.enforce_contiguous(queries, dtype="float64")
 
         verbose_info = super().proximities(
             queries=queries,
@@ -1461,18 +1465,18 @@ class Spline(SplinepyBase, core.PySpline):
                 initial_guess_sample_resolutions,
                 self.control_mesh_resolutions * 2,
             ),
-            tolerance=_default_if_none(tolerance, settings.TOLERANCE),
+            tolerance=_default_if_none(tolerance, _settings.TOLERANCE),
             max_iterations=max_iterations,
             aggressive_search_bounds=aggressive_search_bounds,
-            nthreads=_default_if_none(nthreads, settings.NTHREADS),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
         if return_verbose:
             return verbose_info
         else:
-            if np.any(
+            if _np.any(
                 verbose_info[4]
-                > _default_if_none(tolerance, settings.TOLERANCE)
+                > _default_if_none(tolerance, _settings.TOLERANCE)
             ):
                 self._logw(
                     "Proximity search did not converge within the tolerance "
@@ -1514,7 +1518,7 @@ class Spline(SplinepyBase, core.PySpline):
         """
         reduced = super().reduce_degrees(
             para_dims=parametric_dimensions,
-            tolerance=_default_if_none(tolerance, settings.TOLERANCE),
+            tolerance=_default_if_none(tolerance, _settings.TOLERANCE),
         )
 
         def meaningful(r):
@@ -1547,31 +1551,31 @@ class Spline(SplinepyBase, core.PySpline):
         """
         # prepare export destination
         fname = str(fname)
-        dirname = os.path.dirname(fname)
-        if not os.path.isdir(dirname) and dirname != "":
-            os.makedirs(dirname)
+        dirname = _os.path.dirname(fname)
+        if not _os.path.isdir(dirname) and dirname != "":
+            _os.makedirs(dirname)
 
         # ext tells you what you
-        ext = os.path.splitext(fname)[1]
+        ext = _os.path.splitext(fname)[1]
 
         if ext == ".iges":
-            io.iges.export(fname, [self])
+            _io.iges.export(fname, [self])
 
         elif ext == ".xml":
-            io.xml.export(fname, [self])
+            _io.xml.export(fname, [self])
 
         elif ext == ".itd":
-            io.irit.export(fname, [self])
+            _io.irit.export(fname, [self])
 
         elif ext == ".npz":
-            io.npz.export(fname, self)
+            _io.npz.export(fname, self)
 
         elif ext == ".json":
-            io.json.export(fname, self)
+            _io.json.export(fname, self)
 
         elif ext == ".mesh":
             # mfem nurbs mesh.
-            io.mfem.export(fname, self, precision=12)
+            _io.mfem.export(fname, self, precision=12)
 
         else:
             raise ValueError(
@@ -1596,7 +1600,7 @@ class Spline(SplinepyBase, core.PySpline):
         dict_spline: dict
         """
         self._logd("Preparing dict_spline")
-        if core.has_core(self):
+        if _core.has_core(self):
             core_properties = self.current_core_properties()
             if tolist:
                 new_dict = {}
@@ -1618,7 +1622,7 @@ class Spline(SplinepyBase, core.PySpline):
             # attr are either list or np.ndarray
             # prepare list if needed.
             if tolist and (tmp_prop is not None):
-                if isinstance(tmp_prop, np.ndarray):
+                if isinstance(tmp_prop, _np.ndarray):
                     tmp_prop = tmp_prop.tolist()  # copies
                     should_copy = False
                 if p.startswith("knot_vectors"):
@@ -1626,7 +1630,7 @@ class Spline(SplinepyBase, core.PySpline):
                     should_copy = False
 
             if should_copy:
-                tmp_prop = copy.deepcopy(tmp_prop)
+                tmp_prop = _copy.deepcopy(tmp_prop)
 
             # update
             dict_spline[p] = tmp_prop
@@ -1656,7 +1660,7 @@ class Spline(SplinepyBase, core.PySpline):
             for k, v in self._data.items():
                 if k in required_properties:
                     continue
-                new._data[k] = copy.deepcopy(v)
+                new._data[k] = _copy.deepcopy(v)
 
         return new
 
@@ -1676,7 +1680,7 @@ class Spline(SplinepyBase, core.PySpline):
         -------
         showable_or_plotter: dict or vedo.Plotter
         """
-        return visualize.show(self, **kwargs)
+        return _visualize.show(self, **kwargs)
 
     def showable(self, **kwargs):
         """Equivalent to
@@ -1696,7 +1700,7 @@ class Spline(SplinepyBase, core.PySpline):
         -------
         spline_showable: dict
         """
-        return visualize.show(self, return_showable=True, **kwargs)
+        return _visualize.show(self, return_showable=True, **kwargs)
 
     # short cuts / alias
     ds = degrees

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -9,8 +9,8 @@ import numpy as _np
 from splinepy import helpme as _helpme
 from splinepy import io as _io
 from splinepy import settings as _settings
-from splinepy import utils as _utils
 from splinepy import splinepy_core as _core
+from splinepy import utils as _utils
 from splinepy._base import SplinepyBase as _SplinepyBase
 from splinepy.helpme import visualize as _visualize
 from splinepy.helpme.check import Checker as _Checker
@@ -874,7 +874,7 @@ class Spline(_SplinepyBase, _core.PySpline):
             self._logd(
                 "Returning multiplicities of knots if Bezier was BSpline"
             )
-            return [np.array([d + 1, d + 1]) for d in self.degrees]
+            return [_np.array([d + 1, d + 1]) for d in self.degrees]
 
         else:
             self._logd("Retrieving knot multiplicities")
@@ -1190,7 +1190,8 @@ class Spline(_SplinepyBase, _core.PySpline):
         self._logd(f"Sampling {_np.prod(resolutions)} points from spline.")
 
         return super().sample(
-            resolutions, nthreads=_default_if_none(nthreads, _settings.NTHREADS)
+            resolutions,
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 
     def derivative(self, queries, orders, nthreads=None):

--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -2,13 +2,15 @@
 
 Helps helpee to manage data. Some useful data structures.
 """
-from itertools import accumulate, chain, repeat
+from itertools import accumulate as _accumulate
+from itertools import chain as _chain
+from itertools import repeat as _repeat
 
-import numpy as np
-from gustaf.helpers.data import DataHolder
+import numpy as _np
+from gustaf.helpers.data import DataHolder as _DataHolder
 
-from splinepy import splinepy_core
-from splinepy._base import SplinepyBase
+from splinepy import splinepy_core as _splinepy_core
+from splinepy._base import SplinepyBase as _SplinepyBase
 
 __all__ = [
     "PhysicalSpaceArray",
@@ -20,7 +22,7 @@ __all__ = [
 ]
 
 
-class PhysicalSpaceArray(np.ndarray):
+class PhysicalSpaceArray(_np.ndarray):
     """numpy array object that keeps mirroring inplace changes to the source.
     Meant to help control_points.
     """
@@ -75,7 +77,7 @@ class PhysicalSpaceArray(np.ndarray):
 
     def copy(self, *args, **kwargs):
         """copy creates regular numpy array"""
-        return np.array(self, *args, copy=True, **kwargs)
+        return _np.array(self, *args, copy=True, **kwargs)
 
     def view(self, *args, **kwargs):
         """Set writeable flags to False for the view."""
@@ -169,14 +171,14 @@ class PhysicalSpaceArray(np.ndarray):
         #
         # here, we will try to parse very simple, yet, quite often used
         # indexings
-        contig = np.ascontiguousarray  # frequently used
+        contig = _np.ascontiguousarray  # frequently used
         if isinstance(key, int) or (
-            isinstance(key, np.ndarray) and key.ndim == 0
+            isinstance(key, _np.ndarray) and key.ndim == 0
         ):
             # single get item is always contiguous
             self._source_ptr.set_row(key, self[key])
 
-        elif isinstance(key, np.ndarray) and key.ndim == 1:
+        elif isinstance(key, _np.ndarray) and key.ndim == 1:
             if key.dtype.kind.startswith("b"):
                 key = contig(self.row_indices()[key])
 
@@ -190,14 +192,14 @@ class PhysicalSpaceArray(np.ndarray):
         # tuple is a bit tricky
         elif isinstance(key, tuple) and (
             isinstance(key[0], int)
-            or (isinstance(key[0], np.ndarray) and key[0].ndim == 0)
+            or (isinstance(key[0], _np.ndarray) and key[0].ndim == 0)
         ):
             self._source_ptr.set_row(key[0], self[key[0]])
 
         elif isinstance(key, tuple) and (
-            isinstance(key[0], (list, np.ndarray))
+            isinstance(key[0], (list, _np.ndarray))
         ):
-            if isinstance(key[0][0], (np.bool_, bool)):
+            if isinstance(key[0][0], (_np.bool_, bool)):
                 key = (contig(self.row_indices()[key[0]]),)
 
             self._source_ptr.sync_rows(key[0], self)
@@ -215,7 +217,7 @@ class PhysicalSpaceArray(np.ndarray):
             stop = stop + len(self) if stop < 0 else stop
             step = 1 if key.step is None else key.step
 
-            ids = np.arange(
+            ids = _np.arange(
                 start, stop, step, dtype="int32"
             )  # should be contig
             self._source_ptr.sync_rows(ids, self)
@@ -228,7 +230,7 @@ class PhysicalSpaceArray(np.ndarray):
         else:
             # even more complex? then
             # TODO - just sync if this seems to take too long
-            ids = np.unique(self.full_row_indices()[key])
+            ids = _np.unique(self.full_row_indices()[key])
             self._source_ptr.sync_rows(contig(ids), self)
 
         return sr
@@ -241,7 +243,7 @@ class PhysicalSpaceArray(np.ndarray):
             return self._row_indices
 
         len_, d = self._source_ptr.len(), self._source_ptr.dim()
-        self._row_indices = np.arange(len_, dtype="int32")
+        self._row_indices = _np.arange(len_, dtype="int32")
         self._full_row_indices = self._row_indices.repeat(d).reshape(len_, d)
         return self._row_indices
 
@@ -253,7 +255,7 @@ class PhysicalSpaceArray(np.ndarray):
             return self._full_row_indices
 
         len_, d = self._source_ptr.len(), self._source_ptr.dim()
-        self._row_indices = np.arange(len_, dtype="int32")
+        self._row_indices = _np.arange(len_, dtype="int32")
         self._full_row_indices = self._row_indices.repeat(d).reshape(len_, d)
         return self._full_row_indices
 
@@ -277,15 +279,15 @@ def enforce_contiguous(array, dtype=None, asarray=False):
     -------
     contiguous_array: array-like
     """
-    if isinstance(array, np.ndarray):
+    if isinstance(array, _np.ndarray):
         if array.flags["C_CONTIGUOUS"] and (
-            dtype is None or np.dtype(dtype) is array.dtype
+            dtype is None or _np.dtype(dtype) is array.dtype
         ):
             return array
-        return np.ascontiguousarray(array, dtype=dtype)
+        return _np.ascontiguousarray(array, dtype=dtype)
 
-    if asarray and isinstance(array, (list, tuple, splinepy_core.KnotVector)):
-        return np.ascontiguousarray(array, dtype=dtype)
+    if asarray and isinstance(array, (list, tuple, _splinepy_core.KnotVector)):
+        return _np.ascontiguousarray(array, dtype=dtype)
 
     return array
 
@@ -307,11 +309,11 @@ def enforce_contiguous_values(dict_):
     dict_with_contiguous = {}
     for key, value in dict_.items():
         # most likely will be asking about np.ndarray
-        if isinstance(value, np.ndarray):
+        if isinstance(value, _np.ndarray):
             contig_value = enforce_contiguous(value)
 
         # or, list. only check if the first element is np.ndarray
-        elif isinstance(value, list) and isinstance(value[0], np.ndarray):
+        elif isinstance(value, list) and isinstance(value[0], _np.ndarray):
             contig_value = [enforce_contiguous(v) for v in value]
 
         # abandon Nones
@@ -352,25 +354,25 @@ def cartesian_product(arrays, reverse=True):
     cartesian: (n, len(arrays)) np.ndarray
     """
     n_arr = len(arrays)
-    dtype = np.result_type(*arrays)
+    dtype = _np.result_type(*arrays)
 
     # for reverse, use view of reverse ordered arrays
     if reverse:
         arrays = arrays[::-1]
 
     shape = *map(len, arrays), n_arr
-    cartesian = np.empty(shape, dtype=dtype)
+    cartesian = _np.empty(shape, dtype=dtype)
 
     # reverse order the view of output array, so that reverse
     # is again in original order, but just reversed fastest iterating dim
     _cartesian = cartesian[..., ::-1] if reverse else cartesian
 
     dim_reducing_views = (
-        *accumulate(
-            chain((_cartesian,), repeat(0, n_arr - 1)), np.ndarray.__getitem__
+        *_accumulate(
+            _chain((_cartesian,), _repeat(0, n_arr - 1)), _np.ndarray.__getitem__
         ),
     )
-    idx = slice(None), *repeat(None, n_arr - 1)
+    idx = slice(None), *_repeat(None, n_arr - 1)
     for i in range(n_arr - 1, 0, -1):
         dim_reducing_views[i][..., i] = arrays[i][idx[: n_arr - i]]
         dim_reducing_views[i - 1][1:] = dim_reducing_views[i]
@@ -379,7 +381,7 @@ def cartesian_product(arrays, reverse=True):
     return cartesian.reshape(-1, n_arr)
 
 
-class SplineDataAdaptor(SplinepyBase):
+class SplineDataAdaptor(_SplinepyBase):
     """
     Prepares data to be presentable on spline. To support both
     scalar-data and vector-data, which are representable with colors and
@@ -400,7 +402,8 @@ class SplineDataAdaptor(SplinepyBase):
 
     def __init__(self, data, locations=None, function=None):
         """ """
-        from splinepy import Multipatch, Spline
+        from splinepy import Multipatch as _Multipatch
+        from splinepy import Spline as _Spline
 
         # default
         self._user_created = True
@@ -412,7 +415,7 @@ class SplineDataAdaptor(SplinepyBase):
         self.arrow_data_only = False
 
         # is spline we know?
-        if isinstance(data, (Spline, Multipatch)):
+        if isinstance(data, (_Spline, _Multipatch)):
             self.is_spline = True
 
         # data has evaluate?
@@ -432,7 +435,7 @@ class SplineDataAdaptor(SplinepyBase):
             # set what holds true
             self.has_locations = True
             self.arrow_data_only = True
-            self.locations = np.asanyarray(locations)
+            self.locations = _np.asanyarray(locations)
 
             # if this is not a spline we know, it doesn't have a function,
             # it should:
@@ -523,7 +526,7 @@ class SplineDataAdaptor(SplinepyBase):
         raise RuntimeError("Something went wrong while preparing spline data.")
 
 
-class SplineData(DataHolder):
+class SplineData(_DataHolder):
     """
     Data manager for splines.
     """
@@ -634,7 +637,7 @@ class MultipatchData(SplineData):
         if "Multipatch" not in str(type(helpee).__mro__):
             raise AttributeError("Helpee is not a multipatch")
 
-        DataHolder.__init__(self, helpee)
+        _DataHolder.__init__(self, helpee)
 
     def __setitem__(self, key, value):
         """
@@ -681,7 +684,7 @@ class MultipatchData(SplineData):
         if isinstance(key, int):
             return self._helpee.fields[key]
         elif isinstance(key, str):
-            saved = DataHolder.__getitem__(self, key)  # will raise KeyError
+            saved = _DataHolder.__getitem__(self, key)  # will raise KeyError
             if isinstance(saved, int):
                 return self._helpee.fields[saved]
             elif isinstance(saved, SplineDataAdaptor):

--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -14,7 +14,7 @@ from splinepy._base import SplinepyBase as _SplinepyBase
 
 __all__ = [
     "PhysicalSpaceArray",
-    "DataHolder",
+    "_DataHolder",
     "enforce_contiguous_values",
     "cartesian_product",
     "SplineDataAdaptor",
@@ -369,7 +369,8 @@ def cartesian_product(arrays, reverse=True):
 
     dim_reducing_views = (
         *_accumulate(
-            _chain((_cartesian,), _repeat(0, n_arr - 1)), _np.ndarray.__getitem__
+            _chain((_cartesian,), _repeat(0, n_arr - 1)),
+            _np.ndarray.__getitem__,
         ),
     )
     idx = slice(None), *_repeat(None, n_arr - 1)

--- a/splinepy/utils/log.py
+++ b/splinepy/utils/log.py
@@ -2,8 +2,8 @@
 Thin logging wrapper.
 """
 
-import functools
-import logging
+import functools as _functools
+import logging as _logging
 
 
 def configure(debug=False, logfile=None):
@@ -21,14 +21,14 @@ def configure(debug=False, logfile=None):
     None
     """
     # logger
-    logger = logging.getLogger("splinepy")
+    logger = _logging.getLogger("splinepy")
 
     # level
-    level = logging.DEBUG if debug else logging.INFO
+    level = _logging.DEBUG if debug else _logging.INFO
     logger.setLevel(level)
 
     # format
-    formatter = logging.Formatter(
+    formatter = _logging.Formatter(
         fmt="%(asctime)-15s %(name)s [%(levelname)s] %(message)s"
     )
 
@@ -38,7 +38,7 @@ def configure(debug=False, logfile=None):
     new_handlers = []
     for _i, h in enumerate(logger.handlers):
         # we skip all the stream handler.
-        if isinstance(h, logging.StreamHandler):
+        if isinstance(h, _logging.StreamHandler):
             continue
 
         # blindly keep other ones
@@ -46,7 +46,7 @@ def configure(debug=False, logfile=None):
             new_handlers.append(h)
 
     # add new stream handler
-    stream_handler = logging.StreamHandler()
+    stream_handler = _logging.StreamHandler()
     stream_handler.setLevel(level)
     stream_handler.setFormatter(formatter)
     new_handlers.append(stream_handler)
@@ -55,7 +55,7 @@ def configure(debug=False, logfile=None):
 
     # output logs
     if logfile is not None:
-        file_logger_handler = logging.FileHandler(logfile)
+        file_logger_handler = _logging.FileHandler(logfile)
         logger.addHandler(file_logger_handler)
 
 
@@ -71,7 +71,7 @@ def debug(*log):
     --------
     None
     """
-    logger = logging.getLogger("splinepy")
+    logger = _logging.getLogger("splinepy")
     logger.debug(" ".join(map(str, log)))
 
 
@@ -87,7 +87,7 @@ def info(*log):
     --------
     None
     """
-    logger = logging.getLogger("splinepy")
+    logger = _logging.getLogger("splinepy")
     logger.info(" ".join(map(str, log)))
 
 
@@ -103,7 +103,7 @@ def warning(*log):
     --------
     None
     """
-    logger = logging.getLogger("splinepy")
+    logger = _logging.getLogger("splinepy")
     logger.warning(" ".join(map(str, log)))
 
 
@@ -121,4 +121,4 @@ def prepend_log(message, log_func):
     -------
     prepended: function
     """
-    return functools.partial(log_func, message)
+    return _functools.partial(log_func, message)

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import splinepy
 
 try:

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -1,4 +1,5 @@
 import numpy as np
+import splinepy
 
 try:
     from . import common as c
@@ -94,7 +95,7 @@ class CreatorTest(c.SplineBasedTestCase):
 
         # Expect Failure - not a spline
         with self.assertRaises(NotImplementedError):
-            c.splinepy.spline.helpme.create.revolved([4])
+            splinepy.helpme.create.revolved([4])
         # Expect Failure - No rotation axis
         with self.assertRaises(ValueError):
             cuboid.create.revolved()

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-import splinepy
-
 try:
     from . import common as c
 except BaseException:
@@ -96,7 +94,7 @@ class CreatorTest(c.SplineBasedTestCase):
 
         # Expect Failure - not a spline
         with self.assertRaises(NotImplementedError):
-            splinepy.helpme.create.revolved([4])
+            c.splinepy.helpme.create.revolved([4])
         # Expect Failure - No rotation axis
         with self.assertRaises(ValueError):
             cuboid.create.revolved()


### PR DESCRIPTION
# Overview
Leading underscores were added to the module imports to make them private. This means that they are not accessible from outside the module and can only be used within the module itself.

## Addressed issues
[#270](https://github.com/tataratat/splinepy/issues/270)
## Showcase
```
import splinepy as _splinepy

new, feature = _splinepy.tataratat()
```
