### PR TITLE
Fix examples 2.0

### DIFF
--- a/examples/show_isophotes_and_curvature.py
+++ b/examples/show_isophotes_and_curvature.py
@@ -36,7 +36,7 @@ def isophotes_to_direction(normal=None, interval=0.02):
     def isophotes_scalars(data, resolutions=None, on=None):
         if resolutions is not None:
             q = gus.create.vertices.raster(
-                data.knot_vector_bounds.tolist(), resolutions
+                data.parametric_bounds.tolist(), resolutions
             ).vertices
             v1 = data.derivative(q, [1, 0])
             v2 = data.derivative(q, [0, 1])
@@ -56,7 +56,7 @@ def isophotes_to_direction(normal=None, interval=0.02):
 def gaussian_curvature(data, resolutions=None, on=None):
     if resolutions is not None:
         q = gus.create.vertices.raster(
-            data.knot_vector_bounds.tolist(), resolutions
+            data.parametric_bounds.tolist(), resolutions
         ).vertices
         v1 = data.derivative(q, [1, 0])
         v2 = data.derivative(q, [0, 1])
@@ -83,7 +83,7 @@ def gaussian_curvature(data, resolutions=None, on=None):
 def mean_curvature(data, resolutions=None, on=None):
     if resolutions is not None:
         q = gus.create.vertices.raster(
-            data.knot_vector_bounds.tolist(), resolutions
+            data.parametric_bounds.tolist(), resolutions
         ).vertices
         v1 = data.derivative(q, [1, 0])
         v2 = data.derivative(q, [0, 1])

--- a/examples/show_multipatch.py
+++ b/examples/show_multipatch.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                 box0.parametric_bounds, resolutions
             ).vertices
             return np.linalg.det(
-                np.vstack(d.jacobian(q) for d in data.patches)
+                np.vstack([d.jacobian(q) for d in data.patches])
             )
         elif on is not None:
             return np.linalg.det(data.jacobians(on))

--- a/examples/show_multipatch.py
+++ b/examples/show_multipatch.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     generator.microtile = splinepy.microstructure.tiles.CrossTile2D()
     generator.tiling = [3, 2]
 
-    m = splinepy.Multipatch(generator.create(center_expansion=1.2))
+    m = generator.create(center_expansion=1.2)
     m.spline_data["detJ"] = splinepy.SplineDataAdaptor(m, function=plot_jacs)
     m.show_options["data_name"] = "detJ"
     m.show_options["lighting"] = "off"

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -160,10 +160,15 @@ def faces(
             boundaries = spline.boundary_multipatch()
         else:
             boundaries = Multipatch(splines=spline.extract.boundaries())
-
-        n_faces = (resolution - 1) ** 2
-        vertices = resolution**2
-        f_loc = connec.make_quad_faces(enforce_len(resolution, 2))
+        # The following block assumes a integer resolution but might get a list
+        # as input. In that case, we take the max of the list and use it as
+        # resolution.
+        # I am not sure if this is correct or if we should instead rework the
+        # following lines so that list resolution is supported.
+        res = resolution if isinstance(resolution, int) else max(resolution)
+        n_faces = (res - 1) ** 2
+        vertices = res**2
+        f_loc = connec.make_quad_faces(enforce_len(res, 2))
         face_connectivity = np.empty((n_faces * len(boundaries.patches), 4))
 
         # Create Connectivity for Multipatches

--- a/splinepy/microstructure/microstructure.py
+++ b/splinepy/microstructure/microstructure.py
@@ -584,7 +584,7 @@ class Microstructure(SplinepyBase):
 
             # Determine the microtile (prior to insertion) derivative is set to
             # None if the parameter sensitivity is not requested
-            (tile, derivatives) = self._microtile.create_tile(
+            tile, derivatives = self._microtile.create_tile(
                 parameters=tile_parameters,
                 parameter_sensitivities=tile_sens_on_support,
                 closure=face_closure,

--- a/splinepy/microstructure/tiles/crosstile3d.py
+++ b/splinepy/microstructure/tiles/crosstile3d.py
@@ -214,7 +214,7 @@ class CrossTile3D(TileBase):
                 Bezier(degrees=[1, 1, 2], control_points=branch_ctps)
             )
 
-            return spline_list
+            return (spline_list, None)
         elif closure == "z_max":
             # The branch is located at zmax of current tile
             branch_thickness = parameters[4, 0]

--- a/splinepy/microstructure/tiles/inversecrosstile3d.py
+++ b/splinepy/microstructure/tiles/inversecrosstile3d.py
@@ -953,12 +953,15 @@ class InverseCrossTile3D(TileBase):
             )
 
         if closure is not None:
-            return self._closing_tile(
-                parameters=parameters,
-                parameter_sensitivities=parameter_sensitivities,
-                seperator_distance=seperator_distance,
-                closure=closure,
-                **kwargs,
+            return (
+                self._closing_tile(
+                    parameters=parameters,
+                    parameter_sensitivities=parameter_sensitivities,
+                    seperator_distance=seperator_distance,
+                    closure=closure,
+                    **kwargs,
+                ),
+                None,
             )
 
         [
@@ -1601,5 +1604,4 @@ class InverseCrossTile3D(TileBase):
         spline_list.append(
             Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_max)
         )
-
-        return (spline_list, None)
+        return spline_list, None

--- a/splinepy/microstructure/tiles/inversecrosstile3d.py
+++ b/splinepy/microstructure/tiles/inversecrosstile3d.py
@@ -468,7 +468,7 @@ class InverseCrossTile3D(TileBase):
                 )
             )
 
-            return spline_list
+            return (spline_list, None)
 
         elif closure == "z_max":
             branch_thickness = parameters.flatten()[4]
@@ -953,15 +953,12 @@ class InverseCrossTile3D(TileBase):
             )
 
         if closure is not None:
-            return (
-                self._closing_tile(
-                    parameters=parameters,
-                    parameter_sensitivities=parameter_sensitivities,
-                    seperator_distance=seperator_distance,
-                    closure=closure,
-                    **kwargs,
-                ),
-                None,
+            return self._closing_tile(
+                parameters=parameters,
+                parameter_sensitivities=parameter_sensitivities,
+                seperator_distance=seperator_distance,
+                closure=closure,
+                **kwargs,
             )
 
         [
@@ -1604,4 +1601,4 @@ class InverseCrossTile3D(TileBase):
         spline_list.append(
             Bezier(degrees=[2, 2, 2], control_points=x_max_y_max_z_max)
         )
-        return spline_list, None
+        return (spline_list, None)

--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -486,9 +486,20 @@ class SplineDataAdaptor(SplinepyBase):
         # if resolutions is specified, this is not a location query
         if resolutions is not None:
             if self.has_function:
+                # enable to have a tuple of splines in the data field
+                # to enable comparisons, enforce para_dim match
+                if isinstance(self.data, tuple):
+                    para_dim = self.data[0].para_dim
+                    if any(d.para_dim != para_dim for d in self.data):
+                        raise ValueError(
+                            "All splines in the data field need to be "
+                            "of the same parametric dimension."
+                        )
+                else:
+                    para_dim = self.data.para_dim
                 return self.function(
                     self.data,
-                    resolutions=enforce_len(resolutions, self.data.para_dim),
+                    resolutions=enforce_len(resolutions, para_dim),
                 )
             elif self.is_spline and self.data.para_dim > 2:
                 # TODO: replace this with generalized query helpers.

--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -6,6 +6,7 @@ from itertools import accumulate, chain, repeat
 
 import numpy as np
 from gustaf.helpers.data import DataHolder
+from gustaf.utils.arr import enforce_len
 
 from splinepy import splinepy_core
 from splinepy._base import SplinepyBase
@@ -485,7 +486,10 @@ class SplineDataAdaptor(SplinepyBase):
         # if resolutions is specified, this is not a location query
         if resolutions is not None:
             if self.has_function:
-                return self.function(self.data, resolutions=resolutions)
+                return self.function(
+                    self.data,
+                    resolutions=enforce_len(resolutions, self.data.para_dim),
+                )
             elif self.is_spline and self.data.para_dim > 2:
                 # TODO: replace this with generalized query helpers.
                 return self.data.extract.faces(


### PR DESCRIPTION
# Overview
The second iteration of fix examples PR. Mainly to address the issue of incorporating the incoming changes for #291. 

Found also the issue that `show_isophotes_and_curvature` used the deprecated knot_vector_bounds parameter/function. Changes this to parameteric_bounds as it is called now. I am not sure why the alias from the spline class did not function correctly, but it gave me an error now.

## Addressed issues
*  Incorporate changes from fix for #291 (TODO)
* Fix example `show_isophotes_and_curvature`

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
