### PR TITLE
strip binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ wheel.packages = [
 
 build-dir = "build"
 
+install.strip = true
+
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"
 input = "splinepy/_version.py"


### PR DESCRIPTION
# Overview
Using `scikit-build-core` allows us to distribute static libraries as well. This results in giant files. Setting `install.strip=true` reduces size, so this PR does that. I will maybe remove `3.7` wheels as well.

## Addressed issues
*  Giant binary

