### PR TITLE
accept any number of order-queries for derivatives

### DIFF
--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1198,12 +1198,13 @@ class Spline(_SplinepyBase, _core.PySpline):
         Parameters
         -----------
         queries: (n, para_dim) array-like
-        orders: (para_dim,) or (n, para_dim) array-like
+        orders: (para_dim,) or (m, para_dim) array-like
         nthreads: int
 
         Returns
         --------
-        results: (n, dim) np.ndarray
+        results: (n, m, dim) np.ndarray
+          Iff m == 1, it will have (n, dim) shape.
         """
         self._logd("Evaluating derivatives of the spline")
 
@@ -1337,12 +1338,13 @@ class Spline(_SplinepyBase, _core.PySpline):
         Parameters
         ----------
         queries: (n, para_dim) array-like
-        orders: (para_dim,) or (n, para_dim) array-like
+        orders: (para_dim,) or (m, para_dim) array-like
         nthreads: int
 
         Returns
         --------
-        basis_derivatives: (n, prod(degrees + 1)) np.ndarray
+        basis_derivatives: (n, m, prod(degrees + 1)) np.ndarray
+          Iff m == 1, it will have (n, prod(degrees + 1)) shape.
         """
         self._logd("Evaluating basis function derivatives")
         queries = _utils.data.enforce_contiguous(
@@ -1369,12 +1371,13 @@ class Spline(_SplinepyBase, _core.PySpline):
         Parameters
         ----------
         queries: (n, para_dim) array-like
-        orders: (para_dim,) or (n, para_dim) array-like
+        orders: (para_dim,) or (m, para_dim) array-like
         nthreads: int
 
         Returns
         --------
-        basis_derivatives: (n, prod(degrees + 1)) np.ndarray
+        basis_derivatives: (n, m, prod(degrees + 1)) np.ndarray
+          Iff m == 1, it will have (n, prod(degrees + 1)) shape.
         supports: (n, prod(degrees + 1)) np.ndarray
         """
         self._logd("Evaluating basis function derivatives")

--- a/src/py/py_spline.cpp
+++ b/src/py/py_spline.cpp
@@ -435,7 +435,7 @@ py::array_t<double> PySpline::Derivative(py::array_t<double> queries,
   // process input
   CheckPyArrayShape(queries, {-1, para_dim_}, true);
   const int n_queries = queries.shape(0);
-  int n_orders;
+  int n_orders{};
   if (CheckPyArraySize(orders, para_dim_, false)) {
     n_orders = 1;
   } else if (CheckPyArrayShape(orders, {-1, para_dim_}, false)) {
@@ -558,7 +558,7 @@ py::array_t<double> PySpline::BasisDerivative(py::array_t<double> queries,
                                               int nthreads) const {
   CheckPyArrayShape(queries, {-1, para_dim_}, true);
   const int n_queries = queries.shape(0);
-  int n_orders;
+  int n_orders{};
   if (CheckPyArraySize(orders, para_dim_, false)) {
     n_orders = 1;
   } else if (CheckPyArrayShape(orders, {-1, para_dim_}, false)) {
@@ -604,7 +604,7 @@ py::tuple PySpline::BasisDerivativeAndSupport(py::array_t<double> queries,
                                               int nthreads) const {
   CheckPyArrayShape(queries, {-1, para_dim_}, true);
   const int n_queries = queries.shape(0);
-  int n_orders;
+  int n_orders{};
   if (CheckPyArraySize(orders, para_dim_, false)) {
     n_orders = 1;
   } else if (CheckPyArrayShape(orders, {-1, para_dim_}, false)) {


### PR DESCRIPTION
# Overview
Implements #248

## Addressed issues
*  #248

## Showcase
A short / one-liner example to highlight the (new) feature
```python
import splinepy
import numpy as np

q = np.random.random((10000, spline.para_dim))

assert np.allclose(
    spline.jacobian(q),
    spline.derivative(q, np.eye(spline.para_dim)).transpose(0, 2, 1)
)
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
