### PR TITLE
helpers use weakref

### DIFF
--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -1,4 +1,5 @@
 import numpy as _np
+from gustaf.helpers._base import HelperBase as _HelperBase
 
 
 def valid_queries(spline, queries):
@@ -53,7 +54,7 @@ def valid_queries(spline, queries):
     return True
 
 
-class Checker:
+class Checker(_HelperBase):
     """Helper class to allow direct extraction from spline obj (BSpline or
     NURBS). Internal use only.
 
@@ -70,8 +71,10 @@ class Checker:
       Parent spline, that is to be checked
     """
 
+    __slots__ = ()
+
     def __init__(self, spl):
-        self._spline = spl
+        self._helpee = spl
 
     def valid_queries(self, queries):
-        return valid_queries(self._spline, queries)
+        return valid_queries(self._helpee, queries)

--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -1,5 +1,4 @@
 import numpy as _np
-from gustaf.helpers._base import HelperBase as _HelperBase
 
 
 def valid_queries(spline, queries):
@@ -54,7 +53,7 @@ def valid_queries(spline, queries):
     return True
 
 
-class Checker(_HelperBase):
+class Checker:
     """Helper class to allow direct extraction from spline obj (BSpline or
     NURBS). Internal use only.
 
@@ -71,10 +70,14 @@ class Checker(_HelperBase):
       Parent spline, that is to be checked
     """
 
-    __slots__ = ()
+    __slots__ = ("_helpee",)
 
     def __init__(self, spl):
         self._helpee = spl
 
     def valid_queries(self, queries):
         return valid_queries(self._helpee, queries)
+
+
+# Use function docstrings in Checker functions
+Checker.valid_queries.__doc__ = valid_queries.__doc__

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -1,5 +1,4 @@
 import numpy as _np
-from gustaf.helpers._base import HelperBase as _HelperBase
 from gustaf.utils import arr as _arr
 
 from splinepy import settings as _settings
@@ -949,7 +948,7 @@ def pyramid(width, length, height):
     return p
 
 
-class Creator(_HelperBase):
+class Creator:
     """Helper class to build new splines from existing geometries.
 
     Examples
@@ -957,7 +956,7 @@ class Creator(_HelperBase):
     >>> spline_faces = my_spline.create.extrude(vector=[3, 1, 3])
     """
 
-    __slots__ = ()
+    __slots__ = ("_helpee",)
 
     def __init__(self, spl):
         self._helpee = spl

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -1,4 +1,5 @@
 import numpy as _np
+from gustaf.helpers._base import HelperBase as _HelperBase
 from gustaf.utils import arr as _arr
 
 from splinepy import settings as _settings
@@ -948,7 +949,7 @@ def pyramid(width, length, height):
     return p
 
 
-class Creator:
+class Creator(_HelperBase):
     """Helper class to build new splines from existing geometries.
 
     Examples
@@ -956,20 +957,22 @@ class Creator:
     >>> spline_faces = my_spline.create.extrude(vector=[3, 1, 3])
     """
 
+    __slots__ = ()
+
     def __init__(self, spl):
-        self.spline = spl
+        self._helpee = spl
 
     def extruded(self, *args, **kwargs):
-        return extruded(self.spline, *args, **kwargs)
+        return extruded(self._helpee, *args, **kwargs)
 
     def revolved(self, *args, **kwargs):
-        return revolved(self.spline, *args, **kwargs)
+        return revolved(self._helpee, *args, **kwargs)
 
     def parametric_view(self, *args, **kwargs):
-        return parametric_view(self.spline, *args, **kwargs)
+        return parametric_view(self._helpee, *args, **kwargs)
 
     def determinant_spline(self, *args, **kwargs):
-        return determinant_spline(self.spline, *args, **kwargs)
+        return determinant_spline(self._helpee, *args, **kwargs)
 
 
 # Use function docstrings in Extractor functions

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -3,7 +3,6 @@ from gustaf import Edges as _Edges
 from gustaf import Faces as _Faces
 from gustaf import Vertices as _Vertices
 from gustaf import Volumes as _Volumes
-from gustaf.helpers._base import HelperBase as _HelperBase
 from gustaf.utils import connec as _connec
 from gustaf.utils.arr import enforce_len as _enforce_len
 
@@ -527,7 +526,7 @@ def boundaries(spline, boundary_ids=None):
         ]
 
 
-class Extractor(_HelperBase):
+class Extractor:
     """Helper class to allow direct extraction from spline obj (BSpline or
     NURBS). Internal use only.
 
@@ -536,7 +535,7 @@ class Extractor(_HelperBase):
     >>> spline_faces = my_spline.extract.faces()
     """
 
-    __slots__ = ()
+    __slots__ = ("_helpee",)
 
     def __init__(self, spl):
         from splinepy import Multipatch as _Multipatch

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -3,6 +3,7 @@ from gustaf import Edges as _Edges
 from gustaf import Faces as _Faces
 from gustaf import Vertices as _Vertices
 from gustaf import Volumes as _Volumes
+from gustaf.helpers._base import HelperBase as _HelperBase
 from gustaf.utils import connec as _connec
 from gustaf.utils.arr import enforce_len as _enforce_len
 
@@ -526,7 +527,7 @@ def boundaries(spline, boundary_ids=None):
         ]
 
 
-class Extractor:
+class Extractor(_HelperBase):
     """Helper class to allow direct extraction from spline obj (BSpline or
     NURBS). Internal use only.
 
@@ -535,37 +536,39 @@ class Extractor:
     >>> spline_faces = my_spline.extract.faces()
     """
 
+    __slots__ = ()
+
     def __init__(self, spl):
         from splinepy import Multipatch as _Multipatch
         from splinepy import Spline as _Spline
 
         if not isinstance(spl, (_Spline, _Multipatch)):
             raise ValueError("Extractor expects a Spline or Multipatch type")
-        self._spline = spl
+        self._helpee = spl
 
     def edges(self, *args, **kwargs):
-        return edges(self._spline, *args, **kwargs)
+        return edges(self._helpee, *args, **kwargs)
 
     def faces(self, *args, **kwargs):
-        return faces(self._spline, *args, **kwargs)
+        return faces(self._helpee, *args, **kwargs)
 
     def volumes(self, *args, **kwargs):
-        return volumes(self._spline, *args, **kwargs)
+        return volumes(self._helpee, *args, **kwargs)
 
     def control_points(self):
-        return control_points(self._spline)
+        return control_points(self._helpee)
 
     def control_edges(self):
-        return control_edges(self._spline)
+        return control_edges(self._helpee)
 
     def control_faces(self):
-        return control_faces(self._spline)
+        return control_faces(self._helpee)
 
     def control_volumes(self):
-        return control_volumes(self._spline)
+        return control_volumes(self._helpee)
 
     def control_mesh(self):
-        return control_mesh(self._spline)
+        return control_mesh(self._helpee)
 
     def beziers(self):
         """
@@ -581,12 +584,12 @@ class Extractor:
           List of all individual bezier patches representing the non-zero
           knot-spans
         """
-        if not self._spline.has_knot_vectors:
-            return [self._spline]
-        return self._spline.extract_bezier_patches()
+        if not self._helpee.has_knot_vectors:
+            return [self._helpee]
+        return self._helpee.extract_bezier_patches()
 
     def boundaries(self, *args, **kwargs):
-        return boundaries(self._spline, *args, **kwargs)
+        return boundaries(self._helpee, *args, **kwargs)
 
     def spline(self, splitting_plane=None, interval=None):
         """Extract a spline from a spline.
@@ -612,12 +615,12 @@ class Extractor:
             splitting_plane = dict(
                 sorted(splitting_plane.items(), key=lambda x: x[0])[::-1]
             )
-            spline_copy = self._spline.copy()
+            spline_copy = self._helpee.copy()
             for key, item in splitting_plane.items():
                 spline_copy = spline(spline_copy, key, item)
             return spline_copy
         else:
-            return spline(self._spline, splitting_plane, interval)
+            return spline(self._helpee, splitting_plane, interval)
 
 
 # Use function docstrings in Extractor functions

--- a/splinepy/helpme/ffd.py
+++ b/splinepy/helpme/ffd.py
@@ -290,7 +290,7 @@ class FFD(_SplinepyBase):
             raise ValueError("Please set a mesh before calling show()")
         return_showable = kwargs.pop("return_showable", False)
         return_gustaf = kwargs.pop("return_gustaf", False)
-        title = kwargs.pop("title", "gustaf - FFD")
+        title = kwargs.pop("title", "FFD")
 
         if return_gustaf and return_showable:
             raise ValueError(

--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -31,7 +31,7 @@ def volume(spline, orders=None):
 
     # Check i_nput type
     if not isinstance(spline, _Spline):
-        raise NotImplementedError("Extrude only works for splines")
+        raise NotImplementedError("volume integration only works for splines")
 
     # Determine integration points
     positions = []

--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -1,5 +1,4 @@
 import numpy as _np
-from gustaf.helpers._base import HelperBase as _HelperBase
 
 from splinepy.utils.data import cartesian_product as _cartesian_product
 
@@ -108,7 +107,7 @@ def physical_function(
     )
 
 
-class Integrator(_HelperBase):
+class Integrator:
     """Helper class to integrate some values on a given spline geometry
 
     Examples
@@ -126,7 +125,7 @@ class Integrator(_HelperBase):
       Spline parent
     """
 
-    __slots__ = ()
+    __slots__ = ("_helpee",)
 
     def __init__(self, spl):
         self._helpee = spl

--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -1,4 +1,5 @@
 import numpy as _np
+from gustaf.helpers._base import HelperBase as _HelperBase
 
 from splinepy.utils.data import cartesian_product as _cartesian_product
 
@@ -107,7 +108,7 @@ def physical_function(
     )
 
 
-class Integrator:
+class Integrator(_HelperBase):
     """Helper class to integrate some values on a given spline geometry
 
     Examples
@@ -125,8 +126,10 @@ class Integrator:
       Spline parent
     """
 
+    __slots__ = ()
+
     def __init__(self, spl):
-        self.spline = spl
+        self._helpee = spl
 
     def volume(self, *args, **kwargs):
-        return volume(self.spline, *args, **kwargs)
+        return volume(self._helpee, *args, **kwargs)

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -239,7 +239,8 @@ def _get_helper(spl, attr_name, helper_class):
     if attr is not None:  # hasattr
         return attr
 
-    # don't have attr - create and set
+    # if attr doesn't exist, create one and save to its member defined in
+    # slots
     helper_obj = helper_class(spl)
     setattr(spl, attr_name, helper_obj)
 
@@ -385,10 +386,6 @@ class Spline(_SplinepyBase, _core.PySpline):
     """
 
     __slots__ = (
-        "_extractor",
-        "_checker",
-        "_creator",
-        "_integrator",
         "_show_options",
         "_spline_data",
     )
@@ -566,7 +563,7 @@ class Spline(_SplinepyBase, _core.PySpline):
         --------
         extractor: Extractor
         """
-        return _get_helper(self, "_extractor", _Extractor)
+        return _Extractor(self)
 
     @property
     def check(self):
@@ -583,9 +580,9 @@ class Spline(_SplinepyBase, _core.PySpline):
 
         Returns
         --------
-        extractor: Extractor
+        checker: Checker
         """
-        return _get_helper(self, "_checker", _Checker)
+        return _Checker(self)
 
     @property
     def integrate(self):
@@ -607,7 +604,7 @@ class Spline(_SplinepyBase, _core.PySpline):
         --------
         integrator: Integrator
         """
-        return _get_helper(self, "_integrator", _Integrator)
+        return _Integrator(self)
 
     @property
     def create(self):
@@ -626,7 +623,7 @@ class Spline(_SplinepyBase, _core.PySpline):
         -------
         creator: spline.Creator
         """
-        return _get_helper(self, "_creator", _Creator)
+        return _Creator(self)
 
     @property
     def show_options(self):


### PR DESCRIPTION
# Overview
to avoid circular reference, we keep weakref of the helpee within helpers. See tataratat/gustaf#185.
Turns out, keeping everything weakref doesn't allow "chained"-one-line uses. So, we will just create helpers that don't have states on the fly. Ones that have states will use weakref - they are okay, since we won't use them in "chained"-one-lines.

## Addressed issues
*  fixed #327

