### PR TITLE
add extract.arrow_data

### DIFF
--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -974,7 +974,7 @@ class Creator:
         return determinant_spline(self._helpee, *args, **kwargs)
 
 
-# Use function docstrings in Extractor functions
+# Use function docstrings in Creator functions
 Creator.extruded.__doc__ = extruded.__doc__
 Creator.revolved.__doc__ = revolved.__doc__
 Creator.parametric_view.__doc__ = parametric_view.__doc__


### PR DESCRIPTION
# Overview
adds arrow_data extraction that respects show_options. There are times, where you want to just get data_origin, and arrow_end


## Addressed issues
*  Want arrows only, please

## Showcase
A short / one-liner example to highlight the (new) feature
```python
spline.spline_data["me"] = spp.SplineDataAdapter(spline, locations=np.random.random((10,10)))

edges = spline.extract.arrow_data("me")

begin_and_ends = edges.vertices[edges.edges]
print(begin_and_ends.shape)
# should be (n_locations, 2, dim)
```

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
