### PR TITLE
Selective Field Output in G+smo

### DIFF
--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -48,8 +48,8 @@ def _spline_to_ET(
     if fields_only and (len(multipatch.fields) == 0):
         return
 
-    if fields_only and fields_only is not None:
-        if not isinstance(fields_only, (list, np.ndarray)):
+    if fields_only and field_mask is not None:
+        if not isinstance(field_mask, (list, np.ndarray)):
             raise ValueError("field_mask must be list of integers")
         field_mask = np.unique(
             enforce_contiguous(field_mask, dtype=np.int64, asarray=True)

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -17,7 +17,7 @@ def _spline_to_ET(
     index_offset,
     fields_only=False,
     as_base64=False,
-    field_mask=True,
+    field_mask=None,
 ):
     """
     Write spline data to xml element in gismo format

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -49,10 +49,10 @@ def _spline_to_ET(
         return
 
     if fields_only and field_mask is not None:
-        if not isinstance(field_mask, (list, np.ndarray)):
+        if not isinstance(field_mask, (list, _np.ndarray)):
             raise ValueError("field_mask must be list of integers")
-        field_mask = np.unique(
-            enforce_contiguous(field_mask, dtype=np.int64, asarray=True)
+        field_mask = _np.unique(
+            _enforce_contiguous(field_mask, dtype=_np.int64, asarray=True)
         )
 
         # Check if range is valid
@@ -241,8 +241,9 @@ def export(
       'attributes'->dictionary (optional), 'children'->list in the same format
       (optional)
     export_fields : bool
-      Export fields to separate files ending with field<id>.xml, e.g.,
-      filename.xml.field.xml
+      Export fields to separate file ending with fields.xml, e.g.,
+      filename.xml.fields.xml. Only non-zero splines are exported to save
+      memory
     field_mask : list
       Selection of active fields that are exported (to save memory and speed up
       export)


### PR DESCRIPTION
# Overview
Field output is not in the usual gismo standard and only works together with [pygadjoint](https://github.com/tataratat/pygadjoints/tree/main) so I decided to extend the export functionality a little more.

## Addressed issues
*  Macro spline optimization sometimes only applies to a subset of all macro-spline ctps

@j042 I need this for optimisations only. I can have it on a separate branch for all eternity if you prefer. Also relevant for @kkILSB

## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
