### PR TITLE
update documentation method for helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,20 +10,20 @@ git clone git@github.com:<path-to-your-fork>
 cd splinepy  # or <forkname>
 git submodule update --init --recursive
 git checkout -b new-feature0
-pip install -e. --config-settings=cmake.args=-DSPLINEPY_MORE=OFF --config-settings=cmake.build-type="Debug"
+pip install -e. -v --config-settings=cmake.args=-DSPLINEPY_MORE=OFF --config-settings=cmake.build-type="Debug"
 ```
-`--config-settings=cmake.args=-DSPLINEPY_MORE` build argument builds splines up to 3D (both parametric and physical dimensions if they are part of template parameters), and that way we can reduce compile time. `--config-settings=cmake.build-type="Debug"` build also reduces compile time. We are experimenting with ways to reduce compile time during development. Let us know if you have a great idea!
+`--config-settings=cmake.args=-DSPLINEPY_MORE` build argument builds splines up to 3D (both parametric and physical dimensions if they are part of template parameters), and that way we can reduce compile time. `--config-settings=cmake.build-type="Debug"` build also reduces compile time. We are experimenting with ways to reduce compile time during development. Let us know if you have a good idea!
 
 ## Python style / implementation preferences
-- use [`PEP 8`](https://peps.python.org/pep-0008/) style guide for python code
+- use [`PEP 8`](https://peps.python.org/pep-0008/) style guide
 - no complex comphrehensions: preferably fits in a line, 2 lines max if it is totally necessary
 - use first letter abbreviations in element loops:  `for kv in knot_vectors`
 - use `i`, `j`, `k`, `l` for pure index: `for i, kv in enumerate(knot_vectors)`
 - module local import with a leading underscore: `from splinepy import settings as _settings`
-- to avoid redundancy, doc strings can be copied (see, e.g., helpme module)
+- make sure function wrappers are properly documented (see, e.g., helpme.create.Creator's member functions)
 
 ## C++ style / implementation preferences
-For c++, we've prepared a `.clang-format`, with that you can just run `clang-format`. We closely follow naming scheme suggested by [google stype guide](https://google.github.io/styleguide/cppguide.html#Naming), with a clear exception of file naming.
+For c++, we've prepared a `.clang-format`, with that you can just run `clang-format`. We closely follow naming scheme suggested by [google stype guide](https://google.github.io/styleguide/cppguide.html#Naming), with a clear exception of file naming: we use [`.hpp`, `.inl`, `.cpp`].
 Here's another preference:
 - `#pragma once`
 
@@ -38,7 +38,6 @@ precommit run -a
 ```bash
 pip install -r docs/requirements.txt
 python3 docs/source/handle_markdown.py
-sphinx-build -b html docs/source docs/build -E -j auto
-# `-E` to ignore existing files, -j auto for parallel build (or specify number
-# of processes) you can now open `docs/build/index.html` with your browser
+sphinx-build -b html docs/source docs/build -E
+# you can now open `docs/build/index.html` with your browser
 ```

--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -1,3 +1,5 @@
+from functools import wraps as _wraps
+
 import numpy as _np
 
 
@@ -75,9 +77,6 @@ class Checker:
     def __init__(self, spl):
         self._helpee = spl
 
+    @_wraps(valid_queries)
     def valid_queries(self, queries):
         return valid_queries(self._helpee, queries)
-
-
-# Use function docstrings in Checker functions
-Checker.valid_queries.__doc__ = valid_queries.__doc__

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -1,3 +1,5 @@
+from functools import wraps as _wraps
+
 import numpy as _np
 from gustaf.utils import arr as _arr
 
@@ -961,21 +963,18 @@ class Creator:
     def __init__(self, spl):
         self._helpee = spl
 
+    @_wraps(extruded)
     def extruded(self, *args, **kwargs):
         return extruded(self._helpee, *args, **kwargs)
 
+    @_wraps(revolved)
     def revolved(self, *args, **kwargs):
         return revolved(self._helpee, *args, **kwargs)
 
+    @_wraps(parametric_view)
     def parametric_view(self, *args, **kwargs):
         return parametric_view(self._helpee, *args, **kwargs)
 
+    @_wraps(determinant_spline)
     def determinant_spline(self, *args, **kwargs):
         return determinant_spline(self._helpee, *args, **kwargs)
-
-
-# Use function docstrings in Creator functions
-Creator.extruded.__doc__ = extruded.__doc__
-Creator.revolved.__doc__ = revolved.__doc__
-Creator.parametric_view.__doc__ = parametric_view.__doc__
-Creator.determinant_spline.__doc__ = determinant_spline.__doc__

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -692,7 +692,7 @@ class Extractor:
 
         Parameters
         ----------
-        splitting_plane : int or dictionary {int : (float, float))
+        splitting_plane : int or dictionary {int : (float, float)}
           if int : parametric dimension to be extracted
           if dict : list of splitting planes and ranges to be passed
         interval : float or tuple<float,float>

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -1,3 +1,5 @@
+from functools import wraps as _wraps
+
 import numpy as _np
 from gustaf import Edges as _Edges
 from gustaf import Faces as _Faces
@@ -410,7 +412,7 @@ def spline(spline, para_dim, split_plane):
     spline: Spline / Multipatch
       (`self`-argument if called via extract member of a spline)
     para_dim : int
-      parametric dimension to be extract ted
+      parametric dimension to be extracted
     split_plane : float / tuple<float, float>
       interval or value in parametric space to be extracted from the spline
       representation
@@ -628,27 +630,35 @@ class Extractor:
             raise ValueError("Extractor expects a Spline or Multipatch type")
         self._helpee = spl
 
+    @_wraps(edges)
     def edges(self, *args, **kwargs):
         return edges(self._helpee, *args, **kwargs)
 
+    @_wraps(faces)
     def faces(self, *args, **kwargs):
         return faces(self._helpee, *args, **kwargs)
 
+    @_wraps(volumes)
     def volumes(self, *args, **kwargs):
         return volumes(self._helpee, *args, **kwargs)
 
+    @_wraps(control_points)
     def control_points(self):
         return control_points(self._helpee)
 
+    @_wraps(control_edges)
     def control_edges(self):
         return control_edges(self._helpee)
 
+    @_wraps(control_faces)
     def control_faces(self):
         return control_faces(self._helpee)
 
+    @_wraps(control_points)
     def control_volumes(self):
         return control_volumes(self._helpee)
 
+    @_wraps(control_mesh)
     def control_mesh(self):
         return control_mesh(self._helpee)
 
@@ -670,6 +680,7 @@ class Extractor:
             return [self._helpee]
         return self._helpee.extract_bezier_patches()
 
+    @_wraps(boundaries)
     def boundaries(self, *args, **kwargs):
         return boundaries(self._helpee, *args, **kwargs)
 
@@ -681,12 +692,13 @@ class Extractor:
 
         Parameters
         ----------
-        splitting_plane : int / dictionary (int : (float))
-          if integer : parametric dimension to be extracted
-          if dictionary : list of splitting planes and ranges to be passed
-        interval : float / tuple<float,float>
+        splitting_plane : int or dictionary {int : (float, float))
+          if int : parametric dimension to be extracted
+          if dict : list of splitting planes and ranges to be passed
+        interval : float or tuple<float,float>
           interval or value in parametric space to be extracted from the
           spline representation
+
         Returns
         -------
         spline
@@ -704,17 +716,6 @@ class Extractor:
         else:
             return spline(self._helpee, splitting_plane, interval)
 
+    @_wraps(arrow_data)
     def arrow_data(self, *args, **kwargs):
         return arrow_data(self._helpee, *args, **kwargs)
-
-
-# Use function docstrings in Extractor functions
-Extractor.edges.__doc__ = edges.__doc__
-Extractor.faces.__doc__ = faces.__doc__
-Extractor.volumes.__doc__ = volumes.__doc__
-Extractor.control_points.__doc__ = control_points.__doc__
-Extractor.control_edges.__doc__ = control_edges.__doc__
-Extractor.control_faces.__doc__ = control_faces.__doc__
-Extractor.control_volumes.__doc__ = control_volumes.__doc__
-Extractor.control_mesh.__doc__ = control_mesh.__doc__
-Extractor.boundaries.__doc__ = boundaries.__doc__

--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -1,3 +1,5 @@
+from functools import wraps as _wraps
+
 import numpy as _np
 
 from splinepy.utils.data import cartesian_product as _cartesian_product
@@ -130,5 +132,6 @@ class Integrator:
     def __init__(self, spl):
         self._helpee = spl
 
+    @_wraps(volume)
     def volume(self, *args, **kwargs):
         return volume(self._helpee, *args, **kwargs)


### PR DESCRIPTION
# Overview
Instead of grabbing onto `__docs__`, this PR uses built-in functools to document helper functions.

## Addressed issues
*  aesthetics 

## Checklists
* [ ] Documentations are up-to-date.
