### PR TITLE
revert default only-python-install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.cw_build }}
         CIBW_TEST_SKIP: "*-macosx_arm64"
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
+        SKBUILD_INSTALL_COMPONENTS: PythonModule
 
     - uses: actions/upload-artifact@v3
       with:
@@ -50,6 +51,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
+        SKBUILD_INSTALL_COMPONENTS: PythonModule
 
     - uses: actions/upload-artifact@v3
       with:
@@ -74,6 +76,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.cw_build }}
         CIBW_TEST_SKIP: "*-win_arm64"
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
+        SKBUILD_INSTALL_COMPONENTS: PythonModule
 
     - uses: actions/upload-artifact@v3
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ wheel.packages = [
 build-dir = "build"
 
 install.strip = true
-install.components = ["PythonModule"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
# Overview
Reverting part of #364, where we only install `PythonModule`. For local builds, it is very convenient to have them installed (at least for my use case). For wheel builds and distribution, we keep this to reduce wheel size. We can perhaps set a specific version of python and add all the targets only for that one.

## Addressed issues
*  Need all components for local use
