### PR TITLE
add __array_wrap__

### DIFF
--- a/splinepy/utils/data.py
+++ b/splinepy/utils/data.py
@@ -164,6 +164,11 @@ class PhysicalSpaceArray(_np.ndarray):
         self._sync_source_ptr()
         return sr
 
+    def __array_wrap__(self, *args, **kwargs):
+        sr = super(self.__class__, self).__array_wrap__(*args, **kwargs)
+        self._sync_source_ptr()
+        return sr
+
     def __setitem__(self, key, value):
         # set first. invalid setting will cause error
         sr = super(self.__class__, self).__setitem__(key, value)

--- a/tests/test_property_modification.py
+++ b/tests/test_property_modification.py
@@ -194,7 +194,13 @@ class InplaceModificationTest(c.SplineBasedTestCase):
         n.cps[..., :1] = -62.5
         cps_are_synced(n)
 
-        # 8. if you have ideas for use case not listed above, please add!
+        # 8. ufunc
+        c.np.add(n.cps, n.cps, out=n.cps)
+        cps_are_synced(n)
+        c.np.multiply(n.cps, n.cps, out=n.cps)
+        cps_are_synced(n)
+
+        # 9. if you have ideas for use case not listed above, please add!
 
         # now, child arrays
         carr = n.cps[0]


### PR DESCRIPTION
# Overview
using numpy's ufunc, PhysicalSpaceArray won't sync afterward. Now they do.

## Addressed issues
*  `np.add(spline.cps, values, out=spline.cps)` won't sync core control points


## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
