### PR TITLE
*WIP* Inline type hints

### DIFF
--- a/examples/basis_and_support.py
+++ b/examples/basis_and_support.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     kv = [[0, 0, 0, 0.5, 1, 1, 1], [0, 0, 0, 1, 1, 1], [0, 0, 1, 1]]
     cp1 = np.array(
         [
@@ -57,3 +58,7 @@ if __name__ == "__main__":
         *b.basis_and_support(q), b.control_points.shape[0], as_array=True
     )
     print(basis_function_matrix)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/create_basic_splines.py
+++ b/examples/create_basic_splines.py
@@ -3,7 +3,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     line = splinepy.helpme.create.line(
         np.array([[0, 0, 0], [2, 5, 0], [4, 4, 2]])
     )
@@ -40,3 +41,7 @@ if __name__ == "__main__":
 
     sphere = splinepy.helpme.create.sphere(3)
     gus.show(["Sphere", sphere], resolution=50)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/export_spline_svg.py
+++ b/examples/export_spline_svg.py
@@ -6,62 +6,72 @@ import numpy as np
 
 import splinepy as spp
 
-box = spp.helpme.create.box(10, 5).bspline
-box.elevate_degrees([0, 1])
-box.insert_knots(0, [0.5])
 
-# Create a simple curve
-spline_curve = spp.Bezier(degrees=[2], control_points=[[0, 0], [2, 0], [2, 2]])
-spp.io.svg.export("spline_curve_1.svg", spline_curve)
+def example():
+    box = spp.helpme.create.box(10, 5).bspline
+    box.elevate_degrees([0, 1])
+    box.insert_knots(0, [0.5])
 
-# Make it more complex
-rational_spline_curve = spline_curve.nurbs
-rational_spline_curve.elevate_degrees([0, 0])
-rational_spline_curve.insert_knots(0, [0.4, 0.6])
-rational_spline_curve.weights = np.random.random(
-    rational_spline_curve.cps.shape[0]
-)
-spp.io.svg.export("spline_curve_3.svg", rational_spline_curve)
+    # Create a simple curve
+    spline_curve = spp.Bezier(
+        degrees=[2], control_points=[[0, 0], [2, 0], [2, 2]]
+    )
+    spp.io.svg.export("spline_curve_1.svg", spline_curve)
 
-# Export some surfaces
-circle = spp.helpme.create.surface_circle(1)
-spp.io.svg.export("spline_circle_1.svg", circle)
+    # Make it more complex
+    rational_spline_curve = spline_curve.nurbs
+    rational_spline_curve.elevate_degrees([0, 0])
+    rational_spline_curve.insert_knots(0, [0.4, 0.6])
+    rational_spline_curve.weights = np.random.random(
+        rational_spline_curve.cps.shape[0]
+    )
+    spp.io.svg.export("spline_curve_3.svg", rational_spline_curve)
 
-#
-circle = circle.nurbs
-circle.insert_knots(0, [0.333, 0.666])
-circle.insert_knots(1, [0.333, 0.666])
-circle.spline_data["field"] = circle
-# svg export also respects many of the show_option configurations
-circle.show_options["arrow_data"] = "field"
-circle.show_options["arrow_data_scale"] = 0.4
-circle.show_options["arrow_data_on"] = spp.utils.data.cartesian_product(
-    [np.linspace(0, 1, 10) for _ in range(2)]
-)
-spp.io.svg.export("spline_circle_2.svg", circle, box_margins=1.0)
+    # Export some surfaces
+    circle = spp.helpme.create.surface_circle(1)
+    spp.io.svg.export("spline_circle_1.svg", circle)
 
-# Create a spline with a scalar field
-distorted_rectangle = spp.Bezier(
-    degrees=[2, 2],
-    control_points=[
-        [0.0, 0.0],
-        [1.0, 0.5],
-        [2.0, 0.0],
-        [0.5, 0.8],
-        [1.2, 1.0],
-        [2.3, 1.0],
-        [0.0, 2.0],
-        [1.0, 1.5],
-        [2.0, 1.8],
-    ],
-).bspline
-distorted_rectangle.insert_knots(0, [0.2, 0.4, 0.6, 0.8])
-distorted_rectangle.insert_knots(1, [0.25, 0.5, 0.75])
+    #
+    circle = circle.nurbs
+    circle.insert_knots(0, [0.333, 0.666])
+    circle.insert_knots(1, [0.333, 0.666])
+    circle.spline_data["field"] = circle
+    # svg export also respects many of the show_option configurations
+    circle.show_options["arrow_data"] = "field"
+    circle.show_options["arrow_data_scale"] = 0.4
+    circle.show_options["arrow_data_on"] = spp.utils.data.cartesian_product(
+        [np.linspace(0, 1, 10) for _ in range(2)]
+    )
+    spp.io.svg.export("spline_circle_2.svg", circle, box_margins=1.0)
 
-# Extract a field (jacobian determinant spline projection)
-jacobian_determinant_spline = distorted_rectangle.create.determinant_spline()
-distorted_rectangle.spline_data["jac_dets"] = jacobian_determinant_spline
-distorted_rectangle.show_options["data"] = "jac_dets"
-spp.io.svg.export(
-    "spline_rectangle_with_field.svg", distorted_rectangle, box_margins=1.0
-)
+    # Create a spline with a scalar field
+    distorted_rectangle = spp.Bezier(
+        degrees=[2, 2],
+        control_points=[
+            [0.0, 0.0],
+            [1.0, 0.5],
+            [2.0, 0.0],
+            [0.5, 0.8],
+            [1.2, 1.0],
+            [2.3, 1.0],
+            [0.0, 2.0],
+            [1.0, 1.5],
+            [2.0, 1.8],
+        ],
+    ).bspline
+    distorted_rectangle.insert_knots(0, [0.2, 0.4, 0.6, 0.8])
+    distorted_rectangle.insert_knots(1, [0.25, 0.5, 0.75])
+
+    # Extract a field (jacobian determinant spline projection)
+    jacobian_determinant_spline = (
+        distorted_rectangle.create.determinant_spline()
+    )
+    distorted_rectangle.spline_data["jac_dets"] = jacobian_determinant_spline
+    distorted_rectangle.show_options["data"] = "jac_dets"
+    spp.io.svg.export(
+        "spline_rectangle_with_field.svg", distorted_rectangle, box_margins=1.0
+    )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/extract_spline_from_spline.py
+++ b/examples/extract_spline_from_spline.py
@@ -2,7 +2,8 @@ import gustaf as gus
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     # create 2p2d nurbs
     s_nurbs = splinepy.Bezier(
         degrees=[2, 1],
@@ -25,3 +26,7 @@ if __name__ == "__main__":
         ["extract.spline({0: [0.4, 0.8], 1: 0.7})", line, s_nurbs],
         ["Extracted spline", line],
     )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/ffd.py
+++ b/examples/ffd.py
@@ -2,7 +2,8 @@ import gustaf as gus
 
 import splinepy as sp
 
-if __name__ == "__main__":
+
+def example():
     # 1.
     # create mesh 2d - extracted from bspline
     mesh_2d = sp.helpme.create.disk(
@@ -68,3 +69,7 @@ if __name__ == "__main__":
     ffd_with_out_mesh.spline = spline_3d
     ffd_with_out_mesh.mesh = volume_3d
     ffd_with_out_mesh.show(title="Setting spline first, then mesh")
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/fitting.py
+++ b/examples/fitting.py
@@ -3,7 +3,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     # 1. Curve fitting
     # Create a function that creates the points for approximation
     def f(x):
@@ -23,7 +24,6 @@ if __name__ == "__main__":
         return np.max(distances), np.mean(distances)
 
     n_sample = 25
-    n_resolution = 3 * n_sample
     x = np.linspace(-1, 1, n_sample)
     fitting_points = np.vstack([x, f(x)]).T.reshape(-1, 2)
     pts = gus.create.vertices.Vertices(fitting_points)
@@ -88,7 +88,6 @@ if __name__ == "__main__":
 
     # 2. Surface fitting
     n_sample = [20, 20]
-    resolution = [3 * n for n in n_sample]
 
     # Create dataset
     x = [np.linspace(-1, 1, n) for n in n_sample]
@@ -180,3 +179,7 @@ if __name__ == "__main__":
         for (cps, surface, errs) in approximated_surfaces
     ]
     gus.show(*gus_list)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/iga/collocation_laplace_problem.py
+++ b/examples/iga/collocation_laplace_problem.py
@@ -20,90 +20,91 @@ try:
 except ImportError:
     has_scipy = False
 
-# Test Case
-n_refine = 15
 
+def example():
+    # Test Case
+    n_refine = 15
 
-# Source Function
-def source_function(x):
-    return np.ones(x.shape[0])
+    # Source Function
+    def source_function(x):
+        return np.ones(x.shape[0])
 
-
-# Define the Geometry
-geometry = sp.BSpline(
-    degrees=[2, 2],
-    control_points=[
-        [0.0, 0.0],
-        [1.0, 0.5],
-        [2.0, 0.2],
-        [0.5, 1.5],
-        [1.0, 1.5],
-        [1.5, 1.5],
-        [0.0, 3.0],
-        [1.0, 2.5],
-        [2.0, 3.0],
-    ],
-    knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
-)
-
-# Define the solution field
-solution_field = sp.BSpline(
-    degrees=geometry.degrees,
-    control_points=np.ones((geometry.control_points.shape[0], 1)),
-    knot_vectors=geometry.knot_vectors,
-)
-
-
-# Use refinement
-solution_field.elevate_degrees([0, 1, 0, 1])
-new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
-solution_field.insert_knots(0, new_knots)
-solution_field.insert_knots(1, new_knots)
-
-
-# Get greville points and geometric values
-evaluation_points = solution_field.greville_abscissae()
-mapper = solution_field.mapper(reference=geometry)
-
-# Compute Laplacian matrix
-laplacian = sp.utils.data.make_matrix(
-    *mapper.basis_laplacian_and_support(evaluation_points),
-    solution_field.control_points.shape[0],
-)
-
-# Evaluate RHS function
-physical_points = geometry.evaluate(evaluation_points)
-rhs = source_function(physical_points)
-
-# Set dirichlet values (identify boundary nodes and set matrix to identity rhs
-# to 0)
-indices = np.hstack(
-    (
-        solution_field.multi_index[0, :],
-        solution_field.multi_index[-1, :],
-        solution_field.multi_index[:, 0],
-        solution_field.multi_index[:, -1],
-    )
-)
-laplacian[indices, :] = 0
-laplacian[indices, indices] = 1
-rhs[indices] = 0
-
-# Solve linear system
-if has_scipy:
-    solution_field.control_points = scipy.sparse.linalg.spsolve(
-        -laplacian, rhs
-    ).reshape(-1, 1)
-else:
-    solution_field.control_points = np.linalg.solve(-laplacian, rhs).reshape(
-        -1, 1
+    # Define the Geometry
+    geometry = sp.BSpline(
+        degrees=[2, 2],
+        control_points=[
+            [0.0, 0.0],
+            [1.0, 0.5],
+            [2.0, 0.2],
+            [0.5, 1.5],
+            [1.0, 1.5],
+            [1.5, 1.5],
+            [0.0, 3.0],
+            [1.0, 2.5],
+            [2.0, 3.0],
+        ],
+        knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
     )
 
+    # Define the solution field
+    solution_field = sp.BSpline(
+        degrees=geometry.degrees,
+        control_points=np.ones((geometry.control_points.shape[0], 1)),
+        knot_vectors=geometry.knot_vectors,
+    )
 
-# Plot geometry and field
-geometry.spline_data["field"] = solution_field
-geometry.show_options["data"] = "field"
-geometry.show_options["cmap"] = "jet"
-geometry.show_options["lighting"] = "off"
-geometry.show_options["scalarbar"] = True
-geometry.show(knots=True, control_points=False)
+    # Use refinement
+    solution_field.elevate_degrees([0, 1, 0, 1])
+    new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
+    solution_field.insert_knots(0, new_knots)
+    solution_field.insert_knots(1, new_knots)
+
+    # Get greville points and geometric values
+    evaluation_points = solution_field.greville_abscissae()
+    mapper = solution_field.mapper(reference=geometry)
+
+    # Compute Laplacian matrix
+    laplacian = sp.utils.data.make_matrix(
+        *mapper.basis_laplacian_and_support(evaluation_points),
+        solution_field.control_points.shape[0],
+    )
+
+    # Evaluate RHS function
+    physical_points = geometry.evaluate(evaluation_points)
+    rhs = source_function(physical_points)
+
+    # Set dirichlet values (identify boundary nodes and set matrix to identity rhs
+    # to 0)
+    indices = np.hstack(
+        (
+            solution_field.multi_index[0, :],
+            solution_field.multi_index[-1, :],
+            solution_field.multi_index[:, 0],
+            solution_field.multi_index[:, -1],
+        )
+    )
+    laplacian[indices, :] = 0
+    laplacian[indices, indices] = 1
+    rhs[indices] = 0
+
+    # Solve linear system
+    if has_scipy:
+        solution_field.control_points = scipy.sparse.linalg.spsolve(
+            -laplacian, rhs
+        ).reshape(-1, 1)
+    else:
+        solution_field.control_points = np.linalg.solve(
+            -laplacian, rhs
+        ).reshape(-1, 1)
+
+    # Plot geometry and field
+    geometry.spline_data["field"] = solution_field
+    geometry.show_options["data"] = "field"
+    geometry.show_options["cmap"] = "jet"
+    geometry.show_options["lighting"] = "off"
+    geometry.show_options["scalarbar"] = True
+    geometry.show(knots=True, control_points=False)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/iga/collocation_laplace_problem_sparse.py
+++ b/examples/iga/collocation_laplace_problem_sparse.py
@@ -14,86 +14,88 @@ from scipy.sparse import linalg
 
 import splinepy as sp
 
-# Test Case
-n_refine = 15
 
+def example():
+    # Test Case
+    n_refine = 15
 
-# Source Function
-def source_function(x):
-    return np.ones(x.shape[0])
+    # Source Function
+    def source_function(x):
+        return np.ones(x.shape[0])
 
-
-# Define the Geometry
-geometry = sp.BSpline(
-    degrees=[2, 2],
-    control_points=[
-        [0.0, 0.0],
-        [1.0, 0.5],
-        [2.0, 0.2],
-        [0.5, 1.5],
-        [1.0, 1.5],
-        [1.5, 1.5],
-        [0.0, 3.0],
-        [1.0, 2.5],
-        [2.0, 3.0],
-    ],
-    knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
-)
-
-# Define the solution field
-solution_field = sp.BSpline(
-    degrees=geometry.degrees,
-    control_points=np.ones((geometry.control_points.shape[0], 1)),
-    knot_vectors=geometry.knot_vectors,
-)
-
-
-# Use refinement
-solution_field.elevate_degrees([0, 1, 0, 1])
-new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
-solution_field.insert_knots(0, new_knots)
-solution_field.insert_knots(1, new_knots)
-
-
-# Get greville points and geometric values
-evaluation_points = solution_field.greville_abscissae()
-mapper = solution_field.mapper(reference=geometry)
-sp_laplacian = sp.utils.data.make_matrix(
-    *mapper.basis_laplacian_and_support(evaluation_points),
-    solution_field.cps.shape[0],
-    as_array=False,
-)
-
-
-# Evaluate RHS function
-physical_points = geometry.evaluate(evaluation_points)
-rhs = source_function(physical_points)
-
-# Set dirichlet values (identify boundary nodes and set matrix to identity rhs
-# to 0)
-boundary_dof_ids = np.concatenate(
-    (
-        solution_field.multi_index[0, :],
-        solution_field.multi_index[-1, :],
-        solution_field.multi_index[1:-1, 0],
-        solution_field.multi_index[1:-1, -1],
+    # Define the Geometry
+    geometry = sp.BSpline(
+        degrees=[2, 2],
+        control_points=[
+            [0.0, 0.0],
+            [1.0, 0.5],
+            [2.0, 0.2],
+            [0.5, 1.5],
+            [1.0, 1.5],
+            [1.5, 1.5],
+            [0.0, 3.0],
+            [1.0, 2.5],
+            [2.0, 3.0],
+        ],
+        knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
     )
-)
-sp_laplacian[boundary_dof_ids] *= 0  # this does not change sparsity pattern
-sp_laplacian[boundary_dof_ids, boundary_dof_ids] = 1
 
-rhs[boundary_dof_ids] = 0.0
+    # Define the solution field
+    solution_field = sp.BSpline(
+        degrees=geometry.degrees,
+        control_points=np.ones((geometry.control_points.shape[0], 1)),
+        knot_vectors=geometry.knot_vectors,
+    )
 
-# Solve linear system
-solution_field.control_points[:] = linalg.spsolve(-sp_laplacian, rhs).reshape(
-    -1, 1
-)
+    # Use refinement
+    solution_field.elevate_degrees([0, 1, 0, 1])
+    new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
+    solution_field.insert_knots(0, new_knots)
+    solution_field.insert_knots(1, new_knots)
+
+    # Get greville points and geometric values
+    evaluation_points = solution_field.greville_abscissae()
+    mapper = solution_field.mapper(reference=geometry)
+    sp_laplacian = sp.utils.data.make_matrix(
+        *mapper.basis_laplacian_and_support(evaluation_points),
+        solution_field.cps.shape[0],
+        as_array=False,
+    )
+
+    # Evaluate RHS function
+    physical_points = geometry.evaluate(evaluation_points)
+    rhs = source_function(physical_points)
+
+    # Set dirichlet values (identify boundary nodes and set matrix to identity rhs
+    # to 0)
+    boundary_dof_ids = np.concatenate(
+        (
+            solution_field.multi_index[0, :],
+            solution_field.multi_index[-1, :],
+            solution_field.multi_index[1:-1, 0],
+            solution_field.multi_index[1:-1, -1],
+        )
+    )
+    sp_laplacian[
+        boundary_dof_ids
+    ] *= 0  # this does not change sparsity pattern
+    sp_laplacian[boundary_dof_ids, boundary_dof_ids] = 1
+
+    rhs[boundary_dof_ids] = 0.0
+
+    # Solve linear system
+    solution_field.control_points[:] = linalg.spsolve(
+        -sp_laplacian, rhs
+    ).reshape(-1, 1)
+
+    # Plot geometry and field
+    geometry.spline_data["field"] = solution_field
+    geometry.show_options["data"] = "field"
+    geometry.show_options["cmap"] = "jet"
+    geometry.show_options["lighting"] = "off"
+    geometry.show_options["scalarbar"] = True
+    geometry.show(knots=True, control_points=False)
 
 
-# Plot geometry and field
-geometry.spline_data["field"] = solution_field
-geometry.show_options["data"] = "field"
-geometry.show_options["cmap"] = "jet"
-geometry.show_options["lighting"] = "off"
-geometry.show_options["scalarbar"] = True
-geometry.show(knots=True, control_points=False)
+if __name__ == "__main__":
+    example()

--- a/examples/iga/galerkin_laplace_problem.py
+++ b/examples/iga/galerkin_laplace_problem.py
@@ -13,138 +13,142 @@ import numpy as np
 
 import splinepy as sp
 
-# Test Case
-n_refine = 15
 
+def example():
+    # Test Case
+    n_refine = 15
 
-# Source Function
-def source_function(x):
-    return np.ones(x.shape[0])
+    # Source Function
+    def source_function(x):
+        return np.ones(x.shape[0])
 
+    # Auxiliary function to map positions into the element
+    def map_positions(positions, x_min, x_max, y_min, y_max):
+        mapped_positions = np.empty(positions.shape, dtype=np.float64)
+        mapped_positions[:, 0] = (x_max - x_min) * 0.5 * positions[:, 0] + (
+            x_max + x_min
+        ) * 0.5
+        mapped_positions[:, 1] = (y_max - y_min) * 0.5 * positions[:, 0] + (
+            y_max + y_min
+        ) * 0.5
+        return mapped_positions
 
-# Auxiliary function to map positions into the element
-def map_positions(positions, x_min, x_max, y_min, y_max):
-    mapped_positions = np.empty(positions.shape, dtype=np.float64)
-    mapped_positions[:, 0] = (x_max - x_min) * 0.5 * positions[:, 0] + (
-        x_max + x_min
-    ) * 0.5
-    mapped_positions[:, 1] = (y_max - y_min) * 0.5 * positions[:, 0] + (
-        y_max + y_min
-    ) * 0.5
-    return mapped_positions
-
-
-# Define the Geometry
-geometry = sp.BSpline(
-    degrees=[2, 2],
-    control_points=[
-        [0.0, 0.0],
-        [1.0, 0.5],
-        [2.0, 0.2],
-        [0.5, 1.5],
-        [1.0, 1.5],
-        [1.5, 1.5],
-        [0.0, 3.0],
-        [1.0, 2.5],
-        [2.0, 3.0],
-    ],
-    knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
-)
-
-# Define the solution field
-solution_field = sp.BSpline(
-    degrees=geometry.degrees,
-    control_points=np.ones((geometry.control_points.shape[0], 1)),
-    knot_vectors=geometry.knot_vectors,
-)
-
-
-# Use refinement
-solution_field.elevate_degrees([0, 1, 0, 1])
-new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
-solution_field.insert_knots(0, new_knots)
-solution_field.insert_knots(1, new_knots)
-
-# Retrieve integration points and weights
-max_order = int(np.max(solution_field.degrees))
-positions, weights = np.polynomial.legendre.leggauss(deg=max_order)
-positions = sp.utils.data.cartesian_product(
-    [positions for _ in range(geometry.para_dim)]
-)
-weights = sp.utils.data.cartesian_product(
-    [weights for _ in range(geometry.para_dim)]
-)
-weights = np.prod(weights, axis=1)
-
-# Assemble individual elements
-ukv = solution_field.unique_knots
-n_dofs = solution_field.control_points.shape[0]
-system_matrix = np.zeros((n_dofs, n_dofs))
-system_rhs = np.zeros(n_dofs)
-mapper = solution_field.mapper(reference=geometry)
-
-# Element Loop
-for i in range(len(ukv[0]) - 1):
-    for j in range(len(ukv[1]) - 1):
-        # Auxiliary values
-        mapped_positions = map_positions(
-            positions,
-            ukv[0][i],
-            ukv[0][i + 1],
-            ukv[1][j],
-            ukv[1][j + 1],
-        )
-        det_jacs = np.linalg.det(geometry.jacobian(mapped_positions))
-
-        # RHS
-        # q : quadrature point | d: dim
-        bf, support = solution_field.basis_and_support(mapped_positions)
-        assert np.all(support[0, :] == support)
-        system_rhs[support[0, :]] += np.einsum(
-            "qj,q,q->j", bf, weights, det_jacs, optimize=True
-        )
-
-        # LHS
-        bf_jacobian, support = mapper.basis_gradient_and_support(
-            mapped_positions
-        )
-        assert np.all(support[0, :] == support)
-        local_matrix = np.einsum(
-            "qid,qjd,q,q->ij",
-            bf_jacobian,
-            bf_jacobian,
-            weights,
-            det_jacs,
-            optimize=True,
-        )
-        support = sp.utils.data.cartesian_product(
-            (support[0, :], support[0, :])
-        )
-        system_matrix[support[:, 0], support[:, 1]] += local_matrix.flatten()
-
-# Set dirichlet values (identify boundary nodes and set matrix to identity rhs
-# to 0)
-indices = np.hstack(
-    (
-        solution_field.multi_index[0, :],
-        solution_field.multi_index[-1, :],
-        solution_field.multi_index[:, 0],
-        solution_field.multi_index[:, -1],
+    # Define the Geometry
+    geometry = sp.BSpline(
+        degrees=[2, 2],
+        control_points=[
+            [0.0, 0.0],
+            [1.0, 0.5],
+            [2.0, 0.2],
+            [0.5, 1.5],
+            [1.0, 1.5],
+            [1.5, 1.5],
+            [0.0, 3.0],
+            [1.0, 2.5],
+            [2.0, 3.0],
+        ],
+        knot_vectors=[[0, 0, 0, 1, 1, 1], [0, 0, 0, 1, 1, 1]],
     )
-)
-system_matrix[indices, :] = 0
-system_matrix[indices, indices] = 1
-system_rhs[indices] = 0
 
-# Solve linear system
-solution_field.control_points = np.linalg.solve(
-    system_matrix, system_rhs
-).reshape(-1, 1)
+    # Define the solution field
+    solution_field = sp.BSpline(
+        degrees=geometry.degrees,
+        control_points=np.ones((geometry.control_points.shape[0], 1)),
+        knot_vectors=geometry.knot_vectors,
+    )
 
-# Plot geometry and field
-geometry.spline_data["field"] = solution_field
-geometry.show_options["data"] = "field"
-geometry.show_options["cmap"] = "jet"
-geometry.show_options["lighting"] = "off"
-geometry.show_options["scalarbar"] = True
-geometry.show(knots=True, control_points=False)
+    # Use refinement
+    solution_field.elevate_degrees([0, 1, 0, 1])
+    new_knots = np.linspace(1 / n_refine, 1, n_refine, endpoint=False)
+    solution_field.insert_knots(0, new_knots)
+    solution_field.insert_knots(1, new_knots)
+
+    # Retrieve integration points and weights
+    max_order = int(np.max(solution_field.degrees))
+    positions, weights = np.polynomial.legendre.leggauss(deg=max_order)
+    positions = sp.utils.data.cartesian_product(
+        [positions for _ in range(geometry.para_dim)]
+    )
+    weights = sp.utils.data.cartesian_product(
+        [weights for _ in range(geometry.para_dim)]
+    )
+    weights = np.prod(weights, axis=1)
+
+    # Assemble individual elements
+    ukv = solution_field.unique_knots
+    n_dofs = solution_field.control_points.shape[0]
+    system_matrix = np.zeros((n_dofs, n_dofs))
+    system_rhs = np.zeros(n_dofs)
+    mapper = solution_field.mapper(reference=geometry)
+
+    # Element Loop
+    for i in range(len(ukv[0]) - 1):
+        for j in range(len(ukv[1]) - 1):
+            # Auxiliary values
+            mapped_positions = map_positions(
+                positions,
+                ukv[0][i],
+                ukv[0][i + 1],
+                ukv[1][j],
+                ukv[1][j + 1],
+            )
+            det_jacs = np.linalg.det(geometry.jacobian(mapped_positions))
+
+            # RHS
+            # q : quadrature point | d: dim
+            bf, support = solution_field.basis_and_support(mapped_positions)
+            assert np.all(support[0, :] == support)
+            system_rhs[support[0, :]] += np.einsum(
+                "qj,q,q->j", bf, weights, det_jacs, optimize=True
+            )
+
+            # LHS
+            bf_jacobian, support = mapper.basis_gradient_and_support(
+                mapped_positions
+            )
+            assert np.all(support[0, :] == support)
+            local_matrix = np.einsum(
+                "qid,qjd,q,q->ij",
+                bf_jacobian,
+                bf_jacobian,
+                weights,
+                det_jacs,
+                optimize=True,
+            )
+            support = sp.utils.data.cartesian_product(
+                (support[0, :], support[0, :])
+            )
+            system_matrix[
+                support[:, 0], support[:, 1]
+            ] += local_matrix.flatten()
+
+    # Set dirichlet values (identify boundary nodes and set matrix to identity rhs
+    # to 0)
+    indices = np.hstack(
+        (
+            solution_field.multi_index[0, :],
+            solution_field.multi_index[-1, :],
+            solution_field.multi_index[:, 0],
+            solution_field.multi_index[:, -1],
+        )
+    )
+    system_matrix[indices, :] = 0
+    system_matrix[indices, indices] = 1
+    system_rhs[indices] = 0
+
+    # Solve linear system
+    solution_field.control_points = np.linalg.solve(
+        system_matrix, system_rhs
+    ).reshape(-1, 1)
+
+    # Plot geometry and field
+    geometry.spline_data["field"] = solution_field
+    geometry.show_options["data"] = "field"
+    geometry.show_options["cmap"] = "jet"
+    geometry.show_options["lighting"] = "off"
+    geometry.show_options["scalarbar"] = True
+    geometry.show(knots=True, control_points=False)
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/parallel_derivative.py
+++ b/examples/parallel_derivative.py
@@ -10,7 +10,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     # define a bspline
     ds = [2, 2]
     kvs = [
@@ -98,3 +99,7 @@ if __name__ == "__main__":
         np.vstack(res_mp), res_s
     ), "Something went wrong during evaluation"
     assert np.allclose(res_t, res_s), "Something went wrong during evaluation"
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/parallel_evaluation.py
+++ b/examples/parallel_evaluation.py
@@ -9,7 +9,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     # define a bspline
     ds = [2, 2]
     kvs = [
@@ -93,3 +94,7 @@ if __name__ == "__main__":
         np.vstack(res_mp), res_s
     ), "Something went wrong during evaluation"
     assert np.allclose(res_t, res_s), "Something went wrong during evaluation"
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -2,30 +2,67 @@
 """
 
 import glob
+import importlib
 import itertools
+import os
 import pathlib
-import subprocess
 import sys
 
+import gustaf
+
 if __name__ == "__main__":
+    gustaf.settings.DEFAULT_OFFSCREEN = True
     files_not_completed = []
     examples_root_dir = pathlib.Path(__file__).parent.absolute()
-    for file in itertools.chain(
+    current_dir = pathlib.Path(os.getcwd()).absolute()
+    # find all example files
+    for file_ in itertools.chain(
         glob.glob(str(examples_root_dir / "*.py")),
         glob.glob(str(examples_root_dir / "iga/*.py")),
     ):
-        if "run_all_examples.py" in file:
+        # ignore this file
+        if "run_all_examples.py" in file_:
             continue
+        # i like pathlib so i convert the path into it
+        file = pathlib.Path(file_)
+        print(
+            f"file: {file}",
+            f"file.parent: {file.parent}",
+            f"current_dir: {current_dir}",
+            f"file.stem: {file.stem}",
+        )
+        # change directory to the file's directory so that imports are
+        # relative to the file's directory
+        os.chdir(file.parent)
         print(f"Calling {file}")
-        proc_return = subprocess.run([sys.executable, file], check=False)
-        if proc_return.returncode != 0:
+        # import and call the file
+        try:
+            # add the file's directory to the path so importlib can
+            # import it
+            sys.path.insert(0, f"{file.parent}{os.sep}")
+            example = importlib.import_module(file.stem)
+        except Exception as e:
+            print(f"Failed to import {file}.")
+            print(f"Error: {e}")
             files_not_completed.append(file)
+            continue
+        try:
+            # run example
+            example.example()
+        except Exception as e:
+            print(f"Failed to call {file}.")
+            print(f"Error: {e}")
+            files_not_completed.append(file)
+            continue
+        # change directory back to the original directory
+        os.chdir(current_dir)
+
+    # print out all files that have failed and give system exit code
     if len(files_not_completed) > 0:
         print(
             f"Failed to call {len(files_not_completed)} files: "
             f"{files_not_completed}."
         )
         sys.exit(1)
-
     print("All files completed successfully.")
     sys.exit(0)

--- a/examples/show_bsplines.py
+++ b/examples/show_bsplines.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     # curve
     # define degrees
     ds1 = [1]
@@ -99,3 +100,7 @@ if __name__ == "__main__":
     )
 
     bspline3.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_gus.py
+++ b/examples/show_gus.py
@@ -4,13 +4,14 @@ import gustaf as gus
 
 import splinepy
 
-WITH_PUPILS = False
-WITH_DARK_BACKGROUND = False
-DARK_WITH_WHITE_OVAL_BACKGROUND = False
-WITH_ALPHA_BACKGROUND = False
 
-if __name__ == "__main__":
-    if WITH_ALPHA_BACKGROUND:
+def example(
+    with_pupiles: bool = False,
+    with_dark_background: bool = False,
+    dark_with_white_oval_background: bool = False,
+    with_alpha_background: bool = False,
+):
+    if with_alpha_background:
         import vedo
 
         vedo.settings.screenshot_transparent_background = 1
@@ -96,20 +97,20 @@ if __name__ == "__main__":
     lower_lip.show_options["knots"] = False
 
     item_to_show = [l_eye, r_eye, upper_lip, inner_mouth, lower_lip]
-    if WITH_PUPILS:
+    if with_pupiles:
         item_to_show += [l_pupil, r_pupil]
 
-    plt = gus.show(
+    gus.show(
         item_to_show,
         lighting="off",
         background="white",
         close=False,
     )
 
-    if WITH_DARK_BACKGROUND:
+    if with_dark_background:
         background = []
 
-        if DARK_WITH_WHITE_OVAL_BACKGROUND:
+        if dark_with_white_oval_background:
             height = 0.6
             width = 0
 
@@ -137,9 +138,13 @@ if __name__ == "__main__":
             l_pupil.show_options["c"] = "black"
             r_pupil.show_options["c"] = "black"
 
-        plt = gus.show(
+        gus.show(
             [*background, *item_to_show],
             lighting="off",
             background="black",
             close=False,
         )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_isophotes_and_curvature.py
+++ b/examples/show_isophotes_and_curvature.py
@@ -16,15 +16,6 @@ import numpy as np
 
 import splinepy as sp
 
-# Create a random spline surface in 3D
-a = sp.helpme.create.box(1, 1).bspline
-a.elevate_degrees([0, 1, 0, 1])
-a.insert_knots(0, [0.33333, 0.66667])
-a.insert_knots(1, [0.33333, 0.66667])
-a.control_points = np.hstack(
-    [a.cps, np.random.random((a.cps.shape[0], 1)) * 0.5]
-)
-
 
 # Function to create a Callable for the SplineDataAdaptor
 def isophotes_to_direction(normal=None, interval=0.02):
@@ -45,7 +36,7 @@ def isophotes_to_direction(normal=None, interval=0.02):
 
 
 # Gaussian Curvature
-def gaussian_curvature(data, on):
+def gaussian_curvature_f(data, on):
     v1 = data.derivative(on, [1, 0])
     v2 = data.derivative(on, [0, 1])
     v3 = data.derivative(on, [2, 0])
@@ -62,7 +53,7 @@ def gaussian_curvature(data, on):
 
 
 # Mean Curvature
-def mean_curvature(data, on=None):
+def mean_curvature_f(data, on=None):
     v1 = data.derivative(on, [1, 0])
     v2 = data.derivative(on, [0, 1])
     v3 = data.derivative(on, [2, 0])
@@ -83,31 +74,44 @@ def mean_curvature(data, on=None):
     return k_g
 
 
-# Spline Adaptor to plot function
-isophotes = sp.SplineDataAdaptor(
-    a, function=isophotes_to_direction(normal=[0, 0, 1])
-)
-mean_curvature = sp.SplineDataAdaptor(a, function=mean_curvature)
-gaussian_curvature = sp.SplineDataAdaptor(a, function=gaussian_curvature)
+def example():
+    # Create a random spline surface in 3D
+    a = sp.helpme.create.box(1, 1).bspline
+    a.elevate_degrees([0, 1, 0, 1])
+    a.insert_knots(0, [0.33333, 0.66667])
+    a.insert_knots(1, [0.33333, 0.66667])
+    a.control_points = np.hstack(
+        [a.cps, np.random.random((a.cps.shape[0], 1)) * 0.5]
+    )
+    # Spline Adaptor to plot function
+    isophotes = sp.SplineDataAdaptor(
+        a, function=isophotes_to_direction(normal=[0, 0, 1])
+    )
+    mean_curvature = sp.SplineDataAdaptor(a, function=mean_curvature_f)
+    gaussian_curvature = sp.SplineDataAdaptor(a, function=gaussian_curvature_f)
 
-# Set Plot options
-a.spline_data["isophotes"] = isophotes
-a.spline_data["gaussian_curvature"] = gaussian_curvature
-a.spline_data["mean_curvature"] = mean_curvature
-a.show_options["lighting"] = "off"
-a.show_options["control_points"] = False
-a.show_options["knots"] = False
+    # Set Plot options
+    a.spline_data["isophotes"] = isophotes
+    a.spline_data["gaussian_curvature"] = gaussian_curvature
+    a.spline_data["mean_curvature"] = mean_curvature
+    a.show_options["lighting"] = "off"
+    a.show_options["control_points"] = False
+    a.show_options["knots"] = False
 
-# Show Isophotes
-a.show_options["data"] = "isophotes"
-a.show(resolutions=1000, title="Isophotes")
+    # Show Isophotes
+    a.show_options["data"] = "isophotes"
+    a.show(resolutions=1000, title="Isophotes")
 
-# Show Gaussian Curvature
-a.show_options["data"] = "gaussian_curvature"
-a.show_options["scalarbar"] = True
-a.show(resolutions=100, title="Gaussian Curvature")
+    # Show Gaussian Curvature
+    a.show_options["data"] = "gaussian_curvature"
+    a.show_options["scalarbar"] = True
+    a.show(resolutions=100, title="Gaussian Curvature")
 
-# Show Curvature
-a.show_options["data"] = "mean_curvature"
-a.show_options["scalarbar"] = True
-a.show(resolutions=100, title="Mean Curvature")
+    # Show Curvature
+    a.show_options["data"] = "mean_curvature"
+    a.show_options["scalarbar"] = True
+    a.show(resolutions=100, title="Mean Curvature")
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_microstructures.py
+++ b/examples/show_microstructures.py
@@ -3,374 +3,375 @@ import numpy as np
 
 import splinepy
 
-# Simple Microstructure consisting Bezier-splines only
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[2, 1],
-    control_points=[[0, 0], [1, 0], [2, -1], [-1, 1], [1, 1], [3, 2]],
-)
-generator.microtile = [
-    splinepy.Bezier(
-        degrees=[3], control_points=[[0, 0.5], [0.5, 1], [0.5, 0], [1, 0.5]]
-    ),
-    splinepy.Bezier(
-        degrees=[4],
-        control_points=[
-            [0.5, 0],
-            [0.75, 0.5],
-            [0.8, 0.8],
-            [0.25, 0.5],
-            [0.5, 1],
-        ],
-    ),
-]
-generator.tiling = [8, 8]
-ms = generator.create(macro_sensitivities=True)
 
-
-# Plot the ms with some of its fields
-for i in range(0, len(ms.fields), 3):
-    ms.spline_data["field"] = i
-    ms.show_options["arrow_data"] = "field"
-    ms.show_options["arrow_data_on"] = np.linspace(0, 1, 5).reshape(-1, 1)
-    ms.show_options["arrow_data_scale"] = 0.1
-    ctps, dim = divmod(i, ms.dim)
-    gus.show(
-        [f"Derivative wrt C{ctps},{dim}", ms],
-        lighting="off",
-        control_points=False,
-        resolutions=100,
+def example():
+    # Simple Microstructure consisting Bezier-splines only
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[2, 1],
+        control_points=[[0, 0], [1, 0], [2, -1], [-1, 1], [1, 1], [3, 2]],
     )
+    generator.microtile = [
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[[0, 0.5], [0.5, 1], [0.5, 0], [1, 0.5]],
+        ),
+        splinepy.Bezier(
+            degrees=[4],
+            control_points=[
+                [0.5, 0],
+                [0.75, 0.5],
+                [0.8, 0.8],
+                [0.25, 0.5],
+                [0.5, 1],
+            ],
+        ),
+    ]
+    generator.tiling = [8, 8]
+    ms = generator.create(macro_sensitivities=True)
 
-# Visualize all available microtiles
-micro_tiles = []
-module_list = map(
-    splinepy.microstructure.tiles.__dict__.get,
-    splinepy.microstructure.tiles.__all__,
-)
-for mt in module_list:
-    if hasattr(mt, "create_tile"):
-        if not isinstance(mt().create_tile(), tuple):
-            mt().create_tile()
-            raise ValueError("Must be tuple in updated version")
-        micro_tiles.append(
-            [
-                mt.__qualname__,
-                mt().create_tile()[0],
-            ]
+    # Plot the ms with some of its fields
+    for i in range(0, len(ms.fields), 3):
+        ms.spline_data["field"] = i
+        ms.show_options["arrow_data"] = "field"
+        ms.show_options["arrow_data_on"] = np.linspace(0, 1, 5).reshape(-1, 1)
+        ms.show_options["arrow_data_scale"] = 0.1
+        ctps, dim = divmod(i, ms.dim)
+        gus.show(
+            [f"Derivative wrt C{ctps},{dim}", ms],
+            lighting="off",
+            control_points=False,
+            resolutions=100,
         )
-gus.show(
-    *micro_tiles,
-    resolutions=7,
-    control_points=False,
-    knots=True,
-    lighting="off",
-)
 
-# Parameter spline
-para_spline = splinepy.BSpline(
-    degrees=[1, 1],
-    knot_vectors=[[0, 0, 2, 2], [0, 0, 1, 1]],
-    control_points=[[0.25], [0.3], [0.1], [0.25]],
-)
-
-
-def para_function(x):
-    return para_spline.evaluate(x)
-
-
-def para_sens_function(x):
-    return splinepy.utils.data.make_matrix(
-        *para_spline.basis_and_support(x),
-        para_spline.cps.shape[0],
-        as_array=True,
-    ).reshape(x.shape[0], 1, para_spline.cps.shape[0])
-
-
-# Parametrized microstructure inner and outer derivatives
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.BSpline(
-    degrees=[1, 1],
-    knot_vectors=[[0, 0, 1, 2, 2], [0, 0, 1, 1]],
-    control_points=[[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]],
-)
-generator.tiling = [2, 2]
-generator.parameter_sensitivity_function = para_sens_function
-generator.parametrization_function = para_function
-generator.microtile = splinepy.microstructure.tiles.Cross2D()
-ms = generator.create(macro_sensitivities=True)
-len(ms.fields)
-
-# Plot the ms with its fields
-for i in range(0, len(ms.fields), 3):
-    ms.spline_data["field"] = i
-    ms.show_options["arrow_data"] = "field"
-    ctps, dim = divmod(i - 4, ms.dim)
-    title = (
-        f"Derivative with respect to Parameter-Spline Coefficient {i}"
-        if i < 4
-        else f"Derivative wrt C{ctps},{dim}"
+    # Visualize all available microtiles
+    micro_tiles = []
+    module_list = map(
+        splinepy.microstructure.tiles.__dict__.get,
+        splinepy.microstructure.tiles.__all__,
     )
-    gus.show([title, ms], lighting="off", control_points=False, knots=False)
-
-
-def foo(x):
-    return 0.1 * np.sum(x, axis=1).reshape(-1, 1)
-
-
-# Cube 3D without closing face
-generator = splinepy.microstructure.microstructure.Microstructure()
-generator.microtile = splinepy.microstructure.tiles.HollowCube()
-
-generator.parametrization_function = foo
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-).create.extruded(extrusion_vector=[0, 0, 1])
-generator.tiling = [3, 3, 2]
-generator.show(
-    knots=True,
-    control_points=False,
-    title="3D Cube Microstructure",
-    resolutions=3,
-    alpha=0.05,
-)
-
-
-para_s = splinepy.BSpline(
-    knot_vectors=[
-        [0, 0, 1 / 5, 2 / 5, 3 / 5, 4 / 5, 1, 1],
-        [0, 0, 1 / 3, 2 / 3, 1, 1],
-    ],
-    degrees=[1, 1],
-    control_points=[
-        [0.15],
-        [0.15],
-        [0.15],
-        [0.15],
-        [0.05],
-        [0.05],
-        [0.05],
-        [0.05],
-        [0.15],
-        [0.15],
-        [0.15],
-        [0.05],
-        [0.05],
-        [0.1],
-        [0.15],
-        [0.05],
-        [0.15],
-        [0.15],
-        [0.2],
-        [0.2],
-        [0.2],
-        [0.15],
-        [0.15],
-        [0.24],
-    ],
-)
-
-
-# Test new microstructure
-def parameter_function_double_lattice(x):
-    """
-    Parametrization Function (determines thickness)
-    """
-    return para_s.evaluate(x)
-
-
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [2, 0], [0, 1], [2, 1]]
-)
-generator.microtile = splinepy.microstructure.tiles.DoubleLattice()
-generator.tiling = [12, 6]
-generator.parametrization_function = parameter_function_double_lattice
-my_ms = generator.create(contact_length=0.4)
-generator.show(
-    use_saved=True,
-    knots=True,
-    control_points=False,
-    title="2D Nuttile Parametrized Microstructure",
-    contact_length=0.4,
-    resolutions=2,
-)
-gus.show(my_ms, knots=True, control_points=False, resolutions=2)
-
-
-def parametrization_function_nut(x):
-    return np.ones((len(x), 1)) * 0.3
-
-
-# Structure with Nut-tile
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-)
-generator.microtile = splinepy.microstructure.tiles.HollowOctagon()
-generator.tiling = [10, 10]
-generator.parametrization_function = parametrization_function_nut
-my_ms = generator.create(closing_face="x", contact_length=0.4)
-generator.show(
-    use_saved=True,
-    knots=True,
-    control_points=False,
-    title="2D Nuttile Parametrized Microstructure",
-    contact_length=0.4,
-    resolutions=2,
-)
-
-
-# Classical cross tile 2D
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-)
-generator.microtile = splinepy.microstructure.tiles.Cross2D()
-generator.tiling = [5, 5]
-generator.parametrization_function = parameter_function_double_lattice
-ms = generator.create(closing_face="x", center_expansion=1.3)
-generator.show(
-    use_saved=True,
-    knots=True,
-    control_points=False,
-    title="2D Crosstile Parametrized Microstructure",
-)
-
-# Micro tile with three bezier lines
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-).create.extruded(extrusion_vector=[0, 0, 1])
-generator.microtile = [
-    splinepy.Bezier(
-        degrees=[3],
-        control_points=[
-            [0, 0.5, 0.5],
-            [0.5, 1, 0.5],
-            [0.5, 0, 0.5],
-            [1, 0.5, 0.5],
-        ],
-    ),
-    splinepy.Bezier(
-        degrees=[3],
-        control_points=[
-            [0.5, 0.5, 0.0],
-            [0.5, 0, 0.5],
-            [0.5, 1.0, 0.5],
-            [0.5, 0.5, 1.0],
-        ],
-    ),
-    splinepy.Bezier(
-        degrees=[3],
-        control_points=[
-            [0.5, 0, 0.5],
-            [1, 0.5, 0.5],
-            [0, 0.5, 0.5],
-            [0.5, 1, 0.5],
-        ],
-    ),
-]
-generator.tiling = [1, 2, 3]
-generator.show(
-    knots=False, control_points=False, title="3D Lattice Microstructure"
-)
-
-# Cross tile 3D in a microstructure
-generator = splinepy.microstructure.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-).create.extruded(extrusion_vector=[0, 0, 1])
-generator.microtile = splinepy.microstructure.tiles.Cross3D()
-generator.tiling = [2, 2, 3]
-generator.show(
-    control_points=False, resolutions=2, title="3D Crosstile Microstructure"
-)
-
-# Non-uniform tiling
-generator = splinepy.microstructure.microstructure.Microstructure()
-generator.deformation_function = splinepy.BSpline(
-    degrees=[2, 1],
-    control_points=[
-        [0, 0],
-        [0.1, 0],
-        [0.2, 0],
-        [1, 0],
-        [0, 1],
-        [0.1, 1],
-        [0.2, 2],
-        [1, 3],
-    ],
-    knot_vectors=[[0, 0, 0, 0.15, 1, 1, 1], [0, 0, 1, 1]],
-)
-generator.microtile = [
-    splinepy.Bezier(
-        degrees=[3], control_points=[[0, 0.5], [0.5, 1], [0.5, 0], [1, 0.5]]
-    ),
-    splinepy.Bezier(
-        degrees=[3], control_points=[[0.5, 0], [1, 0.5], [0, 0.5], [0.5, 1]]
-    ),
-]
-generator.tiling = [5, 1]
-generator.show(
-    knot_span_wise=False,
-    control_points=False,
-    resolutions=20,
-    title="2D Lattice with global tiling",
-)
-
-
-def foo(x):
-    """
-    Parametrization Function (determines thickness)
-    """
-    return (x[:, 0] * 0.05 + x[:, 1] * 0.05 + x[:, 2] * 0.1 + 0.1).reshape(
-        -1, 1
+    for mt in module_list:
+        if hasattr(mt, "create_tile"):
+            if not isinstance(mt().create_tile(), tuple):
+                mt().create_tile()
+                raise ValueError("Must be tuple in updated version")
+            micro_tiles.append(
+                [
+                    mt.__qualname__,
+                    mt().create_tile()[0],
+                ]
+            )
+    gus.show(
+        *micro_tiles,
+        resolutions=7,
+        control_points=False,
+        knots=True,
+        lighting="off",
     )
 
+    # Parameter spline
+    para_spline = splinepy.BSpline(
+        degrees=[1, 1],
+        knot_vectors=[[0, 0, 2, 2], [0, 0, 1, 1]],
+        control_points=[[0.25], [0.3], [0.1], [0.25]],
+    )
 
-# A Parametrized microstructure and its respective inverse structure
-generator = splinepy.microstructure.Microstructure()
-generator.deformation_function = splinepy.Bezier(
-    degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
-).create.extruded(extrusion_vector=[0, 0, 1])
-generator.microtile = splinepy.microstructure.tiles.InverseCross3D()
-generator.tiling = [3, 3, 5]
-generator.parametrization_function = foo
+    def para_function(x):
+        return para_spline.evaluate(x)
 
-inverse_microstructure = generator.create(
-    closing_face="z", seperator_distance=0.4, center_expansion=1.3
-)
+    def para_sens_function(x):
+        return splinepy.utils.data.make_matrix(
+            *para_spline.basis_and_support(x),
+            para_spline.cps.shape[0],
+            as_array=True,
+        ).reshape(x.shape[0], 1, para_spline.cps.shape[0])
 
-# Plot the results
-_, showables_inverse = generator.show(
-    closing_face="z",
-    seperator_distance=0.4,
-    center_expansion=1.3,
-    title="Parametrized Inverse Microstructure",
-    control_points=False,
-    knots=True,
-    return_showable_list=True,
-    resolutions=5,
-    c="hotpink",
-)
+    # Parametrized microstructure inner and outer derivatives
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.BSpline(
+        degrees=[1, 1],
+        knot_vectors=[[0, 0, 1, 2, 2], [0, 0, 1, 1]],
+        control_points=[[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]],
+    )
+    generator.tiling = [2, 2]
+    generator.parameter_sensitivity_function = para_sens_function
+    generator.parametrization_function = para_function
+    generator.microtile = splinepy.microstructure.tiles.Cross2D()
+    ms = generator.create(macro_sensitivities=True)
+    len(ms.fields)
 
-# Corresponding Structure
-generator.microtile = splinepy.microstructure.tiles.Cross3D()
-microstructure = generator.create(
-    closing_face="z", seperator_distance=0.4, center_expansion=1.3
-)
-_, showables = generator.show(
-    closing_face="z",
-    center_expansion=1.3,
-    title="Parametrized Microstructure",
-    control_points=False,
-    knots=True,
-    return_showable_list=True,
-    resolutions=5,
-)
+    # Plot the ms with its fields
+    for i in range(0, len(ms.fields), 3):
+        ms.spline_data["field"] = i
+        ms.show_options["arrow_data"] = "field"
+        ctps, dim = divmod(i - 4, ms.dim)
+        title = (
+            f"Derivative with respect to Parameter-Spline Coefficient {i}"
+            if i < 4
+            else f"Derivative wrt C{ctps},{dim}"
+        )
+        gus.show(
+            [title, ms], lighting="off", control_points=False, knots=False
+        )
 
-gus.show(
-    [*showables_inverse, *showables],
-    title="Parametrized Microstructure and its inverse",
-)
+    def foo(x):
+        return 0.1 * np.sum(x, axis=1).reshape(-1, 1)
+
+    # Cube 3D without closing face
+    generator = splinepy.microstructure.microstructure.Microstructure()
+    generator.microtile = splinepy.microstructure.tiles.HollowCube()
+
+    generator.parametrization_function = foo
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    ).create.extruded(extrusion_vector=[0, 0, 1])
+    generator.tiling = [3, 3, 2]
+    generator.show(
+        knots=True,
+        control_points=False,
+        title="3D Cube Microstructure",
+        resolutions=3,
+        alpha=0.05,
+    )
+
+    para_s = splinepy.BSpline(
+        knot_vectors=[
+            [0, 0, 1 / 5, 2 / 5, 3 / 5, 4 / 5, 1, 1],
+            [0, 0, 1 / 3, 2 / 3, 1, 1],
+        ],
+        degrees=[1, 1],
+        control_points=[
+            [0.15],
+            [0.15],
+            [0.15],
+            [0.15],
+            [0.05],
+            [0.05],
+            [0.05],
+            [0.05],
+            [0.15],
+            [0.15],
+            [0.15],
+            [0.05],
+            [0.05],
+            [0.1],
+            [0.15],
+            [0.05],
+            [0.15],
+            [0.15],
+            [0.2],
+            [0.2],
+            [0.2],
+            [0.15],
+            [0.15],
+            [0.24],
+        ],
+    )
+
+    # Test new microstructure
+    def parameter_function_double_lattice(x):
+        """
+        Parametrization Function (determines thickness)
+        """
+        return para_s.evaluate(x)
+
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [2, 0], [0, 1], [2, 1]]
+    )
+    generator.microtile = splinepy.microstructure.tiles.DoubleLattice()
+    generator.tiling = [12, 6]
+    generator.parametrization_function = parameter_function_double_lattice
+    my_ms = generator.create(contact_length=0.4)
+    generator.show(
+        use_saved=True,
+        knots=True,
+        control_points=False,
+        title="2D Nuttile Parametrized Microstructure",
+        contact_length=0.4,
+        resolutions=2,
+    )
+    gus.show(my_ms, knots=True, control_points=False, resolutions=2)
+
+    def parametrization_function_nut(x):
+        return np.ones((len(x), 1)) * 0.3
+
+    # Structure with Nut-tile
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    )
+    generator.microtile = splinepy.microstructure.tiles.HollowOctagon()
+    generator.tiling = [10, 10]
+    generator.parametrization_function = parametrization_function_nut
+    my_ms = generator.create(closing_face="x", contact_length=0.4)
+    generator.show(
+        use_saved=True,
+        knots=True,
+        control_points=False,
+        title="2D Nuttile Parametrized Microstructure",
+        contact_length=0.4,
+        resolutions=2,
+    )
+
+    # Classical cross tile 2D
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    )
+    generator.microtile = splinepy.microstructure.tiles.Cross2D()
+    generator.tiling = [5, 5]
+    generator.parametrization_function = parameter_function_double_lattice
+    ms = generator.create(closing_face="x", center_expansion=1.3)
+    generator.show(
+        use_saved=True,
+        knots=True,
+        control_points=False,
+        title="2D Crosstile Parametrized Microstructure",
+    )
+
+    # Micro tile with three bezier lines
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    ).create.extruded(extrusion_vector=[0, 0, 1])
+    generator.microtile = [
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[
+                [0, 0.5, 0.5],
+                [0.5, 1, 0.5],
+                [0.5, 0, 0.5],
+                [1, 0.5, 0.5],
+            ],
+        ),
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[
+                [0.5, 0.5, 0.0],
+                [0.5, 0, 0.5],
+                [0.5, 1.0, 0.5],
+                [0.5, 0.5, 1.0],
+            ],
+        ),
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[
+                [0.5, 0, 0.5],
+                [1, 0.5, 0.5],
+                [0, 0.5, 0.5],
+                [0.5, 1, 0.5],
+            ],
+        ),
+    ]
+    generator.tiling = [1, 2, 3]
+    generator.show(
+        knots=False, control_points=False, title="3D Lattice Microstructure"
+    )
+
+    # Cross tile 3D in a microstructure
+    generator = splinepy.microstructure.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    ).create.extruded(extrusion_vector=[0, 0, 1])
+    generator.microtile = splinepy.microstructure.tiles.Cross3D()
+    generator.tiling = [2, 2, 3]
+    generator.show(
+        control_points=False,
+        resolutions=2,
+        title="3D Crosstile Microstructure",
+    )
+
+    # Non-uniform tiling
+    generator = splinepy.microstructure.microstructure.Microstructure()
+    generator.deformation_function = splinepy.BSpline(
+        degrees=[2, 1],
+        control_points=[
+            [0, 0],
+            [0.1, 0],
+            [0.2, 0],
+            [1, 0],
+            [0, 1],
+            [0.1, 1],
+            [0.2, 2],
+            [1, 3],
+        ],
+        knot_vectors=[[0, 0, 0, 0.15, 1, 1, 1], [0, 0, 1, 1]],
+    )
+    generator.microtile = [
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[[0, 0.5], [0.5, 1], [0.5, 0], [1, 0.5]],
+        ),
+        splinepy.Bezier(
+            degrees=[3],
+            control_points=[[0.5, 0], [1, 0.5], [0, 0.5], [0.5, 1]],
+        ),
+    ]
+    generator.tiling = [5, 1]
+    generator.show(
+        knot_span_wise=False,
+        control_points=False,
+        resolutions=20,
+        title="2D Lattice with global tiling",
+    )
+
+    def foo(x):
+        """
+        Parametrization Function (determines thickness)
+        """
+        return (x[:, 0] * 0.05 + x[:, 1] * 0.05 + x[:, 2] * 0.1 + 0.1).reshape(
+            -1, 1
+        )
+
+    # A Parametrized microstructure and its respective inverse structure
+    generator = splinepy.microstructure.Microstructure()
+    generator.deformation_function = splinepy.Bezier(
+        degrees=[1, 1], control_points=[[0, 0], [1, 0], [0, 1], [1, 1]]
+    ).create.extruded(extrusion_vector=[0, 0, 1])
+    generator.microtile = splinepy.microstructure.tiles.InverseCross3D()
+    generator.tiling = [3, 3, 5]
+    generator.parametrization_function = foo
+
+    # inverse microstructure
+    _ = generator.create(
+        closing_face="z", seperator_distance=0.4, center_expansion=1.3
+    )
+
+    # Plot the results
+    _, showables_inverse = generator.show(
+        closing_face="z",
+        seperator_distance=0.4,
+        center_expansion=1.3,
+        title="Parametrized Inverse Microstructure",
+        control_points=False,
+        knots=True,
+        return_showable_list=True,
+        resolutions=5,
+        c="hotpink",
+    )
+
+    # Corresponding Structure
+    generator.microtile = splinepy.microstructure.tiles.Cross3D()
+    # microstructure
+    _ = generator.create(
+        closing_face="z", seperator_distance=0.4, center_expansion=1.3
+    )
+    _, showables = generator.show(
+        closing_face="z",
+        center_expansion=1.3,
+        title="Parametrized Microstructure",
+        control_points=False,
+        knots=True,
+        return_showable_list=True,
+        resolutions=5,
+    )
+
+    gus.show(
+        [*showables_inverse, *showables],
+        title="Parametrized Microstructure and its inverse",
+    )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_multipatch.py
+++ b/examples/show_multipatch.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import splinepy
 
-if __name__ == "__main__":
+
+def example():
     """
     x1
     *---*---*
@@ -75,3 +76,7 @@ if __name__ == "__main__":
     m.show_options["data"] = "detJ"
     m.show_options["lighting"] = "off"
     m.show()
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_spline_data.py
+++ b/examples/show_spline_data.py
@@ -42,7 +42,7 @@ def bspline2p3d():
     )
 
 
-if __name__ == "__main__":
+def example():
     # turn on debug logs
     # gus.utils.log.configure(debug=True)
 
@@ -280,3 +280,7 @@ if __name__ == "__main__":
             bezier,
         ]
     )
+
+
+if __name__ == "__main__":
+    example()

--- a/examples/show_tataratat.py
+++ b/examples/show_tataratat.py
@@ -6,199 +6,209 @@ import vedo
 
 import splinepy
 
-# this will cause a deprecated warning for newer version of vedo.
-# for backward compatibility, we keep this one.
-vedo.settings.screenshot_transparent_background = 1
+
+def example():
+    # this will cause a deprecated warning for newer version of vedo.
+    # for backward compatibility, we keep this one.
+    vedo.settings.screenshot_transparent_background = 1
+
+    if __name__ == "__main__":
+        arg_parser = argparse.ArgumentParser(
+            description=(
+                "Creates a fanfare. Default option corresponds to "
+                "the tataratat logo."
+            )
+        )
+        arg_parser.add_argument(
+            "--r_mouth",
+            dest="r_mouth",
+            default=0.2,
+            help="Mouth radius for mouth piece.",
+        )
+        arg_parser.add_argument(
+            "--r_shaft",
+            dest="r_shaft",
+            default=0.1,
+            help="Shaft radius for mouth piece.",
+        )
+        arg_parser.add_argument(
+            "--r_rounding",
+            dest="r_rounding",
+            default=0.05,
+            help="Radius offset for mouth piece rounding.",
+        )
+        arg_parser.add_argument(
+            "--l_mouth",
+            dest="l_mouth",
+            default=0.4,
+            help="Length of the mouth piece.",
+        )
+        arg_parser.add_argument(
+            "--l_cone",
+            dest="l_cone",
+            default=1.2,
+            help="Length of the cone.",
+        )
+        arg_parser.add_argument(
+            "--r_cone",
+            dest="r_cone",
+            default=0.8,
+            help="Radius of the cone.",
+        )
+        arg_parser.add_argument(
+            "--l_shaft",
+            dest="l_shaft",
+            default=4.0,
+            help="Length of the shaft.",
+        )
+        arg_parser.add_argument(
+            "--r_curve",
+            dest="r_curve",
+            default=0.3,
+            help="Radius of connecting curves.",
+        )
+        args = arg_parser.parse_args()
+
+        # Let's draw a fanfare
+        fanfare = []
+
+        # cast all args to float
+        # Mouthpiece
+        r_mouth = float(args.r_mouth)
+        r_shaft = float(args.r_shaft)
+        r_rounding = float(args.r_rounding)
+        l_mouth = float(args.l_mouth)
+        # Cone
+        l_cone = float(args.l_cone)
+        r_cone = float(args.r_cone)
+        # Shaft
+        l_shaft = float(args.l_shaft)
+        curved_radius = float(args.r_curve)
+
+        # Create fanfare part by part
+        mouth_piece = splinepy.BSpline(
+            knot_vectors=[[0, 0, 0, 0.25, 0.5, 0.5, 0.75, 1, 1, 1]],
+            degrees=[2],
+            control_points=[
+                [l_mouth, r_mouth - r_rounding],
+                [l_mouth + r_rounding, r_mouth - r_rounding],
+                [l_mouth + r_rounding, r_mouth],
+                [l_mouth, r_mouth],
+                [0.5 * l_mouth, r_mouth],
+                [0.5 * l_mouth, r_shaft],
+                [0.0, r_shaft],
+            ],
+        ).nurbs.create.revolved(
+            axis=[1, 0, 0],
+            center=[0, 0, 0],
+            angle=360,
+            degree=True,
+            n_knot_spans=4,
+        )
+
+        isqrt2 = 2 ** (-0.5)
+        cross_section = splinepy.NURBS(
+            degrees=[2],
+            knot_vectors=[
+                [0, 0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1, 1, 1]
+            ],
+            control_points=(
+                np.array(
+                    [
+                        [0.0, 0, 0],
+                        [0.0, 0.5, -0.5],
+                        [0.0, 1, 0],
+                        [0.0, 1 + 0.5, 0.5],
+                        [0.0, 1, 1],
+                        [0.0, 0.5, 1 + 0.5],
+                        [0.0, 0, 1],
+                        [0.0, -0.5, 0.5],
+                        [0, 0, 0],
+                    ]
+                )
+                + np.array([0, -0.5, -0.5])
+            )
+            * (r_shaft * 2 * isqrt2),
+            weights=[1, isqrt2, 1, isqrt2, 1, isqrt2, 1, isqrt2, 1],
+        )
+
+        shaft = cross_section.create.extruded(
+            extrusion_vector=[-l_shaft, 0, 0]
+        )
+
+        lower_shaft = shaft.copy()
+        lower_shaft.control_points += [0, -2 * curved_radius, 0]
+        upper_shaft = shaft.copy()
+        upper_shaft.control_points += [
+            0,
+            -2 * curved_radius + 2 * isqrt2 * curved_radius,
+            -2 * isqrt2 * curved_radius,
+        ]
+
+        cross_section.control_points += [-l_shaft, 0, 0]
+
+        curved_piece = cross_section.nurbs.create.revolved(
+            axis=[0.0, 0, 1], center=[-l_shaft, -curved_radius, 0], angle=180
+        )
+        cross_section.control_points += [l_shaft, -2 * curved_radius, 0]
+        second_curved_piece = cross_section.nurbs.create.revolved(
+            axis=[0, 1.0, 1.0],
+            center=[
+                0,
+                -2 * curved_radius + isqrt2 * curved_radius,
+                -isqrt2 * curved_radius,
+            ],
+            angle=180,
+        )
+
+        cone_part = splinepy.BSpline(
+            degrees=[2],
+            knot_vectors=[[0, 0, 0, 0.5, 1, 1, 1]],
+            control_points=[
+                [0.0, r_shaft, 0.0],
+                [-0.25 * l_cone, r_shaft, 0.0],
+                [-l_cone, 0.5 * (r_cone + r_shaft), 0.0],
+                [-l_cone, r_cone, 0.0],
+            ],
+        ).nurbs.create.revolved(
+            axis=[1, 0, 0],
+            center=[0, 0, 0],
+            angle=360,
+            degree=True,
+        )
+        cone_part.control_points += [
+            -l_shaft,
+            -2 * curved_radius + 2 * isqrt2 * curved_radius,
+            -2 * isqrt2 * curved_radius,
+        ]
+
+        fanfare.append(mouth_piece)
+        fanfare.append(curved_piece)
+        fanfare.append(second_curved_piece)
+        fanfare.append(upper_shaft)
+        fanfare.append(cone_part)
+        fanfare.append(shaft)
+        fanfare.append(lower_shaft)
+
+        # show fanfare - prepare only surface and full spline components
+        face_showables = []
+        spline_showables = []
+        for f in fanfare:
+            showables = f.showable(resolutions=500, c=(255, 215, 0))
+            faces = showables["spline"]
+            face_showables.append(faces)
+            spline_showables.extend(list(showables.values()))
+
+        cam = {
+            "pos": (-11.90193, 5.995478, 3.057389),
+            "focalPoint": (-2.817062, -0.6220471, -0.3948362),
+            "viewup": (0.3271027, 0.7493888, -0.5756911),
+            "distance": 11.75773,
+            "clippingRange": (6.030973, 19.21880),
+        }
+
+        gus.show(face_showables, spline_showables, cam=cam)
+
 
 if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser(
-        description=(
-            "Creates a fanfare. Default option corresponds to "
-            "the tataratat logo."
-        )
-    )
-    arg_parser.add_argument(
-        "--r_mouth",
-        dest="r_mouth",
-        default=0.2,
-        help="Mouth radius for mouth piece.",
-    )
-    arg_parser.add_argument(
-        "--r_shaft",
-        dest="r_shaft",
-        default=0.1,
-        help="Shaft radius for mouth piece.",
-    )
-    arg_parser.add_argument(
-        "--r_rounding",
-        dest="r_rounding",
-        default=0.05,
-        help="Radius offset for mouth piece rounding.",
-    )
-    arg_parser.add_argument(
-        "--l_mouth",
-        dest="l_mouth",
-        default=0.4,
-        help="Length of the mouth piece.",
-    )
-    arg_parser.add_argument(
-        "--l_cone",
-        dest="l_cone",
-        default=1.2,
-        help="Length of the cone.",
-    )
-    arg_parser.add_argument(
-        "--r_cone",
-        dest="r_cone",
-        default=0.8,
-        help="Radius of the cone.",
-    )
-    arg_parser.add_argument(
-        "--l_shaft",
-        dest="l_shaft",
-        default=4.0,
-        help="Length of the shaft.",
-    )
-    arg_parser.add_argument(
-        "--r_curve",
-        dest="r_curve",
-        default=0.3,
-        help="Radius of connecting curves.",
-    )
-    args = arg_parser.parse_args()
-
-    # Let's draw a fanfare
-    fanfare = []
-
-    # cast all args to float
-    # Mouthpiece
-    r_mouth = float(args.r_mouth)
-    r_shaft = float(args.r_shaft)
-    r_rounding = float(args.r_rounding)
-    l_mouth = float(args.l_mouth)
-    # Cone
-    l_cone = float(args.l_cone)
-    r_cone = float(args.r_cone)
-    # Shaft
-    l_shaft = float(args.l_shaft)
-    curved_radius = float(args.r_curve)
-
-    # Create fanfare part by part
-    mouth_piece = splinepy.BSpline(
-        knot_vectors=[[0, 0, 0, 0.25, 0.5, 0.5, 0.75, 1, 1, 1]],
-        degrees=[2],
-        control_points=[
-            [l_mouth, r_mouth - r_rounding],
-            [l_mouth + r_rounding, r_mouth - r_rounding],
-            [l_mouth + r_rounding, r_mouth],
-            [l_mouth, r_mouth],
-            [0.5 * l_mouth, r_mouth],
-            [0.5 * l_mouth, r_shaft],
-            [0.0, r_shaft],
-        ],
-    ).nurbs.create.revolved(
-        axis=[1, 0, 0],
-        center=[0, 0, 0],
-        angle=360,
-        degree=True,
-        n_knot_spans=4,
-    )
-
-    isqrt2 = 2 ** (-0.5)
-    cross_section = splinepy.NURBS(
-        degrees=[2],
-        knot_vectors=[[0, 0, 0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1, 1, 1]],
-        control_points=(
-            np.array(
-                [
-                    [0.0, 0, 0],
-                    [0.0, 0.5, -0.5],
-                    [0.0, 1, 0],
-                    [0.0, 1 + 0.5, 0.5],
-                    [0.0, 1, 1],
-                    [0.0, 0.5, 1 + 0.5],
-                    [0.0, 0, 1],
-                    [0.0, -0.5, 0.5],
-                    [0, 0, 0],
-                ]
-            )
-            + np.array([0, -0.5, -0.5])
-        )
-        * (r_shaft * 2 * isqrt2),
-        weights=[1, isqrt2, 1, isqrt2, 1, isqrt2, 1, isqrt2, 1],
-    )
-
-    shaft = cross_section.create.extruded(extrusion_vector=[-l_shaft, 0, 0])
-
-    lower_shaft = shaft.copy()
-    lower_shaft.control_points += [0, -2 * curved_radius, 0]
-    upper_shaft = shaft.copy()
-    upper_shaft.control_points += [
-        0,
-        -2 * curved_radius + 2 * isqrt2 * curved_radius,
-        -2 * isqrt2 * curved_radius,
-    ]
-
-    cross_section.control_points += [-l_shaft, 0, 0]
-
-    curved_piece = cross_section.nurbs.create.revolved(
-        axis=[0.0, 0, 1], center=[-l_shaft, -curved_radius, 0], angle=180
-    )
-    cross_section.control_points += [l_shaft, -2 * curved_radius, 0]
-    second_curved_piece = cross_section.nurbs.create.revolved(
-        axis=[0, 1.0, 1.0],
-        center=[
-            0,
-            -2 * curved_radius + isqrt2 * curved_radius,
-            -isqrt2 * curved_radius,
-        ],
-        angle=180,
-    )
-
-    cone_part = splinepy.BSpline(
-        degrees=[2],
-        knot_vectors=[[0, 0, 0, 0.5, 1, 1, 1]],
-        control_points=[
-            [0.0, r_shaft, 0.0],
-            [-0.25 * l_cone, r_shaft, 0.0],
-            [-l_cone, 0.5 * (r_cone + r_shaft), 0.0],
-            [-l_cone, r_cone, 0.0],
-        ],
-    ).nurbs.create.revolved(
-        axis=[1, 0, 0],
-        center=[0, 0, 0],
-        angle=360,
-        degree=True,
-    )
-    cone_part.control_points += [
-        -l_shaft,
-        -2 * curved_radius + 2 * isqrt2 * curved_radius,
-        -2 * isqrt2 * curved_radius,
-    ]
-
-    fanfare.append(mouth_piece)
-    fanfare.append(curved_piece)
-    fanfare.append(second_curved_piece)
-    fanfare.append(upper_shaft)
-    fanfare.append(cone_part)
-    fanfare.append(shaft)
-    fanfare.append(lower_shaft)
-
-    # show fanfare - prepare only surface and full spline components
-    face_showables = []
-    spline_showables = []
-    for f in fanfare:
-        showables = f.showable(resolutions=500, c=(255, 215, 0))
-        faces = showables["spline"]
-        face_showables.append(faces)
-        spline_showables.extend(list(showables.values()))
-
-    cam = {
-        "pos": (-11.90193, 5.995478, 3.057389),
-        "focalPoint": (-2.817062, -0.6220471, -0.3948362),
-        "viewup": (0.3271027, 0.7493888, -0.5756911),
-        "distance": 11.75773,
-        "clippingRange": (6.030973, 19.21880),
-    }
-
-    gus.show(face_showables, spline_showables, cam=cam)
+    example()


### PR DESCRIPTION
# !!! Currently no type hints !!!
I have started with the example overall similar to https://github.com/tataratat/gustaf/pull/197 to enable type hint tracing also in the examples.
*Example tracing with `run_all_examples` is not possible :(*


Also, I wanted to enable us to run the examples in CI/CD to also check them.

# Overview
Similar to #381 but not in stub-files but with inline type hinting.

Using https://github.com/dropbox/pyannotate to trace tests to automatically detect the types enables us to add type hints quicker.

## Addressed issues
* Type hints are available
* Autocomplete in IDE is better
* During further development adding type hints is easier than using stub-files
* Secondary benefit, check which functions are called during tests and examples

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)

# Dependencies
* https://github.com/tataratat/gustaf/pull/197
  -> Due to using the gustaf setting `DEFAULT_OFFSCREEN`