### PR TITLE
Bugfix - Wrong indices for back substitution

### DIFF
--- a/src/proximity/proximity.cpp
+++ b/src/proximity/proximity.cpp
@@ -206,7 +206,6 @@ void Proximity::VerboseQuery(
 
   // allocate index arrays
   IndexArray_ clipped(para_dim);
-  IndexArray_ previous_clipped(para_dim);
 
   // search_bounds is parametric bounds here
   spline_.SplinepyParametricBounds(search_bounds.data());


### PR DESCRIPTION
The indices of the solution vector do not change as the pivoting only affects the rows of the matrix and the lhs, but not the solution (columns remain unchanged).

@j042, please verify

## Addressed issues
*  #385 


## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
