### PR TITLE
Interface Orientations were not available

### DIFF
--- a/include/splinepy/py/py_multipatch.hpp
+++ b/include/splinepy/py/py_multipatch.hpp
@@ -137,16 +137,16 @@ InterfacesFromBoundaryCenters(const py::array_t<double>& py_center_vertices,
 /// @param pyspline_end Spline object from end///to which is mapped
 /// @param boundary_end Boundary ID of adjacent spline
 /// @param tolerance Tolerance
-/// @param int_mappings_ptr (output) integer mappings
-/// @param bool_orientations_ptr (output) axis alignment
+/// @param mappings_ptr (output) integer mappings
+/// @param orientations_ptr (output) axis alignment
 void GetInterfaceOrientation(
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
     const int& boundary_start,
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
     const int& boundary_end,
     const double& tolerance,
-    int* int_mappings_ptr,
-    bool* bool_orientations_ptr);
+    int* mappings_ptr,
+    int* orientations_ptr);
 
 /// @brief Extract all Boundary Patches and store them in a python list
 ///
@@ -212,7 +212,7 @@ public:
   py::array_t<int> interfaces_;
 
   /// interface orientations that define mapping of parametric axis
-  py::array_t<int> orientations_;
+  py::array_t<int> interface_orientations_;
 
   /// shape: (n_patches,)
   py::array_t<int> boundary_ids_;

--- a/include/splinepy/py/py_multipatch.hpp
+++ b/include/splinepy/py/py_multipatch.hpp
@@ -139,7 +139,7 @@ InterfacesFromBoundaryCenters(const py::array_t<double>& py_center_vertices,
 /// @param tolerance Tolerance
 /// @param int_mappings_ptr (output) integer mappings
 /// @param bool_orientations_ptr (output) axis alignment
-void GetBoundaryOrientation(
+void GetInterfaceOrientation(
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
     const int& boundary_start,
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
@@ -147,24 +147,6 @@ void GetBoundaryOrientation(
     const double& tolerance,
     int* int_mappings_ptr,
     bool* bool_orientations_ptr);
-
-/// @brief Get the Boundary Orientations object
-///
-/// @param spline_list
-/// @param base_id
-/// @param base_face_id
-/// @param neighbor_id
-/// @param neighbor_face_id
-/// @param tolerance
-/// @param n_threads
-/// @return py::tuple
-py::tuple GetBoundaryOrientations(const py::list& spline_list,
-                                  const py::array_t<int>& base_id,
-                                  const py::array_t<int>& base_face_id,
-                                  const py::array_t<int>& neighbor_id,
-                                  const py::array_t<int>& neighbor_face_id,
-                                  const double tolerance,
-                                  const int n_threads);
 
 /// @brief Extract all Boundary Patches and store them in a python list
 ///
@@ -228,6 +210,9 @@ public:
   /// patch-to-patch connectivity information
   /// shape: (n_patches, n_boundary_elements)
   py::array_t<int> interfaces_;
+
+  /// interface orientations that define mapping of parametric axis
+  py::array_t<int> orientations_;
 
   /// shape: (n_patches,)
   py::array_t<int> boundary_ids_;
@@ -374,6 +359,14 @@ public:
   /// @brief getter for interface info. recomputes if unavailable
   /// @param recompute compute even if already available
   py::array_t<int> GetInterfaces(const bool recompute = false);
+
+  /// @brief Get the Boundary Orientations object
+  ///
+  /// @param tolerance
+  /// @param n_threads
+  /// @return py::tuple
+  py::array_t<int> GetInterfaceOrientations(const double tolerance,
+                                            const int n_threads);
 
   /// @brief Gets IDs of boundary patch
   /// @param bid boundary ID to be extracted

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -148,7 +148,7 @@ class Multipatch(_SplinepyBase, _PyMultipatch):
           multipatch object
         """
         return super().interface_orientations(
-            tolerance=_default_if_none(nthreads, _settings.TOLERANCE),
+            tolerance=_default_if_none(tolerance, _settings.TOLERANCE),
             nthreads=_default_if_none(nthreads, _settings.NTHREADS),
         )
 

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -128,7 +128,7 @@ class Multipatch(_SplinepyBase, _PyMultipatch):
         # Assignment
         super().set_interfaces(con)
 
-    def interface_orientations(tolerance=None, nthreads=None):
+    def interface_orientations(self, tolerance=None, nthreads=None):
         """
         Determine orientation between adjacent splines which is required, e.g.,
         for gismo export and orientation check

--- a/splinepy/multipatch.py
+++ b/splinepy/multipatch.py
@@ -128,6 +128,30 @@ class Multipatch(_SplinepyBase, _PyMultipatch):
         # Assignment
         super().set_interfaces(con)
 
+    def interface_orientations(tolerance=None, nthreads=None):
+        """
+        Determine orientation between adjacent splines which is required, e.g.,
+        for gismo export and orientation check
+
+        Parameters
+        ----------
+        tolerance : double
+          normed distance between two neighboring points to be considered equal
+        nthreads : int
+          Number of threads to be used for extraction, defaults to
+          settings.NTHREADS
+
+        Returns
+        -------
+        interface_orientations : np.array (np.int64)
+          description of the orientations between adjacent splines in a
+          multipatch object
+        """
+        return super().interface_orientations(
+            tolerance=_default_if_none(nthreads, _settings.TOLERANCE),
+            nthreads=_default_if_none(nthreads, _settings.NTHREADS),
+        )
+
     @property
     def boundaries(self):
         """

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -565,14 +565,14 @@ InterfacesFromBoundaryCenters(const py::array_t<double>& py_center_vertices,
                                      tolerance);
 }
 
-void GetBoundaryOrientation(
+void GetInterfaceOrientation(
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_start,
     const int& boundary_start,
     const std::shared_ptr<splinepy::splines::SplinepyBase>& pyspline_end,
     const int& boundary_end,
     const double& tolerance,
     int* int_mappings_ptr,
-    bool* bool_orientations_ptr) {
+    int* bool_orientations_ptr) {
   // Init return values and get auxiliary data
   const int& para_dim_ = pyspline_start->SplinepyParaDim();
   const int& dim_ = pyspline_start->SplinepyDim();
@@ -604,7 +604,7 @@ void GetBoundaryOrientation(
   // it is poosible the orientation of the interface edge might be flipped
   // (bugfix: negate the following expression)
   bool_orientations_ptr[boundary_start_p_dim] =
-      (boundary_start_orientation ^ boundary_end_orientation);
+      (boundary_start_orientation ^ boundary_end_orientation) ? 1 : 0;
 
   /// Compare jacobians for remaining entries
   // Calculate Parametric bounds
@@ -665,68 +665,103 @@ void GetBoundaryOrientation(
       const double cos_angle = abs(dot_p / std::sqrt(norm_s * norm_e));
       if (cos_angle > (1. - tolerance)) {
         int_mappings_ptr[i_pd] = j;
-        bool_orientations_ptr[i_pd] = (dot_p > 0);
+        bool_orientations_ptr[i_pd] = (dot_p > 0) ? 1 : 0;
         break;
       }
     }
   }
 }
 
-py::tuple GetBoundaryOrientations(const py::list& spline_list,
-                                  const py::array_t<int>& base_id,
-                                  const py::array_t<int>& base_face_id,
-                                  const py::array_t<int>& neighbor_id,
-                                  const py::array_t<int>& neighbor_face_id,
-                                  const double tolerance,
-                                  const int n_threads) {
-  // Basic Checks
-  // Check if all have same size
-  if (!((base_id.size() == base_face_id.size())
-        && (neighbor_id.size() == neighbor_face_id.size())
-        && (base_id.size() == neighbor_face_id.size()))) {
-    splinepy::utils::PrintAndThrowError(
-        "The ID arrays need to be of same size, please check for "
-        "consistencies.");
+py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
+                                                        const int n_threads) {
+
+  // Check if already exists
+  if (orientations_.size() != 0) {
+    return orientations_;
   }
 
-  // Auxiliary data
-  const int* base_id_ptr = static_cast<int*>(base_id.request().ptr);
-  const int* base_face_id_ptr = static_cast<int*>(base_face_id.request().ptr);
-  const int* neighbor_id_ptr = static_cast<int*>(neighbor_id.request().ptr);
-  const int* neighbor_face_id_ptr =
-      static_cast<int*>(neighbor_face_id.request().ptr);
-  const auto cpp_spline_list = ToCoreSplineVector(spline_list);
-  const int n_connections = base_id.size();
+  int n_patches = patches_.size();
 
-  const int para_dim_ = cpp_spline_list[0]->SplinepyParaDim();
+  // get para dim of the first patch
+  int para_dim = ParaDim();
 
-  py::array_t<int> int_mapping(n_connections * para_dim_);
-  int* int_mapping_ptr = static_cast<int*>(int_mapping.request().ptr);
-  py::array_t<bool> bool_orientations(n_connections * para_dim_);
-  bool* bool_orientations_ptr =
-      static_cast<bool*>(bool_orientations.request().ptr);
+  // Pointer request() for interfaces
+  const int n_faces_per_element = 2 * para_dim;
+  const int n_entries_per_line = 4 + 2 * para_dim;
+
+  // Make sure Interfaces are available
+  GetInterfaces(false);
+  const int* interfaces_ptr = static_cast<int*>(interfaces_.request().ptr);
+
+  // Loop over interfaces to compute number of interfaces (This is generally not
+  // time critical as comparisons are much more expensive)
+  int number_of_interfaces{};
+  for (int i_interface{}; i_interface < interfaces_.size(); i_interface++) {
+    if (interfaces_ptr[i_interface] >= 0) {
+      // interface found
+      if (interfaces_ptr[i_interface] > i_interface) {
+        number_of_interfaces++;
+      }
+    }
+  }
+
+  orientations_ = py::array_t<int>(number_of_interfaces * (4 + para_dim * 2));
+  int* orientations_ptr = static_cast<int*>(orientations_.request().ptr);
+
+  // Second loop to fill the interface information
+  int i_connection{};
+  for (int i_interface{}; i_interface < interfaces_.size(); i_interface++) {
+    if (interfaces_ptr[i_interface] >= 0) {
+      // interface found
+      if (interfaces_ptr[i_interface] > i_interface) {
+        orientations_ptr[i_connection * n_entries_per_line + 0] =
+            i_interface / n_faces_per_element;
+        orientations_ptr[i_connection * n_entries_per_line + 1] =
+            i_interface % n_faces_per_element; // std::div
+        orientations_ptr[i_connection * n_entries_per_line + 2] =
+            interfaces_ptr[i_interface] / n_faces_per_element;
+        orientations_ptr[i_connection * n_entries_per_line + 3] =
+            interfaces_ptr[i_interface] % n_faces_per_element; // std::div
+        i_connection++;
+      }
+    }
+  }
+
+  // Sanity check
+  assert(i_connection == number_of_interfaces);
+
+  const auto cpp_spline_list = ToCoreSplineVector(patches_, n_threads);
 
   // Provide lambda for multithread execution
   auto get_orientation = [&](const int start, const int end, int) {
     for (int i{start}; i < end; ++i) {
-      GetBoundaryOrientation(cpp_spline_list[base_id_ptr[i]],
-                             base_face_id_ptr[i],
-                             cpp_spline_list[neighbor_id_ptr[i]],
-                             neighbor_face_id_ptr[i],
-                             tolerance,
-                             &int_mapping_ptr[i * para_dim_],
-                             &bool_orientations_ptr[i * para_dim_]);
+      // Assign connections (start and end faces)
+      const int& patch_id_start = orientations_ptr[i * n_entries_per_line + 0];
+      const int& face_id_start = orientations_ptr[i * n_entries_per_line + 1];
+      const int& patch_id_end = orientations_ptr[i * n_entries_per_line + 2];
+      const int& face_id_end = orientations_ptr[i * n_entries_per_line + 3];
+
+      // Determine the mappings
+      GetInterfaceOrientation(
+          cpp_spline_list[patch_id_start],
+          face_id_start,
+          cpp_spline_list[patch_id_end],
+          face_id_end,
+          tolerance,
+          &orientations_ptr[i * n_entries_per_line + 4],
+          &orientations_ptr[i * n_entries_per_line + 4 + para_dim]);
     }
   };
 
   // Execute in parallel
-  splinepy::utils::NThreadExecution(get_orientation, n_connections, n_threads);
+  splinepy::utils::NThreadExecution(get_orientation,
+                                    number_of_interfaces,
+                                    n_threads);
 
   // Resize and return
-  int_mapping.resize({n_connections, para_dim_});
-  bool_orientations.resize({n_connections, para_dim_});
+  orientations_.resize({number_of_interfaces, n_entries_per_line});
 
-  return py::make_tuple(int_mapping, bool_orientations);
+  return orientations_;
 }
 
 py::list ExtractAllBoundarySplines(const py::list& spline_list,
@@ -1015,6 +1050,7 @@ void PyMultipatch::Clear() {
   boundary_patch_ids_ = py::array_t<int>();
   boundary_multipatch_ = nullptr;
   interfaces_ = py::array_t<int>();
+  orientations_ = py::array_t<int>();
   boundary_ids_ = py::array_t<int>();
   sub_patch_centers_ = py::array_t<double>();
   field_multipatches_ = py::list();
@@ -1193,6 +1229,8 @@ py::array_t<int> PyMultipatch::GetInterfaces(const bool recompute) {
     // get, but need to compute since saved member is empty
     interfaces_ =
         InterfacesFromBoundaryCenters(SubPatchCenters(), tolerance_, ParaDim());
+    // Reinit orientations_ as no longer valid
+    orientations_ = py::array_t<int>();
   }
 
   // regardless of set/get, it will always return the saved member of
@@ -1213,6 +1251,9 @@ void PyMultipatch::SetInterfaces(const py::array_t<int>& interfaces) {
       {static_cast<int>(CorePatches().size()),
        static_cast<int>(CorePatches()[0]->SplinepyParaDim() * 2)},
       true);
+
+  // Reinit orientations_ as no longer valid
+  orientations_ = py::array_t<int>();
 
   interfaces_ = interfaces;
 }
@@ -1620,15 +1661,6 @@ void init_multipatch(py::module_& m) {
         py::arg("splines"),
         py::arg("interfaces"),
         py::arg("nthreads") = 1);
-  m.def("orientations",
-        &splinepy::py::GetBoundaryOrientations,
-        py::arg("splines"),
-        py::arg("base_ids"),
-        py::arg("base_face_ids"),
-        py::arg("neighbor_ids"),
-        py::arg("neighbor_face_ids"),
-        py::arg("tolerance"),
-        py::arg("nthreads") = 1);
   m.def("boundaries_from_continuity",
         &splinepy::py::AddBoundariesFromContinuity,
         py::arg("boundary_splines"),
@@ -1691,6 +1723,10 @@ void init_multipatch(py::module_& m) {
            py::arg("checK_control_mesh_resolutions"),
            py::arg("nthreads"))
       .def("fields", &PyMultipatch::GetFields)
+      .def("interface_orientations",
+           &PyMultipatch::GetInterfaceOrientations,
+           py::arg("tolerance"),
+           py::arg("nthreads") = 1)
       //.def("", &PyMultipatch::)
       ;
 }

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -686,6 +686,7 @@ py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
   int para_dim = ParaDim();
 
   const int n_faces_per_element = 2 * para_dim;
+  // 4 includes - patch id start, face id start, patch id end, face id end
   const int n_entries_per_line = 4 + 2 * para_dim;
 
   // Make sure Interfaces are available
@@ -705,7 +706,7 @@ py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
   }
 
   interface_orientations_ =
-      py::array_t<int>({number_of_interfaces, (4 + para_dim * 2)});
+      py::array_t<int>({number_of_interfaces, n_entries_per_line});
   int* orientations_ptr =
       static_cast<int*>(interface_orientations_.request().ptr);
 

--- a/src/py/py_multipatch.cpp
+++ b/src/py/py_multipatch.cpp
@@ -685,13 +685,11 @@ py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
   // get para dim of the first patch
   int para_dim = ParaDim();
 
-  // Pointer request() for interfaces
   const int n_faces_per_element = 2 * para_dim;
   const int n_entries_per_line = 4 + 2 * para_dim;
 
   // Make sure Interfaces are available
-  GetInterfaces(false);
-  const int* interfaces_ptr = static_cast<int*>(interfaces_.request().ptr);
+  const int* interfaces_ptr = static_cast<int*>(GetInterfaces(false).request().ptr);
 
   // Loop over interfaces to compute number of interfaces (This is generally not
   // time critical as comparisons are much more expensive)
@@ -705,7 +703,7 @@ py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
     }
   }
 
-  orientations_ = py::array_t<int>(number_of_interfaces * (4 + para_dim * 2));
+  orientations_ = py::array_t<int>({number_of_interfaces, (4 + para_dim * 2)});
   int* orientations_ptr = static_cast<int*>(orientations_.request().ptr);
 
   // Second loop to fill the interface information
@@ -759,7 +757,6 @@ py::array_t<int> PyMultipatch::GetInterfaceOrientations(const double tolerance,
                                     n_threads);
 
   // Resize and return
-  orientations_.resize({number_of_interfaces, n_entries_per_line});
 
   return orientations_;
 }

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -35,53 +35,32 @@ class orientationTest(c.unittest.TestCase):
             degrees=[1, 1], control_points=[[2, 1], [1, 1], [2, 0], [1, 0]]
         )
 
-        # Provide connectivity data
-        spline_list = [a_s, b_s, c_s, d_s, e_s]
-        start_ids = [0, 0, 0, 0]
-        start_face_ids = [1, 3, 0, 2]
-        neighbor_ids = [1, 2, 3, 4]
-        neighbor_face_ids = [2, 2, 1, 2]
-
-        # Determine orientation single thread
-        (
-            axis_mapping,
-            axis_orientation,
-        ) = c.splinepy.splinepy_core.orientations(
-            spline_list,
-            start_ids,
-            start_face_ids,
-            neighbor_ids,
-            neighbor_face_ids,
-            0.00001,
-            1,
-        )
-
-        # Check results
-        expected_mappings = [[1, 0], [0, 1], [0, 1], [0, 1]]
-        expected_orientations = [
-            [True, True],
-            [True, True],
-            [True, False],
-            [False, False],
+        # Expected Values
+        expected_interfaces = [
+            [13, 6, 18, 10],
+            [-1, -1, 1, -1],
+            [-1, -1, 3, -1],
+            [-1, 0, -1, -1],
+            [-1, -1, 2, -1],
         ]
-        self.assertTrue(c.np.all(expected_mappings == axis_mapping))
-        self.assertTrue(c.np.all(expected_orientations == axis_orientation))
 
-        # Repeat with multithread execution
-        (
-            axis_mapping,
-            axis_orientation,
-        ) = c.splinepy.splinepy_core.orientations(
-            spline_list,
-            start_ids,
-            start_face_ids,
-            neighbor_ids,
-            neighbor_face_ids,
-            0.00001,
-            3,
-        )
-        self.assertTrue(c.np.all(expected_mappings == axis_mapping))
-        self.assertTrue(c.np.all(expected_orientations == axis_orientation))
+        expected_orientations = [
+            [0, 0, 3, 1, 0, 1, 1, 0],
+            [0, 1, 1, 2, 1, 0, 1, 1],
+            [0, 2, 4, 2, 0, 1, 0, 0],
+            [0, 3, 2, 2, 0, 1, 1, 1],
+        ]
+
+        # Provide connectivity data
+        mp = c.splinepy.Multipatch([a_s, b_s, c_s, d_s, e_s])
+
+        # First compare interfaces to what is expected
+        interfaces = mp.interfaces
+        self.assertTrue(c.np.all(interfaces == expected_interfaces))
+
+        # Then check orientations
+        orientations = mp.interface_orientations()
+        self.assertTrue(c.np.all(orientations == expected_orientations))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview
Interface orientations were always computed on the fly... What a waste. I wanted to have them available in case we ever decide to check the conformity...


## Checklists
* [x] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)
