### PR TITLE
Ft extract basis

### DIFF
--- a/examples/show_basis.py
+++ b/examples/show_basis.py
@@ -1,0 +1,81 @@
+import splinepy as spp
+
+if __name__ == "__main__":
+    # curve
+    # define degrees
+    ds1 = [2]
+
+    # define knot vectors
+    kvs1 = [[0.0, 0.0, 0.0, 1.0, 1.0, 1.0]]
+
+    # define control points
+    cps1 = [
+        [0.0, 0.0],
+        [-2.0, 4.0],
+        [1.0, 3.0],
+    ]
+
+    # init bspline
+    b = spp.BSpline(
+        degrees=ds1,
+        knot_vectors=kvs1,
+        control_points=cps1,
+    )
+
+    # make richer
+    b.elevate_degrees([0, 0])
+    b.insert_knots(0, [0.1, 0.2, 0.4, 0.7, 0.8, 0.8, 0.8])
+
+    # press `+` key to plot axes behind
+    spp.show(
+        ["BSpline", b],
+        ["Basis", *b.extract.bases()],
+        ["Basis (physical space)", *b.extract.bases(parametric_view=False)],
+        resolutions=201,
+    )
+
+    # 2D Basis and 1D Basis
+    # define degrees
+    ds2 = [2, 2]
+
+    # define knot vectors
+    kvs2 = [
+        [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+        [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+    ]
+
+    # define control points
+    cps2 = [
+        [0, 0],
+        [0, 1],
+        [1, 1.5],
+        [3, 1.5],
+        [-1, 0],
+        [-1, 2],
+        [1, 4],
+        [3, 4],
+        [-2, 0],
+        [-2, 2],
+        [1, 5],
+        [3, 5],
+    ]
+
+    # init bspline
+    b = spp.BSpline(
+        degrees=ds2,
+        knot_vectors=kvs2,
+        control_points=cps2,
+    )
+
+    b.elevate_degrees([0, 0, 1])
+    b.insert_knots(0, [0.1, 0.6, 0.8, 0.8, 0.8])
+    b.insert_knots(1, [0.4, 0.6, 0.8, 0.8, 0.8])
+
+    spp.show(
+        ["BSpline", b],
+        ["Basis", *b.extract.bases()],
+        ["Basis 11, 19, 43", *b.extract.bases([11, 19, 43])],
+        ["Basis (physical space)", *b.extract.bases(parametric_view=False)],
+        resolutions=101,
+        knots=False,
+    )

--- a/splinepy/helpme/create.py
+++ b/splinepy/helpme/create.py
@@ -50,7 +50,8 @@ def embedded(spline, new_dimension):
         )
         return type(spline)(**spline_dict)
     else:
-        return spline.copy()
+        # use todict() to avoid unnecessary data copies from `copy()`
+        return type(spline)(**spline.todict())
 
 
 def extruded(spline, extrusion_vector=None):

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -608,7 +608,7 @@ def arrow_data(spline, adata_name):
     return as_edges
 
 
-def bases(spline, ids=None):
+def bases(spline, ids=None, parametric_view=True):
     """
     Creates spline that represents basis functions of given ids.
     Parametric bounds equals to the given spline.
@@ -632,8 +632,13 @@ def bases(spline, ids=None):
         raise TypeError(f"Bases ids ({type(ids)}) should be a list.")
 
     # first, create conforming parametric view
-    conform_para_view = spline.create.parametric_view(axes=False, conform=True)
-    base_basis = conform_para_view.create.embedded(spline.para_dim + 1)
+    if parametric_view:
+        conform_para_view = spline.create.parametric_view(
+            axes=False, conform=True
+        )
+        base_basis = conform_para_view.create.embedded(spline.para_dim + 1)
+    else:
+        base_basis = spline.create.embedded(spline.dim + 1)
 
     # for template, the last axis should be all zero
     # also, set control point show_option to False
@@ -645,6 +650,7 @@ def bases(spline, ids=None):
     for i in ids:
         basis_i = base_basis.copy()
         basis_i.control_points[i, -1] = 1.0
+        basis_i.show_options["c"] = int(i)
         basis_splines.append(basis_i)
 
     return basis_splines

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -608,6 +608,48 @@ def arrow_data(spline, adata_name):
     return as_edges
 
 
+def bases(spline, ids=None):
+    """
+    Creates spline that represents basis functions of given ids.
+    Parametric bounds equals to the given spline.
+
+    Parameters
+    ----------
+    spline: Spline
+    ids: list
+      Supports ids of basis functions. Default is None and returns all supports
+
+    Returns
+    -------
+    basis_splines: list
+    """
+    # if none, extract all
+    if ids is None:
+        ids = _np.arange(len(spline.control_points))
+
+    # type check
+    if not isinstance(ids, (list, tuple, _np.ndarray)):
+        raise TypeError(f"Bases ids ({type(ids)}) should be a list.")
+
+    # first, create conforming parametric view
+    conform_para_view = spline.create.parametric_view(axes=False, conform=True)
+    base_basis = conform_para_view.create.embedded(spline.para_dim + 1)
+
+    # for template, the last axis should be all zero
+    # also, set control point show_option to False
+    base_basis.control_points[:, -1] = 0.0
+    base_basis.show_options["control_points"] = False
+
+    # loop and e
+    basis_splines = []
+    for i in ids:
+        basis_i = base_basis.copy()
+        basis_i.control_points[i, -1] = 1.0
+        basis_splines.append(basis_i)
+
+    return basis_splines
+
+
 class Extractor:
     """Helper class to allow direct extraction from spline obj (BSpline or
     NURBS). Internal use only.
@@ -716,3 +758,7 @@ class Extractor:
     @_wraps(arrow_data)
     def arrow_data(self, *args, **kwargs):
         return arrow_data(self._helpee, *args, **kwargs)
+
+    @_wraps(bases)
+    def bases(self, *args, **kwargs):
+        return bases(self._helpee, *args, **kwargs)

--- a/splinepy/spline.py
+++ b/splinepy/spline.py
@@ -1565,8 +1565,11 @@ class Spline(_SplinepyBase, _core.PySpline):
         if ext == ".iges":
             _io.iges.export(fname, [self])
 
+        elif ext == ".cats":
+            _io.cats.export(fname.replace(".cats", ".xml"), [self])
+
         elif ext == ".xml":
-            _io.xml.export(fname, [self])
+            _io.gismo.export(fname, [self])
 
         elif ext == ".itd":
             _io.irit.export(fname, [self])
@@ -1644,12 +1647,12 @@ class Spline(_SplinepyBase, _core.PySpline):
     def copy(self, saved_data=True):
         """
         Returns deepcopy of stored data and newly initialized self.
+        Shallow copies are made for `spline_data`.
 
         Parameters
         -----------
         saved_data: bool
-          Default is True. calls deepcopy on saved data excluding
-          coordinate_references
+          Default is True. calls deepcopy on saved data
 
         Returns
         --------
@@ -1665,6 +1668,10 @@ class Spline(_SplinepyBase, _core.PySpline):
                 if k in required_properties:
                     continue
                 new._data[k] = _copy.deepcopy(v)
+
+            # copy show_options and shallow copy spline_data
+            self.show_options.copy_valid_options(new.show_options)
+            new.spline_data._saved = self.spline_data._saved.copy()
 
         return new
 


### PR DESCRIPTION
# Overview
Visualizing basis is easier now. `spline.extract.bases()` will create a spline that represents the basis function. This isn't the most efficient way, but fits right into our current visualization and helpers pipeline.
Some sort of automatic random coloring could be a nice add-on.

## Addressed issues
*  Visualizing basis was not easy.

## Showcase
A short / one-liner example to highlight the (new) feature
```python
bases = spline.extract.bases()
spp.show(bases)

support123 = spline.extract.bases([1, 2, 3])
spp.show(support123)
```
<img width="392" alt="1d" src="https://github.com/tataratat/splinepy/assets/47114801/1131ba74-523d-47bf-b32f-b640246c3a46">
<img width="781" alt="2d" src="https://github.com/tataratat/splinepy/assets/47114801/9f2d1d6f-0ebb-440f-953d-5225f4dc2065">



## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
