### PR TITLE
fix pytest import issue

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,11 +21,11 @@ jobs:
       run: pip install numpy
 
     - name: build splinepy linux
-      run: CC=clang-14 CXX=clang++-14 pip install -e".[test]" -v --config-settings=cmake.args=-DSPLINEPY_MORE=OFF
+      run: CC=clang-14 CXX=clang++-14 pip install ".[test]" -v --config-settings=cmake.args=-DSPLINEPY_MORE=OFF
 
     - name: test
       run: |
-        pytest tests
+        pytest
 
     - name: build docs
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,6 @@ jobs:
       matrix:
         arch: [x86_64, arm64]
         cw_build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
-        exclude:
-          - arch: arm64
-            cw_build: "cp37-*"
-
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,12 @@ jobs:
     - name: build splinepy minimal/debug/warning
       if: matrix.os != 'windows-latest'
       run: |
-        pip install -e ".[test]" -v --config-settings=cmake.args="-DSPLINEPY_MORE=OFF;-DSPLINEPY_ENABLE_WARNINGS=ON" --config-settings=cmake.build-type="Debug"
+        pip install ".[test]" -v --config-settings=cmake.args="-DSPLINEPY_MORE=OFF;-DSPLINEPY_ENABLE_WARNINGS=ON" --config-settings=cmake.build-type="Debug"
 
     - name: build splinepy windows
       if: matrix.os == 'windows-latest'
       run: |
-        pip install -e ".[test]" -v --config-settings=cmake.args="-DSPLINEPY_MORE=OFF"
+        pip install ".[test]" -v --config-settings=cmake.args="-DSPLINEPY_MORE=OFF"
 
     - name: test
       run: |

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: build splinepy
-      run: pip install -e".[test]" -v
+      run: pip install ".[test]" -v
 
     - name: test
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ input = "splinepy/_version.py"
 
 [tool.cibuildwheel]
 test-extras = ["test"]
-test-command = "python -m pytest {project}/tests"
+test-command = "pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
@@ -121,7 +121,7 @@ line-length = 75
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra"
+addopts = "-ra --import-mode=append"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
# Overview
Installing splinepy non-editable mode would cause import issues. Mainly due to the compiled module, as it is not located in local directory. As stated in [pytest doc](https://docs.pytest.org/en/stable/explanation/pythonpath.html), this PR takes `append` mode for pytest to prefer installed packaged.

## Addressed issues
*  failed local / CI test calls

