### PR TITLE
Helper functions for gismo export

### DIFF
--- a/examples/export_gismo.py
+++ b/examples/export_gismo.py
@@ -1,0 +1,104 @@
+"""
+Export to g+smo-compatible xml-file. Recreates poisson2d_bvp.xml from gismo repo
+"""
+
+import splinepy as spp
+import splinepy.io.gismo as gismo
+
+EPS = 1e-8
+
+# Create multipatch geometry
+arc_inner = spp.NURBS(
+    degrees=[1,2],
+    knot_vectors=[
+        [0.0, 0.0, 1.0, 1.0],
+        [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+    ],
+    control_points=[
+        [1.0, 0.0],
+        [2.0, 0.0],
+        [1.0, 1.0],
+        [2.0, 2.0],
+        [0.0, 1.0],
+        [0.0, 2.0]
+    ],
+    weights=[1.0, 1.0, 0.707106781186548, 0.707106781186548, 1.0, 1.0]
+)
+
+arc_outer = arc_inner.copy()
+arc_outer.control_points = [
+    [2.0, 0.0],
+    [3.0, 0.0],
+    [2.0, 2.0],
+    [3.0, 3.0],
+    [0.0, 2.0],
+    [0.0, 3.0]
+]
+
+multipatch = spp.Multipatch(
+    splines=[arc_inner, arc_outer]
+)
+multipatch.determine_interfaces()
+
+# Identifies the patches' boundaries which correspond to the Dirichlet BCs
+def dirichlet_identifier(points):
+    return (points[:,1] < EPS) | ((points[:,0] < EPS) & (points[:,1] > 2-EPS))
+
+# Set Dirichlet boundaries to "BID2", Neumann BCs correspond to "BID1"
+multipatch.boundary_from_function(dirichlet_identifier, boundary_id=2)
+
+# Create function block for rhs
+rhs = gismo.create_function_block(
+    dim=2,
+    function_id=1,
+    function_string="2*pi^2*sin(pi*x)*sin(pi*y)",
+    comment="Right-hand side function"
+)
+
+# Create function block for manufactured solution
+manufactured_solution = gismo.create_function_block(
+    dim=2,
+    function_id=3,
+    function_string="sin(pi*x) * sin(pi*y)",
+    comment="The manufactured exact solution (for reference)"
+)
+
+# Create block for boundary conditions
+boundary_conditions = gismo.create_boundary_conditions_block(
+    bc_id=2,
+    dim=2,
+    function_list=[
+        "sin(pi*x) * sin(pi*y)",
+        ("pi*cos(pi*x) * sin(pi*y)", "pi*sin(pi*x) * cos(pi*y)"),
+        "0"
+    ],
+    bc_list=[
+        ("BID2", "Dirichlet", 0),
+        ("BID1", "Neumann", 1)
+    ],
+    unknown_id=0,
+    multipatch_id=0,
+    comment="The boundary conditions (multipatch=number of patches)"
+)
+
+# Create dictionary for assembly options
+assembly_options = gismo.create_assembly_options_block(
+    options_id=4,
+    comment="Assembler options"
+)
+
+# Visualize geometry and BCs
+boundary_names = ["Neumann boundary", "Dirichlet boundary"]
+spp.show(
+    ["Multipatch", multipatch],
+    *[[f"BID{i+1}: {boundary_names[i]}", multipatch.boundary_multipatch(i+1)] for i in range(len(multipatch.boundaries))],
+    control_points=False
+)
+
+# Export to xml-file
+gismo.export(
+    fname="poisson2d_bvp_recreation.xml",
+    multipatch=multipatch,
+    indent=True,
+    options=[rhs, boundary_conditions, manufactured_solution, assembly_options]
+)

--- a/splinepy/io/gismo.py
+++ b/splinepy/io/gismo.py
@@ -450,6 +450,9 @@ def export(
                     )
                 attributes = gismo_dictionary.get("attributes", {})
                 option_text = gismo_dictionary.get("text", None)
+                comment_text = gismo_dictionary.get("comment", None)
+                if comment_text is not None:
+                    xml_data.append(_ET.Comment(comment_text))
                 optional_data = _ET.SubElement(
                     ETelement,
                     name,
@@ -701,3 +704,269 @@ def load(fname, load_options=True):
         return multipatch, list_of_options
     else:
         return multipatch
+
+
+def create_boundary_conditions_block(
+    bc_id,
+    dim,
+    function_list,
+    bc_list,
+    unknown_id=0,
+    multipatch_id=0,
+    comment=None,
+):
+    """Create Python dictionary of boundary function's block to be used in
+    gismo export function.
+
+    Parameters
+    ----------
+    bc_id : int
+        ID number of boundaryConditions-block
+    dim : int
+        Dimension of physical space
+    function_list : list<str/tuple<str,str,...>>
+        List of functions where entries are strings of the function of the BC.
+        If tuple is given, it will be interpreted as component-wise functions
+        (e.g. for vector valued functions)
+    bc_list : list<tuple<str, str, int>>
+        List of which boundary attains which type of boundary condition. First
+        entry is the boundary name, second the type of condition (e.g.
+        "Dirichlet"), third is on which variable/unknown it should be applied
+    unknown_id : int (0)
+        ID of the unknown/variable on which this boundaryConditions block should be
+        applied
+    multipatch_id : int (0)
+        ID of the multipatch
+    comment: str
+        Comment above boundaryFunctions-block
+
+    Returns
+    -------
+    bc_dict_for_xml : dict
+      Dictionary of boundary conditions
+    """
+    bc_dict_for_xml = {}
+    bc_dict_for_xml["tag"] = "boundaryConditions"
+    bc_dict_for_xml["attributes"] = {
+        "id": str(bc_id),
+        "multipatch": str(multipatch_id),
+    }
+
+    # Define functions
+    children_list = []
+    for index, func_text in enumerate(function_list):
+        function_dict = {
+            "tag": "Function",
+            "attributes": {
+                "type": "FunctionExpr",
+                "dim": str(dim),
+                "index": str(index),
+            },
+        }
+        if type(func_text) != tuple:
+            function_dict["text"] = func_text
+        # Else vector-valued function
+        else:
+            function_dict["attributes"]["c"] = str(dim)
+            function_dict["children"] = [
+                {
+                    "tag": "c",
+                    "attributes": {"index": str(component_index)},
+                    "text": single_func_text,
+                }
+                for component_index, single_func_text in enumerate(func_text)
+            ]
+
+        children_list.append(function_dict)
+
+    children_list += [
+        {
+            "tag": "bc",
+            "attributes": {
+                "name": bidname,
+                "type": bctype,
+                "unknown": str(unknown_id),
+                # component omitted, might be sth for vector-valued unknowns
+                "function": str(function_id),
+            },
+        }
+        for bidname, bctype, function_id in bc_list
+    ]
+
+    bc_dict_for_xml["children"] = children_list
+
+    if comment is not None:
+        bc_dict_for_xml["comment"] = comment
+
+    return bc_dict_for_xml
+
+
+def create_function_block(dim, function_id, function_string, comment=None):
+    """Create Python dictionary of custom function's block to be used in
+    gismo export function.
+
+    Parameters
+    ----------
+    dim: int
+        Physical dimension of the problem
+    id: int
+        ID of function block
+    function_string: str or tuple<str,str>
+        Function as string. If tuple is given, function will be vector-valued.
+    comment: str
+        Comment above function block
+
+    Returns
+    -------
+    function_dict: dict
+        Dictionary to be used in export function
+    """
+    function_dict = {}
+    function_dict["tag"] = "Function"
+    function_dict["attributes"] = {
+        "id": str(function_id),
+        "type": "FunctionExpr",
+        "dim": str(dim),
+    }
+
+    # Scalar-valued function
+    if type(function_string) != tuple:
+        function_dict["text"] = function_string
+    # Vector-valued function
+    else:
+        function_dict["attributes"]["c"] = str(dim)
+        function_dict["children"] = [
+            {
+                "tag": "c",
+                "attributes": {"index": str(component_index)},
+                "text": function_component_string,
+            }
+            for component_index, function_component_string in enumerate(
+                function_string
+            )
+        ]
+
+    if comment is not None:
+        function_dict["comment"] = comment
+
+    return function_dict
+
+
+def create_assembly_options_block(
+    options_id,
+    dirichlet_strategy=11,
+    dirichlet_values=101,
+    interface_strategy=1,
+    bda=2,
+    bdb=1,
+    bdo=0.333,
+    qua=1,
+    qub=1,
+    qurule=1,
+    comment=None,
+):
+    """Create Python dictionary of g+smo assembly options to be used in gismo
+    export function
+
+    Parameters
+    ----------
+    options_id: int
+        ID of the OptionList-block
+    dirichlet_strategy: int
+        Method for enforcement of Dirichlet BCs [11..14]
+    dirichlet_values: int
+        Method for computation of Dirichlet DoF values [100..103]
+    interface_strategy: int
+        Method of treatment of patch interfaces [0..3]
+    bda: int
+        Estimated nonzeros per column of the matrix: bdA*deg + bdB
+    bdb: int
+        Estimated nonzeros per column of the matrix: bdA*deg + bdB
+    bdo: int
+        Overhead of sparse mem. allocation: (1+bdO)(bdA*deg + bdB) [0..1]
+    qua: int
+        Number of quadrature points: quA*deg + quB
+    qub: int
+        Number of quadrature points: quA*deg + quB
+    qurule: int
+        Quadrature rule [1:GaussLegendre,2:GaussLobatto]
+    comment: str
+        Comment above OptionList-block
+
+    Returns
+    -------
+    assembly_dict: dict
+        Dictionary to be used in export function
+    """
+    labels = [
+        "DirichletStrategy",
+        "DirichletValues",
+        "InterfaceStrategy",
+        "bdA",
+        "bdB",
+        "bdO",
+        "quA",
+        "quB",
+        "quRule",
+    ]
+    descriptions = [
+        "Method for enforcement of Dirichlet BCs [11..14]",
+        "Method for computation of Dirichlet DoF values [100..103]",
+        "Method of treatment of patch interfaces [0..3]",
+        "Estimated nonzeros per column of the matrix: bdA*deg + bdB",
+        "Estimated nonzeros per column of the matrix: bdA*deg + bdB",
+        "Overhead of sparse mem. allocation: (1+bdO)(bdA*deg + bdB) [0..1]",
+        "Number of quadrature points: quA*deg + quB",
+        "Number of quadrature points: quA*deg + quB",
+        "Quadrature rule [1:GaussLegendre,2:GaussLobatto]",
+    ]
+    values = [
+        dirichlet_strategy,
+        dirichlet_values,
+        interface_strategy,
+        bda,
+        bdb,
+        bdo,
+        qua,
+        qub,
+        qurule,
+    ]
+    number_types = [
+        "int",
+        "int",
+        "int",
+        "real",
+        "int",
+        "real",
+        "real",
+        "int",
+        "int",
+    ]
+
+    assembly_dict = {}
+    assembly_dict["tag"] = "OptionList"
+    assembly_dict["attributes"] = {"id": str(options_id)}
+    assembly_dict["text"] = "\n    "
+
+    children_list = []
+
+    for label, description, value, number_type in zip(
+        labels, descriptions, values, number_types
+    ):
+        children_list.append(
+            {
+                "tag": number_type,
+                "attributes": {
+                    "label": label,
+                    "desc": description,
+                    "value": str(value),
+                },
+            }
+        )
+
+    assembly_dict["children"] = children_list
+
+    if comment is not None:
+        assembly_dict["comment"] = comment
+
+    return assembly_dict


### PR DESCRIPTION
# Overview
I found the current implementation of exporting gismo-compatible xml-files regarding boundary conditions, custom functions and the assembly options too cumbersome and hard to read with all the nested curly brackets. Therefore, I added three new helper functions to gismo export: one for boundary conditions, one for a function block and one for the assembly options block. This should lead to clearer code.

## New features

All related to gismo export.

* Create boundary conditions block
* Create function block
* Create assembly options block
* Add comment above one of these blocks

## Showcase
New example `examples/export_gismo.py` recreates the xml-file for gismo's Poisson example.

## Checklists
* [ ] Documentations are up-to-date.
* [x] Added example(s)
* [ ] Added test(s)
