### PR TITLE
extend allowed input types in `extract.spline()`

### DIFF
--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -433,22 +433,14 @@ def spline(spline, para_dim, split_plane):
             "Requested parametric dimension exceeds spline's parametric"
             " dimensionality."
         )
-    if isinstance(split_plane, (tuple, list, _np.ndarray)):
-        if not (
-            (len(split_plane) == 2)
-            and (isinstance(split_plane[0], (float, _np.floating)))
-            and (isinstance(split_plane[1], (float, _np.floating)))
-        ):
-            raise ValueError(
-                "Range must be float or tuple of floats with length 2"
-            )
-    elif not isinstance(split_plane, (float, _np.floating)):
-        raise ValueError(
-            "Range must be float or tuple of floats with length 2"
-        )
-    else:
-        # Convert float to tuple to facilitate
-        split_plane = [split_plane]
+
+    # create 1d array for easy type / size check
+    split_plane = _np.asanyarray(split_plane).ravel()
+    if not _np.issubdtype(split_plane.dtype, _np.floating):
+        raise ValueError("split_plane must be floating type.")
+
+    if split_plane.size > 2:
+        raise ValueError("split_plane must have size of 1 or 2.")
 
     is_interval = len(split_plane) == 2
 

--- a/splinepy/helpme/extract.py
+++ b/splinepy/helpme/extract.py
@@ -433,16 +433,16 @@ def spline(spline, para_dim, split_plane):
             "Requested parametric dimension exceeds spline's parametric"
             " dimensionality."
         )
-    if isinstance(split_plane, list):
+    if isinstance(split_plane, (tuple, list, _np.ndarray)):
         if not (
             (len(split_plane) == 2)
-            and (isinstance(split_plane[0], float))
-            and (isinstance(split_plane[1], float))
+            and (isinstance(split_plane[0], (float, _np.floating)))
+            and (isinstance(split_plane[1], (float, _np.floating)))
         ):
             raise ValueError(
                 "Range must be float or tuple of floats with length 2"
             )
-    elif not isinstance(split_plane, float):
+    elif not isinstance(split_plane, (float, _np.floating)):
         raise ValueError(
             "Range must be float or tuple of floats with length 2"
         )


### PR DESCRIPTION
# Overview
`splinepy.helpme.extract.spline` checks input type against list and float. however, often in applications, we have other iterables. This PR allows other frequently used iterables and floating types of numpy.

## Addressed issues
*  Overly restrictive input / type error for split_plane


## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of split planes in the `spline` function to support tuples, lists, or NumPy arrays, ensuring compatibility with different data types and structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->