### PR TITLE
add padding initializer

### DIFF
--- a/splinepy/helpme/ffd.py
+++ b/splinepy/helpme/ffd.py
@@ -64,8 +64,7 @@ class FFD(_SplinepyBase):
         self._q_offset = None
 
         # use setters for attr
-        if padding is None:
-            self.padding = _settings.TOLERANCE
+        self.padding = _settings.TOLERANCE if padding is None else padding
         if mesh is not None:
             self.mesh = mesh
         if spline is not None:


### PR DESCRIPTION
# Overview
`padding` is set during `__init__`. @clemens-fricke can you add back the "lost" test?

## Addressed issues
*  if you initialize with  `padding`, it raises error, as it doesn't set anything

## Showcase
A short / one-liner example to highlight the (new) feature
```
import splinepy

ffd = splinepy.FFD(mesh, spline, 0.05)
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initialization logic to ensure padding is correctly assigned a default value when no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->