### PR TITLE
Ft mfem 3d single-patch IO

### DIFF
--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -3,6 +3,8 @@
 Currently hardcoded for 2D-single-patch-splines.
 """
 
+from ast import literal_eval
+
 import gustaf as _gus
 import numpy as _np
 
@@ -89,7 +91,7 @@ def load(fname):
     knot_vectors_sec = nurbs_dict["knotvectors"][1:]
     knot_vectors = []
     for kvs in knot_vectors_sec:
-        knot_vectors.append(eval("[" + kvs.replace(" ", ",") + "]"))
+        knot_vectors.append(literal_eval("[" + kvs.replace(" ", ",") + "]"))
     # pop some values
     # ds
     degrees = []
@@ -100,11 +102,11 @@ def load(fname):
 
     # ws
     weights = nurbs_dict["weights"]
-    weights = [eval(w) for w in weights]  # hopefully not too slow
+    weights = [literal_eval(w) for w in weights]  # hopefully not too slow
     # cps
     control_points = nurbs_dict["Ordering"]
     control_points = [
-        eval(f"[{cp.replace(' ', ',')}]") for cp in control_points
+        literal_eval(f"[{cp.replace(' ', ',')}]") for cp in control_points
     ]
 
     # double check
@@ -158,7 +160,7 @@ def read_solution(
         collect = False
         while line is not None:
             if collect:  # check this first. should be true most time
-                solution.append(eval(f"[{line.replace(' ', ',')}]"))
+                solution.append(literal_eval(f"[{line.replace(' ', ',')}]"))
             elif hotkey in line:
                 collect = True
 

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -31,7 +31,7 @@ _mfem_meaningful_keywords = {
 def load(fname):
     """Reads mfem spline and returns a spline.
 
-    Again, only supports 2D single patch.
+    Again, only supports 2D/3D single patch.
 
     Parameters
     -----------

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -86,13 +86,18 @@ def load(fname):
 
     # parse nurbs_dict
     # kvs
-    knot_vectors = nurbs_dict["knotvectors"][1:]
-    knot_vectors[0] = eval("[" + knot_vectors[0].replace(" ", ",") + "]")
-    knot_vectors[1] = eval("[" + knot_vectors[1].replace(" ", ",") + "]")
+    knot_vectors_sec = nurbs_dict["knotvectors"][1:]
+    knot_vectors = []
+    for kvs in knot_vectors_sec:
+        knot_vectors.append(eval("[" + kvs.replace(" ", ",") + "]"))
     # pop some values
     # ds
-    degrees = [knot_vectors[0].pop(0), knot_vectors[1].pop(0)]
-    ncps = knot_vectors[0].pop(0) * knot_vectors[1].pop(0)
+    degrees = []
+    ncps = 1
+    for kv in knot_vectors:
+        degrees.append(kv.pop(0))
+        ncps *= kv.pop(0)
+
     # ws
     weights = nurbs_dict["weights"]
     weights = [eval(w) for w in weights]  # hopefully not too slow
@@ -107,7 +112,8 @@ def load(fname):
     if (
         ncps != len(control_points)
         or ncps != len(weights)
-        or int(nurbs_dict["knotvectors"][0]) != 2
+        or int(nurbs_dict["knotvectors"][0]) != len(degrees)
+        or len(degrees) != len(knot_vectors)
     ):
         raise ValueError("Inconsistent spline info in " + fname)
 

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -579,51 +579,84 @@ def export(fname, nurbs, precision=10):
             "4",
             "",
         )
-
-        # I am not sure if mixed order is allowed, but in case not, let's
-        # match orders
-        max_degree = max(nurbs.degrees)
-        for i, d in enumerate(nurbs.degrees):
-            d_diff = int(max_degree - d)
-            if d_diff > 0:
-                for _ in range(d_diff):
-                    nurbs.elevate_degrees(i)
-
-        cnr = nurbs.control_mesh_resolutions
-
-        # double-check
-        if not (nurbs.degrees == nurbs.degrees[0]).all():
-            raise RuntimeError(
-                "Something went wrong trying to match degrees of nurbs "
-                + "before export."
-            )
-
-        # This is reusable
-        def kv_sec(spline):
-            kvs = _form_lines(
-                "knotvectors",
-                str(len(spline.knot_vectors)),
-            )
-            kvs2 = ""
-            for i in range(spline.para_dim):
-                kvs2 += _form_lines(
-                    str(spline.degrees[i])
-                    + " "
-                    + str(cnr[i])
-                    + " "
-                    + str(list(spline.knot_vectors[i]))[1:-1].replace(",", "")
-                )
-
-            kvs = kvs + kvs2
-
-            kvs += "\n"  # missing empty line
-
-            return kvs
-
-        knotvectors_sec = kv_sec(nurbs)
-
+    elif nurbs.para_dim == 3:
+        elements_sec = _form_lines("elements", "1", "1 5 0 1 2 3 4 5 6 7", "")
+        boundary_sec = _form_lines(
+            "boundary",
+            "6",
+            "1 3 3 2 1 0",
+            "2 3 4 5 6 7",
+            "3 3 0 1 5 4",
+            "4 3 1 2 6 5",
+            "5 3 2 3 7 6",
+            "6 3 3 0 4 7",
+            "",
+        )
+        edges_sec = _form_lines(
+            "edges",
+            "12",
+            "0 0 1",
+            "0 3 2",
+            "0 4 5",
+            "0 7 6",
+            "1 0 3",
+            "1 1 2",
+            "1 4 7",
+            "1 5 6",
+            "2 0 4",
+            "2 1 5",
+            "2 2 6",
+            "2 3 7",
+            "",
+        )
+        vertices_sec = _form_lines(
+            "vertices",
+            "8",
+            "",
+        )
     else:
-        raise NotImplementedError
+        raise ValueError("mfem output support 2D and 3D splines.")
+
+    # I am not sure if mixed order is allowed, but in case not, let's
+    # match orders
+    max_degree = max(nurbs.degrees)
+    for i, d in enumerate(nurbs.degrees):
+        d_diff = int(max_degree - d)
+        if d_diff > 0:
+            for _ in range(d_diff):
+                nurbs.elevate_degrees(i)
+
+    cnr = nurbs.control_mesh_resolutions
+
+    # double-check
+    if not (nurbs.degrees == nurbs.degrees[0]).all():
+        raise RuntimeError(
+            "Something went wrong trying to match degrees of nurbs "
+            + "before export."
+        )
+
+    # This is reusable
+    def kv_sec(spline):
+        kvs = _form_lines(
+            "knotvectors",
+            str(len(spline.knot_vectors)),
+        )
+        kvs2 = ""
+        for i in range(spline.para_dim):
+            kvs2 += _form_lines(
+                str(spline.degrees[i])
+                + " "
+                + str(cnr[i])
+                + " "
+                + str(list(spline.knot_vectors[i]))[1:-1].replace(",", "")
+            )
+
+        kvs = kvs + kvs2
+
+        kvs += "\n"  # missing empty line
+        return kvs
+
+    knotvectors_sec = kv_sec(nurbs)
 
     # disregard inverse
     reorder_ids, _ = dof_mapping(nurbs)

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -623,23 +623,7 @@ def export(fname, nurbs, precision=10):
     else:
         raise ValueError("mfem output support 2D and 3D splines.")
 
-    # I am not sure if mixed order is allowed, but in case not, let's
-    # match orders
-    max_degree = max(nurbs.degrees)
-    for i, d in enumerate(nurbs.degrees):
-        d_diff = int(max_degree - d)
-        if d_diff > 0:
-            for _ in range(d_diff):
-                nurbs.elevate_degrees(i)
-
     cnr = nurbs.control_mesh_resolutions
-
-    # double-check
-    if not (nurbs.degrees == nurbs.degrees[0]).all():
-        raise RuntimeError(
-            "Something went wrong trying to match degrees of nurbs "
-            + "before export."
-        )
 
     # This is reusable
     def kv_sec(spline):
@@ -688,7 +672,7 @@ def export(fname, nurbs, precision=10):
 
     fe_space_sec = _form_lines(
         "FiniteElementSpace",
-        "FiniteElementCollection: NURBS" + str(nurbs.degrees[0]),
+        "FiniteElementCollection: NURBS",
         "VDim: " + str(nurbs.dim),
         "Ordering: 1",
         "",

--- a/splinepy/io/mfem.py
+++ b/splinepy/io/mfem.py
@@ -33,7 +33,7 @@ _mfem_meaningful_keywords = {
 def load(fname):
     """Reads mfem spline and returns a spline.
 
-    Again, only supports 2D/3D single patch.
+    Supports 2D/3D single patch.
 
     Parameters
     -----------
@@ -92,12 +92,14 @@ def load(fname):
     knot_vectors = []
     for kvs in knot_vectors_sec:
         knot_vectors.append(literal_eval("[" + kvs.replace(" ", ",") + "]"))
-    # pop some values
-    # ds
+
+    # parse degrees and get number of control points for consistency checks
     degrees = []
     ncps = 1
     for kv in knot_vectors:
+        # first value in kv is degrees
         degrees.append(kv.pop(0))
+        # second value is number of control points
         ncps *= kv.pop(0)
 
     # ws
@@ -117,7 +119,14 @@ def load(fname):
         or int(nurbs_dict["knotvectors"][0]) != len(degrees)
         or len(degrees) != len(knot_vectors)
     ):
-        raise ValueError("Inconsistent spline info in " + fname)
+        raise ValueError(
+            f"Inconsistent spline info in {fname}: "
+            f"ncps = {ncps}, "
+            f"len(control_points) = {len(control_points)}, "
+            f"len(weights) = {len(weights)}, "
+            f"len(degrees) = {len(degrees)}, "
+            f"len(knot_vectors) = {len(knot_vectors)}"
+        )
 
     mfem_dict_spline = {
         "degrees": degrees,

--- a/tests/io/test_mfem_export.py
+++ b/tests/io/test_mfem_export.py
@@ -129,3 +129,28 @@ def test_mfem_export(to_tmpf, are_stripped_lines_same):
             assert are_stripped_lines_same(
                 base_file.readlines(), tmp_read.readlines(), True
             )
+
+
+def test_mfem_single_patch_export(to_tmpf, are_splines_equal, np_rng):
+    """
+    Test MFEM single patch export routine
+    """
+    length = [1, 2, 3]
+    for dim in [2, 3]:
+        spline = splinepy.helpme.create.box(*length[:dim]).nurbs
+
+        # make it a bit complex
+        for i in range(dim):
+            spline.insert_knots(i, np_rng.random([5]))
+        spline.elevate_degrees(list(range(dim)) * 2)
+        for i in range(dim):
+            spline.insert_knots(i, np_rng.random([5]))
+
+        # Test Output
+        with tempfile.TemporaryDirectory() as tmpd:
+            tmpf = to_tmpf(tmpd)
+            splinepy.io.mfem.export(tmpf, spline)
+
+            loaded_spline = splinepy.io.mfem.load(tmpf)
+
+            are_splines_equal(spline, loaded_spline)

--- a/tests/io/test_mfem_export.py
+++ b/tests/io/test_mfem_export.py
@@ -135,15 +135,25 @@ def test_mfem_single_patch_export(to_tmpf, are_splines_equal, np_rng):
     """
     Test MFEM single patch export routine
     """
-    length = [1, 2, 3]
-    for dim in [2, 3]:
-        spline = splinepy.helpme.create.box(*length[:dim]).nurbs
+    # create 2d/3d splines of all supporting types
+    box = splinepy.helpme.create.box(1, 2)
+    boxes = []
+    boxes.extend([box, box.rationalbezier, box.bspline, box.nurbs])
+    boxes.extend([b.create.extruded([0, 0, 3]) for b in boxes[:4]])
+    for spline in boxes:
+        dim = spline.dim
 
         # make it a bit complex
         for i in range(dim):
+            if not spline.has_knot_vectors:
+                break
             spline.insert_knots(i, np_rng.random([5]))
+
         spline.elevate_degrees(list(range(dim)) * 2)
+
         for i in range(dim):
+            if not spline.has_knot_vectors:
+                break
             spline.insert_knots(i, np_rng.random([5]))
 
         # Test Output
@@ -153,4 +163,5 @@ def test_mfem_single_patch_export(to_tmpf, are_splines_equal, np_rng):
 
             loaded_spline = splinepy.io.mfem.load(tmpf)
 
-            are_splines_equal(spline, loaded_spline)
+            # all mfem export is nurbs
+            assert are_splines_equal(spline.nurbs, loaded_spline)


### PR DESCRIPTION
# Overview
Extends single-patch IO to 3D


## Addressed issues
*  We had dof mapping, and IO was missing.

## Next
For complex multipatches, either revive `edges` or contribute to MFEM

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [x] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved NURBS spline loading and exporting, including better handling of knot vectors and consistency checks.

- **Tests**
  - Added a new test for MFEM single patch export to validate the process of creating, modifying, exporting, and loading NURBS splines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->