### PR TITLE
Add: option for pypi readme adaptation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ input = "splinepy/_version.py"
 [tool.cibuildwheel]
 test-extras = ["test"]
 test-command = "pytest {project}/tests"
+before_all = "python docs/source/handle_markdown.py -b"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
# Overview
On PyPi, the readme has no images/only a few images show up. With these changes, this should not happen anymore.

## Addressed issues
*  No images showing up on the PyPi landing page for the package.

## Checklists
* [-] Documentations are up-to-date.
* [-] Added example(s)
* [-] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for preparing README files for PyPI distribution.
	- Added command-line argument support for markdown processing script, enhancing usability.
  
- **Improvements**
	- Refactored markdown handling process for better memory efficiency and link processing.
	- Enhanced build configuration to automate markdown preprocessing during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->