### PR TITLE
Fix KnotVector to numpy array conversion

### DIFF
--- a/src/py/py_knot_vector.cpp
+++ b/src/py/py_knot_vector.cpp
@@ -170,7 +170,9 @@ void init_knot_vector(py::module_& m) {
           "Returns copy of knot vectors as numpy array.")
       .def(
           "__array__",
-          [](const KnotVector& kv, [[maybe_unused]] py::args dtype_ignored) {
+          [](const KnotVector& kv,
+             [[maybe_unused]] py::args dtype_ignored,
+             [[maybe_unused]] py::kwargs copy_ignored) {
             py::array_t<KnotType> arr(kv.GetSize());
             KnotType* arr_ptr = static_cast<KnotType*>(arr.request().ptr);
             for (int i{}; i < kv.GetSize(); ++i) {


### PR DESCRIPTION
# Overview
Since numpy 2.0, a `copy` kwarg was added to `numpy.ndarray.__array__`. This PR adds `**kwargs` to `__array__` function. It is ignored, since we always return a copy.

## Addressed issues
*  CI test fails at #439 


## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the flexibility of the `__array__` method in the `KnotVector` class to accept additional keyword arguments, preparing for future enhancements.
- **Updates**
	- Updated the `pybind11` dependency to a newer commit, potentially introducing bug fixes and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->