### PR TITLE
Minor typo fix in config

### DIFF
--- a/docs/source/handle_markdown.py
+++ b/docs/source/handle_markdown.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import re
 import warnings
+from typing import List, Tuple
 
 # Path to this file.
 file_path = os.path.abspath(os.path.dirname(__file__))
@@ -37,7 +38,7 @@ def get_markdown_links(line: str) -> str:
     return possible if possible else ""
 
 
-def get_special_links(line: str) -> list[tuple[str, str]]:
+def get_special_links(line: str) -> List[Tuple[str, str]]:
     """Get the special links from a string.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ input = "splinepy/_version.py"
 [tool.cibuildwheel]
 test-extras = ["test"]
 test-command = "pytest {project}/tests"
-before_all = "python docs/source/handle_markdown.py -b"
+before-all = "python {project}/docs/source/handle_markdown.py -b"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
# Overview
Typo fix in config file - `before_all` should be `before-all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated configuration settings to improve naming consistency by renaming `before_all` to `before-all` in the build configuration.
  
Please note that this change does not impact existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->