### PR TITLE
add para to parent scaling

### DIFF
--- a/splinepy/helpme/integrate.py
+++ b/splinepy/helpme/integrate.py
@@ -201,7 +201,10 @@ def parametric_function(
             result += _np.einsum(
                 "i...,i,i->...",
                 function(quad_positions),
-                meas(spline, quad_positions),
+                meas(spline, quad_positions)
+                * _np.prod(
+                    _np.diff(bezier_element.control_point_bounds, axis=0)
+                ),
                 weights,
                 optimize=True,
             )

--- a/tests/helpme/test_integrate.py
+++ b/tests/helpme/test_integrate.py
@@ -178,7 +178,7 @@ def test_function_integration(np_rng):
     col1_factor = 2
 
     def volume_function(x):
-        vf = np.ones((x.shape[0], 2))
+        vf = np.ones((len(x), 2))
         # scale it with a factor to get a different value
         vf[:, 1] = col1_factor
         return vf
@@ -186,7 +186,15 @@ def test_function_integration(np_rng):
     bezier = splinepy.Bezier(
         degrees=[1, 2], control_points=np_rng.random((6, 2))
     )
+
     assert np.allclose(
         [bezier.integrate.volume(), col1_factor * bezier.integrate.volume()],
         bezier.integrate.parametric_function(volume_function),
+    )
+
+    # try bsplines
+    bspline = bezier.bspline
+    assert np.allclose(
+        [bspline.integrate.volume(), col1_factor * bspline.integrate.volume()],
+        bspline.integrate.parametric_function(volume_function),
     )


### PR DESCRIPTION
# Overview
Integration of bsplines weren't correct - it was missing parametric space to "parent" (or integration) element scaling.
Added corresponding test
## Addressed issues
*  consider parametric space to parent element mapping

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)
