### PR TITLE
Fix query check lower bound

### DIFF
--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -34,7 +34,7 @@ def valid_queries(spline, queries):
     # Check minimum value
     min_query = _np.min(queries, axis=0)
     if _np.any(bounds[0, :] > min_query):
-        error_dim = _np.where(bounds[1, :] > min_query)[0][0]
+        error_dim = _np.where(bounds[0, :] > min_query)[0][0]
         error_query = _np.argmin(queries, axis=0)[error_dim]
         raise ValueError(
             f"Query request out of bounds in parametric dimension "

--- a/splinepy/helpme/check.py
+++ b/splinepy/helpme/check.py
@@ -40,7 +40,7 @@ def valid_queries(spline, queries):
             f"Query request out of bounds in parametric dimension "
             f"{error_dim}. Detected query {queries[error_query,:]} at "
             f"positions {error_query}, which is out of bounds with "
-            f"minimum values {bounds[1,:]}."
+            f"minimum values {bounds[0,:]}."
         )
 
     # Check maximum value

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -505,7 +505,7 @@ def test_assertions_jacobian(request, splinetype):
         ValueError,
         match=r"Query request out of bounds in parametric dimension 0. "
         r"Detected query \[-0.1  0. \] at positions 0, which is out of"
-        r" bounds with minimum values \[1. 1.\].",
+        r" bounds with minimum values \[0. 0.\].",
     ):
         spline.jacobian(queries=[[-0.1, 0.0], [0.4, 0.6]])
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -473,7 +473,7 @@ def test_assertions_evaluation(request, splinetype):
         ValueError,
         match=r"Query request out of bounds in parametric dimension 0. "
         r"Detected query \[-0.1  0. \] at positions 0, which is out of"
-        r" bounds with minimum values \[1. 1.\].",
+        r" bounds with minimum values \[0. 0.\].",
     ):
         spline.evaluate(queries=[[-0.1, 0.0], [0.4, 0.6]])
 


### PR DESCRIPTION
# Overview
There is a small mistake that shows the wrong bounds when the query is out of bounds.

## Addressed issues
*  Issues addressed

## Showcase
A short / one-liner example to highlight the (new) feature
```Python
import splinepy

bez = splinepy.Bezier([0], [[0]])
# works
bez.evaluate([[0]])
# gives value error
bez.evaluate([[-1]])
```
gives 

```Python
ValueError: Query request out of bounds in parametric dimension 0. Detected query [-1.] at positions 0, which is out of bounds with minimum values [1.].
```

## Checklists
* [ ] Documentations are up-to-date.
* [ ] Added example(s)
* [ ] Added test(s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messages to correctly display the minimum parameter limits. Users will now receive clearer and more accurate feedback when providing inputs that fall outside the accepted range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->