### PR TITLE
Actions version bump

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
-Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: "3.10"
 
     - name: build splinepy linux
-      run: CC=clang-14 CXX=clang++-14 pip install ".[test]" -v --config-settings=cmake.args=-DSPLINEPY_MORE=OFF
+      run: CC=clang CXX=clang++ pip install ".[test]" -v --config-settings=cmake.args=-DSPLINEPY_MORE=OFF
 
     - name: test
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
         doxygen Doxyfile
 
     - name: Set up  python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 
@@ -44,7 +44,7 @@ jobs:
         sphinx-build -W -b html docs/source docs/build
 
     - name: deploy docs only if it is pushed to main
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       with:
         #publish_branch: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,14 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 2
@@ -41,14 +41,14 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 2
@@ -65,14 +65,14 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 2
@@ -89,7 +89,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -97,7 +97,7 @@ jobs:
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 2
@@ -112,7 +112,7 @@ jobs:
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./dist/*
         retention-days: 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         submodules: recursive
     - name: Set up  ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         submodules: recursive
     - name: Set up  ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_wheels.yml
+++ b/.github/workflows/test_wheels.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -43,7 +43,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -68,7 +68,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -92,7 +92,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.23.2
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}

--- a/.github/workflows/test_wheels.yml
+++ b/.github/workflows/test_wheels.yml
@@ -24,7 +24,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 1
@@ -49,7 +49,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 1
@@ -74,7 +74,7 @@ jobs:
         CIBW_BUILD: ${{ matrix.cw_build }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 1
@@ -99,7 +99,7 @@ jobs:
         CIBW_TEST_SKIP: "*-win_arm64"
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./wheelhouse/*.whl
         retention-days: 1
@@ -114,7 +114,7 @@ jobs:
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: ./dist/*
         retention-days: 1


### PR DESCRIPTION
# Overview
Update the CI/CD actions. Some are deprecated and now start to throw errors.

We can think about adding something like Dependabot to keep track of these actions?

## Addressed issues
*  Workflow does not work

## Checklists
* - Documentations are up-to-date.
* - Added example(s)
* - Added test(s)
