### PR TITLE
Add missing option copy

### DIFF
--- a/splinepy/helpme/visualize.py
+++ b/splinepy/helpme/visualize.py
@@ -353,7 +353,12 @@ def _sample_arrow_data(spline, adata, sampled_spline, res):
         )
 
         # transfer options to sampled_spline
-        keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
+        keys = (
+            "arrow_data_scale",
+            "arrow_data_color",
+            "arrow_data",
+            "arrow_data_to_origin",
+        )
         spline.show_options.copy_valid_options(
             sampled_spline.show_options, keys
         )
@@ -393,7 +398,12 @@ def _sample_arrow_data(spline, adata, sampled_spline, res):
         loc_vertices.vertex_data[adata] = adata_values
 
         # transfer options
-        keys = ("arrow_data_scale", "arrow_data_color", "arrow_data")
+        keys = (
+            "arrow_data_scale",
+            "arrow_data_color",
+            "arrow_data",
+            "arrow_data_to_origin",
+        )
         spline.show_options.copy_valid_options(loc_vertices.show_options, keys)
 
         return loc_vertices


### PR DESCRIPTION
# Overview
Adding `arrow_data_to_origin` option added from gustaf-v0.1.0 to a copy list. This is a non-raising copy, so won't effect older versions. However, maybe good to add a warning log in gustaf