### PR TITLE
Fix build for python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-macos-15-intel-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -49,7 +49,7 @@ jobs:
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-macos-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -63,7 +63,7 @@ jobs:
         cw_build: ["cp310*many*", "cp311*many*", "cp312*many*", "cp313*many*", "cp314*many*"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: build wheels
@@ -74,7 +74,7 @@ jobs:
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-linux-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -88,7 +88,7 @@ jobs:
         cw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
     - name: build wheels
@@ -100,7 +100,7 @@ jobs:
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-windows-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
@@ -109,32 +109,34 @@ jobs:
   source_dist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-source
         path: ./dist/*
         retention-days: 1
 
 
-  # upload_pypi:
-  #   needs: [macos_wheel, macos_wheel-m1, linux_wheel, windows_wheel, source_dist]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         pattern: wheels-*
-  #         merge-multiple: true
-  #         path: dist
+  upload_pypi:
+    needs: [macos_wheel, macos_wheel-m1, linux_wheel, windows_wheel, source_dist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
 
-  #     - uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         skip-existing: true
+      - name: Publish wheels to PyPI
+        if: github.ref == 'refs/heads/main'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
+        CIBW_SKIP: "cp314t-*"
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.build }}
+        CIBW_BUILD: ${{ join(matrix.build, ',') }}
         CIBW_SKIP: ${{ matrix.skip || '' }}
         CIBW_TEST_SKIP: ${{ matrix.test_skip || '' }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
       uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ join(matrix.build, ',') }}
+        CIBW_BUILD: ${{ join(matrix.build, ' ') }}
         CIBW_SKIP: ${{ matrix.skip || '' }}
         CIBW_TEST_SKIP: ${{ matrix.test_skip || '' }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: main
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix-build"]
 
 jobs:
   macos_wheel:
@@ -42,7 +42,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.23.2
+      uses: pypa/cibuildwheel@v3
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -67,7 +67,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.23.2
+      uses: pypa/cibuildwheel@v3
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -92,7 +92,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.23.2
+      uses: pypa/cibuildwheel@v3
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -123,18 +123,18 @@ jobs:
         retention-days: 1
 
 
-  upload_pypi:
-    needs: [macos_wheel, macos_wheel-m1, linux_wheel, windows_wheel, source_dist]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: wheels-*
-          merge-multiple: true
-          path: dist
+  # upload_pypi:
+  #   needs: [macos_wheel, macos_wheel-m1, linux_wheel, windows_wheel, source_dist]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: wheels-*
+  #         merge-multiple: true
+  #         path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         skip-existing: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v2.23.2
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,127 +5,74 @@ on:
     branches: ["main", "fix-build"]
 
 jobs:
-  macos_wheel:
-    runs-on: macos-15-intel
+  build_wheels:
     strategy:
+      fail-fast: false
       matrix:
-        arch: [x86_64]
-        cw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+        include:
+          # macOS Intel
+          - os: macos-15-intel
+            arch: x86_64
+            build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+            platform: macos
+          # macOS ARM (M1/M2)
+          - os: macos-latest
+            arch: arm64
+            build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+            platform: macos
+          # Linux
+          - os: ubuntu-latest
+            arch: x86_64
+            build: ["cp310*many*", "cp311*many*", "cp312*many*", "cp313*many*", "cp314*many*"]
+            platform: linux
+            skip: "cp314t-*"
+          # Windows
+          - os: windows-latest
+            arch: AMD64
+            build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
+            platform: windows
+            test_skip: "*-win_arm64"
 
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: build wheels
-      uses: pypa/cibuildwheel@v4.1.0
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.cw_build }}
-        SPLINEPY_GITHUB_ACTIONS_BUILD: True
-        SKBUILD_INSTALL_COMPONENTS: PythonModule
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: wheels-macos-15-intel-${{ strategy.job-index }}
-        path: ./wheelhouse/*.whl
-        retention-days: 1
-
-  macos_wheel-m1:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        arch: [arm64]
-        cw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: build wheels
-      uses: pypa/cibuildwheel@v4.1.0
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.cw_build }}
-        SPLINEPY_GITHUB_ACTIONS_BUILD: True
-        SKBUILD_INSTALL_COMPONENTS: PythonModule
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: wheels-macos-${{ strategy.job-index }}
-        path: ./wheelhouse/*.whl
-        retention-days: 1
-
-  linux_wheel:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [x86_64]
-        cw_build: ["cp310*many*", "cp311*many*", "cp312*many*", "cp313*many*", "cp314*many*"]
-
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v7
       with:
         submodules: recursive
-    - name: build wheels
+
+    - name: Build wheels
       uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.cw_build }}
-        CIBW_SKIP: "cp314t-*"
+        CIBW_BUILD: ${{ matrix.build }}
+        CIBW_SKIP: ${{ matrix.skip || '' }}
+        CIBW_TEST_SKIP: ${{ matrix.test_skip || '' }}
         SPLINEPY_GITHUB_ACTIONS_BUILD: True
         SKBUILD_INSTALL_COMPONENTS: PythonModule
 
     - uses: actions/upload-artifact@v7
       with:
-        name: wheels-linux-${{ strategy.job-index }}
+        name: wheels-${{ matrix.platform }}-${{ matrix.os }}-${{ strategy.job-index }}
         path: ./wheelhouse/*.whl
-        retention-days: 1
+        retention-days: 7
 
-  windows_wheel:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        arch: [AMD64]
-        cw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"]
-
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: recursive
-    - name: build wheels
-      uses: pypa/cibuildwheel@v4.1.0
-      env:
-        CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.cw_build }}
-        CIBW_TEST_SKIP: "*-win_arm64"
-        SPLINEPY_GITHUB_ACTIONS_BUILD: True
-        SKBUILD_INSTALL_COMPONENTS: PythonModule
-
-    - uses: actions/upload-artifact@v7
-      with:
-        name: wheels-windows-${{ strategy.job-index }}
-        path: ./wheelhouse/*.whl
-        retention-days: 1
-
-  source_dist:
+  build_sdist:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
       with:
         submodules: recursive
 
-    - name: Build sdist
+    - name: Build source distribution
       run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v7
       with:
         name: wheels-source
         path: ./dist/*
-        retention-days: 1
-
+        retention-days: 7
 
   upload_pypi:
-    needs: [macos_wheel, macos_wheel-m1, linux_wheel, windows_wheel, source_dist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -136,7 +83,7 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - name: Publish wheels to PyPI
+      - name: Publish to PyPI
         if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v3
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -67,7 +67,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v3
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}
@@ -92,7 +92,7 @@ jobs:
       with:
         submodules: recursive
     - name: build wheels
-      uses: pypa/cibuildwheel@v3
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD: ${{ matrix.cw_build }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docs/source/_generated
 **/CMakeFiles/
 **/Makefile
 **/cmake_install.cmake
+
+#
+examples/not_upload/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/tataratat/splinepy",
+            "url": "https://github.com/isosuite/splinepy",
             "icon": "fa-brands fa-square-github",
         },
         {


### PR DESCRIPTION
# Overview

Fixed building for Python 3.14. Only 3.14t will not be released due to issues in the test pipeline.

## Addressed issues

*  Build issues for Python 3.14
*  Rename (hopefully) all relevant references of `tataratat` to `isosuite`

## Checklists

* [ ] Set target branch to develop
* [x] Documentations are up-to-date.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release and build automation to run on pushes to both `main` and `fix-build`, consolidating wheel creation into a single multi-platform build matrix and improving artifact handling/retention.
  * Tightened package publishing so it only uploads from the `main` branch.
* **Documentation**
  * Updated the Sphinx documentation GitHub link to the new repository.
* **Chores**
  * Updated `.gitignore` to ignore the `examples/not_upload/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->